### PR TITLE
Wrap device health report evidence in collapsible details

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -1532,9 +1532,11 @@ if ($normals.Count -eq 0){
     $badgeHtml = Encode-Html $badgeText
     $areaHtml = Encode-Html $($g.Area)
     $messageHtml = Encode-Html $($g.Message)
-    $goodCards += "<div class='report-card report-card--{0}'><span class='report-badge report-badge--{0}'>{1}</span> <b>{2}</b>: {3}" -f $cardClass, $badgeHtml, $areaHtml, $messageHtml
-    if ($g.Evidence){ $goodCards += "<pre class='report-pre'>$(Encode-Html $($g.Evidence))</pre>" }
-    $goodCards += "</div>"
+    $hasMessage = -not [string]::IsNullOrWhiteSpace($g.Message)
+    $summaryText = if ($hasMessage) { "<strong>$areaHtml</strong>: $messageHtml" } else { "<strong>$areaHtml</strong>" }
+    $goodCards += "<details class='report-card report-card--{0}'><summary><span class='report-badge report-badge--{0}'>{1}</span><span class='report-card__summary-text'>{2}</span></summary>" -f $cardClass, $badgeHtml, $summaryText
+    if ($g.Evidence){ $goodCards += "<div class='report-card__body'><pre class='report-pre'>$(Encode-Html $($g.Evidence))</pre></div>" }
+    $goodCards += "</details>"
   }
   $goodContent = $goodCards
 }
@@ -1551,9 +1553,11 @@ if ($issues.Count -eq 0){
     $badgeHtml = Encode-Html $badgeText
     $areaHtml = Encode-Html $($i.Area)
     $messageHtml = Encode-Html $($i.Message)
-    $issuesCards += "<div class='report-card report-card--{0}'><div class='report-badge report-badge--{0}'>{1}</div> <b>{2}</b>: {3}" -f $cardClass, $badgeHtml, $areaHtml, $messageHtml
-    if ($i.Evidence){ $issuesCards += "<pre class='report-pre'>$(Encode-Html $i.Evidence)</pre>" }
-    $issuesCards += "</div>"
+    $hasMessage = -not [string]::IsNullOrWhiteSpace($i.Message)
+    $summaryText = if ($hasMessage) { "<strong>$areaHtml</strong>: $messageHtml" } else { "<strong>$areaHtml</strong>" }
+    $issuesCards += "<details class='report-card report-card--{0}'><summary><span class='report-badge report-badge--{0}'>{1}</span><span class='report-card__summary-text'>{2}</span></summary>" -f $cardClass, $badgeHtml, $summaryText
+    if ($i.Evidence){ $issuesCards += "<div class='report-card__body'><pre class='report-pre'>$(Encode-Html $i.Evidence)</pre></div>" }
+    $issuesCards += "</details>"
   }
   $issuesContent = $issuesCards
 }

--- a/AutoL1/styles/device-health-report.css
+++ b/AutoL1/styles/device-health-report.css
@@ -27,6 +27,65 @@
   background-color: var(--color-surface);
 }
 
+details.report-card {
+  padding: 0;
+}
+
+details.report-card > summary {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  margin: 0;
+  padding: var(--space-sm) var(--space-md);
+  padding-left: calc(var(--space-md) + 1.25rem);
+  cursor: pointer;
+  list-style: none;
+}
+
+details.report-card > summary:focus-visible {
+  outline: 2px solid var(--color-heading);
+  outline-offset: 2px;
+}
+
+details.report-card > summary::marker {
+  content: "";
+}
+
+details.report-card > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.report-card > summary::before {
+  content: "\25B6";
+  position: absolute;
+  left: var(--space-md);
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+details.report-card[open] > summary::before {
+  content: "\25BC";
+}
+
+details.report-card[open] > summary {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.report-card__summary-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.report-card__body {
+  padding: var(--space-sm) var(--space-md) var(--space-md) calc(var(--space-md) + 1.25rem);
+}
+
+.report-card__body > .report-pre {
+  margin-top: 0;
+}
+
 .report-section {
   margin: var(--space-lg) 0;
   border: 1px solid var(--color-border-subtle);


### PR DESCRIPTION
## Summary
- replace the GOOD and issue report cards with native `<details>/<summary>` markup so the evidence stays hidden until expanded
- add styling for the new summaries, including a CSS chevron, badge/text alignment, and preserved severity colors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3f3eeaa3c832d8830dab5d4b79a1c