### PR TITLE
Handle uptime parsing without TryParse

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -374,7 +374,20 @@ if ($summary.LastBoot){
   }
   if (-not $bootDt){
     $parsedBoot = $null
-    if ([datetime]::TryParse($summary.LastBoot, [ref]$parsedBoot)) { $bootDt = $parsedBoot }
+    foreach ($culture in @([System.Globalization.CultureInfo]::CurrentCulture, [System.Globalization.CultureInfo]::InvariantCulture)) {
+      try {
+        $parsedBoot = [datetime]::Parse($summary.LastBoot, $culture)
+        break
+      } catch {
+        $parsedBoot = $null
+      }
+    }
+    if ($parsedBoot) {
+      $now = Get-Date
+      if ($parsedBoot -le $now.AddMinutes(1)) {
+        $bootDt = $parsedBoot
+      }
+    }
   }
     if ($bootDt){
       $uptimeDays = (New-TimeSpan -Start $bootDt -End (Get-Date)).TotalDays


### PR DESCRIPTION
## Summary
- replace the DateTime.TryParse call with culture-aware Parse fallbacks so analyzers without that overload can still interpret boot strings
- ignore parsed timestamps that fall in the future to avoid bogus uptime results when only a time of day is captured

## Testing
- not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3ccee52e4832d8e6f2f98bad0e1bf