### PR TITLE
Fix autoruns file discovery

### DIFF
--- a/AutoL1/Test-AutorunsDetection.ps1
+++ b/AutoL1/Test-AutorunsDetection.ps1
@@ -11,7 +11,12 @@ if (-not (Test-Path -Path $InputFolder -PathType Container)) {
 }
 
 # Discover candidate text files (txt/log/csv/tsv) beneath the input folder.
-$allTextFiles = Get-ChildItem -Path $InputFolder -Recurse -File -Include *.txt,*.log,*.csv,*.tsv -ErrorAction SilentlyContinue
+# NOTE: -Include only works when the -Path has a wildcard, so we gather all
+# files first and then filter them in PowerShell to ensure we don't miss the
+# Autoruns export.
+$textExtensions = '.txt', '.log', '.csv', '.tsv'
+$allTextFiles = Get-ChildItem -Path $InputFolder -Recurse -File -ErrorAction SilentlyContinue |
+  Where-Object { $textExtensions -contains $_.Extension.ToLowerInvariant() }
 
 # Helper: find an Autoruns file by name hints or content inspection.
 function Find-AutorunsFile {


### PR DESCRIPTION
## Summary
- fix autoruns artifact discovery by filtering extensions with Where-Object instead of relying on -Include
- add comment explaining why -Include is avoided without wildcard paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f540b09c832d92b59f3282c66e02