### PR TITLE
Add fast startup diagnostics and reporting

### DIFF
--- a/AutoL1/Collect-SystemDiagnostics.ps1
+++ b/AutoL1/Collect-SystemDiagnostics.ps1
@@ -206,6 +206,15 @@ $capturePlan = @(
   @{ Name = "systeminfo"; Description = "General system information"; Action = { systeminfo } },
   @{ Name = "OS_CIM"; Description = "Operating system CIM inventory"; Action = { Get-CimInstance Win32_OperatingSystem | Format-List * } },
   @{ Name = "ComputerInfo"; Description = "ComputerInfo snapshot"; Action = { Get-ComputerInfo | Select-Object CsName, WindowsVersion, WindowsBuildLabEx, OsName, OsArchitecture, WindowsProductName, OsHardwareAbstractionLayer, Bios* | Format-List * } },
+  @{ Name = "Power_FastStartup"; Description = "Fast Startup (Fast Boot) configuration"; Action = {
+      try {
+        $props = Get-ItemProperty -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Power' -Name HiberbootEnabled -ErrorAction Stop
+        $value = $props.HiberbootEnabled
+        "HiberbootEnabled : $value"
+      } catch {
+        "Failed to query HiberbootEnabled : $_"
+      }
+    } },
   @{ Name = "NetworkAdapterConfigs"; Description = "Network adapter configuration details"; Action = { Get-CimInstance Win32_NetworkAdapterConfiguration | Select-Object Description,Index,MACAddress,IPAddress,DefaultIPGateway,DHCPEnabled,DHCPServer,DnsServerSearchOrder | Format-List * } },
   @{ Name = "NetIPAddresses"; Description = "Current IP assignments (Get-NetIPAddress)"; Action = { try { Get-NetIPAddress -ErrorAction Stop | Format-List * } catch { "Get-NetIPAddress missing or failed: $_" } } },
   @{ Name = "NetAdapters"; Description = "Network adapter status"; Action = { try { Get-NetAdapter -ErrorAction Stop | Format-List * } catch { Get-CimInstance Win32_NetworkAdapter | Select-Object Name,NetConnectionStatus,MACAddress,Speed | Format-List * } } },


### PR DESCRIPTION
## Summary
- extend the collector to capture the Fast Startup (Fast Boot) registry value for later analysis
- analyze the captured Fast Startup value, emit an OS/Startup issue when it is enabled, and display the status in the device health summary

## Testing
- `pwsh -NoLogo -Command "'PowerShell available'"` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d403f4fd54832dafc37e67af0db87a