### PR TITLE
Run system diagnostics collectors in parallel

### DIFF
--- a/AutoL1/Collect-SystemDiagnostics.ps1
+++ b/AutoL1/Collect-SystemDiagnostics.ps1
@@ -29,84 +29,232 @@ $overallTimer = [System.Diagnostics.Stopwatch]::StartNew()
 Write-Host "Starting diagnostics collection..."
 Write-Host "Output folder: $reportDir"
 
-# Simple helper to run a command and write output
-function Save-Output {
+# Parallel collection settings
+$ThrottleLimit = 6
+$TaskTimeoutSec = 60
+
+function Start-CollectorJob {
   param(
-    [Parameter(Mandatory)] [string]$Name,
-    [Parameter(Mandatory)] [scriptblock]$Action
+    [Parameter(Mandatory)] [string]$Key,
+    [Parameter(Mandatory)] [scriptblock]$Script,
+    [Parameter(Mandatory)] [string]$OutDir,
+    [string]$Description
   )
 
-  $file = Join-Path $reportDir ("$Name.txt")
-  $sep = "`n===== $Name : $(Get-Date) =====`n"
-  Add-Content -Path $file -Value $sep
-  try {
-    & $Action *>&1 | Out-File -FilePath $file -Encoding UTF8 -Append
-  } catch {
-    "ERROR running $Name : $_" | Out-File -FilePath $file -Append
-    Write-Warning "Encountered an error while collecting $Name. Review $file for details."
+  $filePath = Join-Path $OutDir ("$Key.txt")
+  $job = Start-Job -Name "collect_$Key" -ArgumentList @($Key, $Script, $OutDir) -ScriptBlock {
+    param([string]$Key, [scriptblock]$ScriptBlock, [string]$OutDir)
+
+    $file = Join-Path $OutDir ("$Key.txt")
+    $header = "===== $Key : $(Get-Date) ====="
+    Set-Content -Path $file -Value $header -Encoding UTF8
+    '' | Out-File -FilePath $file -Encoding UTF8 -Append
+
+    try {
+      & $ScriptBlock *>&1 | Out-File -FilePath $file -Encoding UTF8 -Append
+      [pscustomobject]@{ Key = $Key; Success = $true }
+    } catch {
+      $errorText = ($_ | Out-String).Trim()
+      if (-not $errorText -and $_.Exception) {
+        $errorText = $_.Exception.Message
+      }
+      "ERROR running $Key : $errorText" | Out-File -FilePath $file -Encoding UTF8 -Append
+      [pscustomobject]@{ Key = $Key; Success = $false; Error = $errorText }
+    }
   }
-  return $file
+
+  [pscustomobject]@{
+    Key = $Key
+    Description = $Description
+    Job = $job
+    File = $filePath
+    StartTime = Get-Date
+  }
 }
 
-$capturePlan = @(
-  @{ Name = "ipconfig_all"; Description = "Detailed IP configuration (ipconfig /all)"; Action = { ipconfig /all } },
-  @{ Name = "route_print"; Description = "Routing table (route print)"; Action = { route print } },
-  @{ Name = "netstat_ano"; Description = "Active connections and ports (netstat -ano)"; Action = { netstat -ano } },
-  @{ Name = "arp_table"; Description = "ARP cache entries (arp -a)"; Action = { arp -a } },
-  @{ Name = "nslookup_google"; Description = "DNS resolution test for google.com"; Action = { nslookup google.com } },
-  @{ Name = "tracert_google"; Description = "Traceroute to 8.8.8.8"; Action = { tracert -d -h 10 8.8.8.8 } },
-  @{ Name = "ping_google"; Description = "Ping test to 8.8.8.8"; Action = { ping -n 4 8.8.8.8 } },
-  @{ Name = "systeminfo"; Description = "General system information"; Action = { systeminfo } },
-  @{ Name = "OS_CIM"; Description = "Operating system CIM inventory"; Action = { Get-CimInstance Win32_OperatingSystem | Format-List * } },
-  @{ Name = "ComputerInfo"; Description = "ComputerInfo snapshot"; Action = { Get-ComputerInfo | Select-Object CsName, WindowsVersion, WindowsBuildLabEx, OsName, OsArchitecture, WindowsProductName, OsHardwareAbstractionLayer, Bios* | Format-List * } },
-  @{ Name = "NetworkAdapterConfigs"; Description = "Network adapter configuration details"; Action = { Get-CimInstance Win32_NetworkAdapterConfiguration | Select-Object Description,Index,MACAddress,IPAddress,DefaultIPGateway,DHCPEnabled,DHCPServer,DnsServerSearchOrder | Format-List * } },
-  @{ Name = "NetIPAddresses"; Description = "Current IP assignments (Get-NetIPAddress)"; Action = { try { Get-NetIPAddress -ErrorAction Stop | Format-List * } catch { "Get-NetIPAddress missing or failed: $_" } } },
-  @{ Name = "NetAdapters"; Description = "Network adapter status"; Action = { try { Get-NetAdapter -ErrorAction Stop | Format-List * } catch { Get-CimInstance Win32_NetworkAdapter | Select-Object Name,NetConnectionStatus,MACAddress,Speed | Format-List * } } },
-  @{ Name = "Disk_Drives"; Description = "Physical disk inventory (wmic diskdrive)"; Action = { wmic diskdrive get model,serialNumber,status,size } },
-  @{ Name = "Volumes"; Description = "Volume overview (Get-Volume)"; Action = { Get-Volume | Format-Table -AutoSize } },
-  @{ Name = "Disks"; Description = "Disk layout (Get-Disk)"; Action = { Get-Disk | Format-List * } },
-  @{ Name = "Hotfixes"; Description = "Recent hotfixes"; Action = { Get-HotFix | Sort-Object InstalledOn -Descending | Select-Object -First 50 | Format-List * } },
-  @{ Name = "Programs_Reg"; Description = "Installed programs (64-bit registry)"; Action = { Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Select DisplayName,DisplayVersion,Publisher,InstallDate | Format-Table -AutoSize } },
-  @{ Name = "Programs_Reg_32"; Description = "Installed programs (32-bit registry)"; Action = { Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Select DisplayName,DisplayVersion,Publisher,InstallDate | Format-Table -AutoSize } },
-  @{ Name = "Services"; Description = "Service state overview"; Action = { Get-Service | Sort-Object Status,Name | Format-Table -AutoSize } },
-  @{ Name = "Processes"; Description = "Running processes (tasklist /v)"; Action = { tasklist /v } },
-  @{ Name = "Drivers"; Description = "Driver inventory (driverquery)"; Action = { driverquery /v /fo list } },
-  @{ Name = "Event_System_100"; Description = "Latest 100 System event log entries"; Action = { wevtutil qe System /c:100 /f:text /rd:true } },
-  @{ Name = "Event_Application_100"; Description = "Latest 100 Application event log entries"; Action = { wevtutil qe Application /c:100 /f:text /rd:true } },
-  @{ Name = "Firewall"; Description = "Firewall profile status"; Action = { netsh advfirewall show allprofiles } },
-  @{ Name = "FirewallRules"; Description = "Firewall rules overview"; Action = { try { Get-NetFirewallRule | Select-Object DisplayName,Direction,Action,Enabled,Profile | Format-Table -AutoSize } catch { "Get-NetFirewallRule not present" } } },
-  @{ Name = "DefenderStatus"; Description = "Microsoft Defender health"; Action = { try { Get-MpComputerStatus | Format-List * } catch { "Get-MpComputerStatus not available or Defender absent" } } },
-  @{ Name = "NetShares"; Description = "File shares (net share)"; Action = { net share } },
-  @{ Name = "ScheduledTasks"; Description = "Scheduled task inventory"; Action = { schtasks /query /fo LIST /v } },
-  @{ Name = "dsregcmd_status"; Description = "Azure AD registration status (dsregcmd /status)"; Action = { dsregcmd /status } },
-  @{ Name = "Whoami"; Description = "Current user context"; Action = { whoami /all } },
-  @{ Name = "Uptime"; Description = "Last boot time"; Action = { (Get-CimInstance Win32_OperatingSystem).LastBootUpTime } },
-  @{ Name = "TopCPU"; Description = "Top CPU processes"; Action = { Get-Process | Sort-Object CPU -Descending | Select-Object -First 25 | Format-Table -AutoSize } },
-  @{ Name = "Memory"; Description = "Memory usage summary"; Action = { Get-CimInstance Win32_OperatingSystem | Select @{n='TotalVisibleMemoryMB';e={[math]::round($_.TotalVisibleMemorySize/1024,0)}}, @{n='FreePhysicalMemoryMB';e={[math]::round($_.FreePhysicalMemory/1024,0)}} | Format-List * } }
+function Update-CollectionProgress {
+  param(
+    [string]$Activity,
+    [int]$Completed,
+    [int]$Total,
+    $RunningJobs
+  )
+
+  if ($Total -le 0) {
+    $percent = 100
+  } else {
+    $percent = [int](($Completed / $Total) * 100)
+  }
+
+  $runningKeys = @()
+  if ($RunningJobs) {
+    foreach ($jobInfo in $RunningJobs) {
+      if ($jobInfo -and $jobInfo.Key) {
+        $runningKeys += $jobInfo.Key
+      }
+    }
+  }
+
+  $runningSummary = if ($runningKeys.Count -gt 0) { "Running: {0}" -f ($runningKeys -join ', ') } else { 'Idle' }
+  $status = "{0}/{1} complete. {2}" -f $Completed, $Total, $runningSummary
+  Write-Progress -Activity $Activity -Status $status -PercentComplete $percent
+}
+
+$tasks = @(
+  @{ Key = "ipconfig_all"; Description = "Detailed IP configuration (ipconfig /all)"; Script = { ipconfig /all } },
+  @{ Key = "route_print"; Description = "Routing table (route print)"; Script = { route print } },
+  @{ Key = "netstat_ano"; Description = "Active connections and ports (netstat -ano)"; Script = { netstat -ano } },
+  @{ Key = "arp_table"; Description = "ARP cache entries (arp -a)"; Script = { arp -a } },
+  @{ Key = "nslookup_google"; Description = "DNS resolution test for google.com"; Script = { nslookup google.com } },
+  @{ Key = "tracert_google"; Description = "Traceroute to 8.8.8.8"; Script = { tracert -d -h 10 8.8.8.8 } },
+  @{ Key = "ping_google"; Description = "Ping test to 8.8.8.8"; Script = { ping -n 4 8.8.8.8 } },
+  @{ Key = "systeminfo"; Description = "General system information"; Script = { systeminfo } },
+  @{ Key = "OS_CIM"; Description = "Operating system CIM inventory"; Script = { Get-CimInstance Win32_OperatingSystem | Format-List * } },
+  @{ Key = "ComputerInfo"; Description = "ComputerInfo snapshot"; Script = { Get-ComputerInfo | Select-Object CsName, WindowsVersion, WindowsBuildLabEx, OsName, OsArchitecture, WindowsProductName, OsHardwareAbstractionLayer, Bios* | Format-List * } },
+  @{ Key = "NetworkAdapterConfigs"; Description = "Network adapter configuration details"; Script = { Get-CimInstance Win32_NetworkAdapterConfiguration | Select-Object Description,Index,MACAddress,IPAddress,DefaultIPGateway,DHCPEnabled,DHCPServer,DnsServerSearchOrder | Format-List * } },
+  @{ Key = "NetIPAddresses"; Description = "Current IP assignments (Get-NetIPAddress)"; Script = { try { Get-NetIPAddress -ErrorAction Stop | Format-List * } catch { "Get-NetIPAddress missing or failed: $_" } } },
+  @{ Key = "NetAdapters"; Description = "Network adapter status"; Script = { try { Get-NetAdapter -ErrorAction Stop | Format-List * } catch { Get-CimInstance Win32_NetworkAdapter | Select-Object Name,NetConnectionStatus,MACAddress,Speed | Format-List * } } },
+  @{ Key = "Disk_Drives"; Description = "Physical disk inventory (wmic diskdrive)"; Script = { wmic diskdrive get model,serialNumber,status,size } },
+  @{ Key = "Volumes"; Description = "Volume overview (Get-Volume)"; Script = { Get-Volume | Format-Table -AutoSize } },
+  @{ Key = "Disks"; Description = "Disk layout (Get-Disk)"; Script = { Get-Disk | Format-List * } },
+  @{ Key = "Hotfixes"; Description = "Recent hotfixes"; Script = { Get-HotFix | Sort-Object InstalledOn -Descending | Select-Object -First 50 | Format-List * } },
+  @{ Key = "Programs_Reg"; Description = "Installed programs (64-bit registry)"; Script = { Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Select DisplayName,DisplayVersion,Publisher,InstallDate | Format-Table -AutoSize } },
+  @{ Key = "Programs_Reg_32"; Description = "Installed programs (32-bit registry)"; Script = { Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Select DisplayName,DisplayVersion,Publisher,InstallDate | Format-Table -AutoSize } },
+  @{ Key = "Services"; Description = "Service state overview"; Script = { Get-Service | Sort-Object Status,Name | Format-Table -AutoSize } },
+  @{ Key = "Processes"; Description = "Running processes (tasklist /v)"; Script = { tasklist /v } },
+  @{ Key = "Drivers"; Description = "Driver inventory (driverquery)"; Script = { driverquery /v /fo list } },
+  @{ Key = "Event_System_100"; Description = "Latest 100 System event log entries"; Script = { wevtutil qe System /c:100 /f:text /rd:true } },
+  @{ Key = "Event_Application_100"; Description = "Latest 100 Application event log entries"; Script = { wevtutil qe Application /c:100 /f:text /rd:true } },
+  @{ Key = "Firewall"; Description = "Firewall profile status"; Script = { netsh advfirewall show allprofiles } },
+  @{ Key = "FirewallRules"; Description = "Firewall rules overview"; Script = { try { Get-NetFirewallRule | Select-Object DisplayName,Direction,Action,Enabled,Profile | Format-Table -AutoSize } catch { "Get-NetFirewallRule not present" } } },
+  @{ Key = "DefenderStatus"; Description = "Microsoft Defender health"; Script = { try { Get-MpComputerStatus | Format-List * } catch { "Get-MpComputerStatus not available or Defender absent" } } },
+  @{ Key = "NetShares"; Description = "File shares (net share)"; Script = { net share } },
+  @{ Key = "ScheduledTasks"; Description = "Scheduled task inventory"; Script = { schtasks /query /fo LIST /v } },
+  @{ Key = "dsregcmd_status"; Description = "Azure AD registration status (dsregcmd /status)"; Script = { dsregcmd /status } },
+  @{ Key = "Whoami"; Description = "Current user context"; Script = { whoami /all } },
+  @{ Key = "Uptime"; Description = "Last boot time"; Script = { (Get-CimInstance Win32_OperatingSystem).LastBootUpTime } },
+  @{ Key = "TopCPU"; Description = "Top CPU processes"; Script = { Get-Process | Sort-Object CPU -Descending | Select-Object -First 25 | Format-Table -AutoSize } },
+  @{ Key = "Memory"; Description = "Memory usage summary"; Script = { Get-CimInstance Win32_OperatingSystem | Select @{n='TotalVisibleMemoryMB';e={[math]::round($_.TotalVisibleMemorySize/1024,0)}}, @{n='FreePhysicalMemoryMB';e={[math]::round($_.FreePhysicalMemory/1024,0)}} | Format-List * } }
 )
 
 $files = @()
 $activity = "Collecting system diagnostics"
+$totalTasks = $tasks.Count
+$runningJobs = New-Object System.Collections.Generic.List[object]
+$completedCount = 0
+$taskIndex = 0
 
-for ($i = 0; $i -lt $capturePlan.Count; $i++) {
-  $stepNumber = $i + 1
-  $step = $capturePlan[$i]
-  $status = "[{0}/{1}] {2}" -f $stepNumber, $capturePlan.Count, $step.Description
-  $percent = [int](($i / $capturePlan.Count) * 100)
-  Write-Progress -Activity $activity -Status $status -PercentComplete $percent
-  Write-Host $status
+Update-CollectionProgress -Activity $activity -Completed $completedCount -Total $totalTasks -RunningJobs $runningJobs
 
-  $timer = [System.Diagnostics.Stopwatch]::StartNew()
-  $file = Save-Output -Name $step.Name -Action $step.Action
-  $timer.Stop()
+while ($taskIndex -lt $totalTasks -or $runningJobs.Count -gt 0) {
+  while ($taskIndex -lt $totalTasks -and $runningJobs.Count -lt $ThrottleLimit) {
+    $task = $tasks[$taskIndex]
+    $taskIndex++
 
-  if ($file) {
-    Write-Host ("     Saved to {0} ({1:N1}s)" -f $file, $timer.Elapsed.TotalSeconds)
-    $files += $file
+    Write-Host ("Starting {0}... {1}" -f $task.Key, $task.Description)
+    $jobInfo = Start-CollectorJob -Key $task.Key -Script $task.Script -OutDir $reportDir -Description $task.Description
+    $runningJobs.Add($jobInfo)
+
+    Update-CollectionProgress -Activity $activity -Completed $completedCount -Total $totalTasks -RunningJobs $runningJobs
   }
 
-  $percentComplete = [int](($stepNumber / $capturePlan.Count) * 100)
-  Write-Progress -Activity $activity -Status $status -PercentComplete $percentComplete
+  if ($runningJobs.Count -eq 0) {
+    continue
+  }
+
+  Start-Sleep -Milliseconds 200
+
+  for ($idx = $runningJobs.Count - 1; $idx -ge 0; $idx--) {
+    $jobInfo = $runningJobs[$idx]
+    $job = $jobInfo.Job
+    $state = $job.State
+    $elapsed = (New-TimeSpan -Start $jobInfo.StartTime -End (Get-Date)).TotalSeconds
+
+    if ($state -eq 'Running' -and $elapsed -ge $TaskTimeoutSec) {
+      Stop-Job -Job $job -Force -ErrorAction SilentlyContinue
+      if (-not (Test-Path $jobInfo.File)) {
+        $header = "===== {0} : {1} =====" -f $jobInfo.Key, (Get-Date)
+        Set-Content -Path $jobInfo.File -Value $header -Encoding UTF8
+        '' | Out-File -FilePath $jobInfo.File -Encoding UTF8 -Append
+      }
+      "ERROR running {0} : Timeout after {1} sec" -f $jobInfo.Key, $TaskTimeoutSec |
+        Out-File -FilePath $jobInfo.File -Encoding UTF8 -Append
+      Write-Warning ("Timed out {0} after {1} sec" -f $jobInfo.Key, $TaskTimeoutSec)
+      Receive-Job -Job $job -ErrorAction SilentlyContinue | Out-Null
+      Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+      $files += $jobInfo.File
+      $completedCount++
+      $runningJobs.RemoveAt($idx)
+      Update-CollectionProgress -Activity $activity -Completed $completedCount -Total $totalTasks -RunningJobs $runningJobs
+      continue
+    }
+
+    if ($state -eq 'Completed') {
+      $result = Receive-Job -Job $job -ErrorAction SilentlyContinue
+      $jobResult = $null
+      if ($null -ne $result) {
+        $resultArray = @($result)
+        if ($resultArray.Count -gt 0) {
+          $jobResult = $resultArray[-1]
+        }
+      }
+
+      $success = $true
+      $errorMessage = $null
+      if ($jobResult -and ($jobResult | Get-Member -Name Success -ErrorAction SilentlyContinue)) {
+        $success = [bool]$jobResult.Success
+        if (-not $success -and ($jobResult | Get-Member -Name Error -ErrorAction SilentlyContinue)) {
+          $errorMessage = $jobResult.Error
+        }
+      }
+
+      if ($success) {
+        Write-Host ("Finished {0} ({1:N1}s)" -f $jobInfo.Key, $elapsed)
+      } else {
+        if (-not $errorMessage) {
+          $errorMessage = "Unknown error"
+        }
+        Write-Warning ("Failed {0}: {1}" -f $jobInfo.Key, $errorMessage)
+        if (-not (Select-String -Path $jobInfo.File -Pattern 'ERROR running' -SimpleMatch -Quiet -ErrorAction SilentlyContinue)) {
+          "ERROR running {0} : {1}" -f $jobInfo.Key, $errorMessage |
+            Out-File -FilePath $jobInfo.File -Encoding UTF8 -Append
+        }
+      }
+
+      Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+      $files += $jobInfo.File
+      $completedCount++
+      $runningJobs.RemoveAt($idx)
+      Update-CollectionProgress -Activity $activity -Completed $completedCount -Total $totalTasks -RunningJobs $runningJobs
+      continue
+    }
+
+    if ($state -eq 'Failed' -or $state -eq 'Stopped') {
+      $reason = $null
+      if ($job.ChildJobs -and $job.ChildJobs.Count -gt 0) {
+        $reason = $job.ChildJobs[0].JobStateInfo.Reason
+      } else {
+        $reason = $job.JobStateInfo.Reason
+      }
+      $reasonText = if ($reason) { $reason.ToString() } else { "Job $state" }
+      if (-not (Test-Path $jobInfo.File)) {
+        $header = "===== {0} : {1} =====" -f $jobInfo.Key, (Get-Date)
+        Set-Content -Path $jobInfo.File -Value $header -Encoding UTF8
+        '' | Out-File -FilePath $jobInfo.File -Encoding UTF8 -Append
+      }
+      if (-not (Select-String -Path $jobInfo.File -Pattern 'ERROR running' -SimpleMatch -Quiet -ErrorAction SilentlyContinue)) {
+        "ERROR running {0} : {1}" -f $jobInfo.Key, $reasonText |
+          Out-File -FilePath $jobInfo.File -Encoding UTF8 -Append
+      }
+      Write-Warning ("Failed {0}: {1}" -f $jobInfo.Key, $reasonText)
+      Receive-Job -Job $job -ErrorAction SilentlyContinue | Out-Null
+      Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+      $files += $jobInfo.File
+      $completedCount++
+      $runningJobs.RemoveAt($idx)
+      Update-CollectionProgress -Activity $activity -Completed $completedCount -Total $totalTasks -RunningJobs $runningJobs
+    }
+  }
 }
 
 Write-Progress -Activity $activity -Completed


### PR DESCRIPTION
## Summary
- run each diagnostics collection command in its own background job that writes to a dedicated output file
- add throttled job queue, timeout handling, and detailed status logging for the collector pipeline
- retain existing task keys and filenames so the analyzer continues to function without changes

## Testing
- not run (PowerShell script requires Windows PowerShell 5.1)


------
https://chatgpt.com/codex/tasks/task_e_68d3ebce00c4832d9e03a004da674ee0