### PR TITLE
Adjust OS category mappings

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -1688,7 +1688,9 @@ function Get-NormalCategory {
     '^(?i)(outlook|office)$' { return 'Office' }
     '^(?i)(network|dns)$'    { return 'Network' }
     '^(?i)security$'         { return 'Security' }
-    '^(?i)(storage|os|events|services|scheduled tasks)$' { return 'Hardware' }
+    '^(?i)os$'               { return 'OS' }
+    '^(?i)scheduled tasks$'  { return 'OS' }
+    '^(?i)storage$'          { return 'Hardware' }
     default { return 'Hardware' }
   }
 }
@@ -1723,7 +1725,7 @@ $goodTitle = "What Looks Good ({0})" -f $normals.Count
 if ($normals.Count -eq 0){
   $goodContent = '<div class="report-card"><i>No specific positives recorded.</i></div>'
 } else {
-  $categoryOrder = @('Office','Network','Hardware','Security')
+  $categoryOrder = @('Office','Network','OS','Hardware','Security')
   $categorized = [ordered]@{}
 
   foreach ($category in $categoryOrder) {


### PR DESCRIPTION
## Summary
- categorize OS-related health findings under a dedicated OS tab
- ensure scheduled task findings are grouped with OS items while keeping storage SMART under hardware
- expose the OS tab in the good findings ordering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d40162c304832db37a31f50a135c97