### PR TITLE
Fix analyzer module PowerShell syntax

### DIFF
--- a/AutoL1/Modules/ActiveDirectory.psm1
+++ b/AutoL1/Modules/ActiveDirectory.psm1
@@ -8,47 +8,59 @@ using module ./Common.psm1
 $AreaName = 'ActiveDirectory'
 
 function Collect-ActiveDirectoryData {
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName='FromFolder')]
   param(
     [Parameter(ParameterSetName='FromFolder', Mandatory)][string]$InputFolder,
     [Parameter(ParameterSetName='Live')][switch]$Live
   )
-  # Hints: nltest /dsgetdc, whoami /upn, Test-ComputerSecureChannel, time sync
+
+  $result = [ordered]@{}
+
   if ($PSCmdlet.ParameterSetName -eq 'Live') {
-    '.*nltest.*dsgetdc.*\.txt$' {{ $result['DsGetDc'] = Read-Text $f.FullName; break }}
-        '.*securechannel.*\.txt$' {{ $result['SecureChannel'] = Read-Text $f.FullName; break }}
-  } else {
-    $result = [ordered]@{}
-    $files = Get-AllTextFiles -Root $InputFolder
-    foreach ($f in $files) {
-      $name = $f.Name.ToLowerInvariant()
-      switch -Regex ($name) {
-        '.*nltest.*dsgetdc.*\.txt$' {{ $result['DsGetDc'] = Read-Text $f.FullName; break }}
-        '.*securechannel.*\.txt$' {{ $result['SecureChannel'] = Read-Text $f.FullName; break }}
-        default { }
-      }
-    }
     return [pscustomobject]$result
   }
+
+  if (-not (Test-Path -LiteralPath $InputFolder)) {
+    return [pscustomobject]$result
+  }
+
+  $files = Get-AllTextFiles -Root $InputFolder
+  foreach ($f in $files) {
+    $name = $f.Name.ToLowerInvariant()
+    switch -Regex ($name) {
+      'nltest.*dsgetdc' {
+        if (-not $result.Contains('DsGetDc')) {
+          $result['DsGetDc'] = Read-Text $f.FullName
+        }
+        continue
+      }
+      'securechannel' {
+        if (-not $result.Contains('SecureChannel')) {
+          $result['SecureChannel'] = Read-Text $f.FullName
+        }
+        continue
+      }
+    }
+  }
+
+  return [pscustomobject]$result
 }
 
 function Analyze-ActiveDirectory {
   [CmdletBinding()]
   param(
-    [Parameter(Mandatory)][hashtable]$Context,  # shared context if needed across modules
-    [Parameter(Mandatory)][psobject]$Data       # output of Collect-ActiveDirectoryData
+    [Parameter(Mandatory)][hashtable]$Context,
+    [Parameter(Mandatory)][psobject]$Data
   )
+
   $cards  = New-Object System.Collections.Generic.List[object]
   $checks = New-Object System.Collections.Generic.List[object]
 
-  
-if ($Data.SecureChannel -and $Data.SecureChannel -match 'False') {
-  $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Computer secure channel to domain is broken' )
-  $checks.Add( New-Check -Area $AreaName -Name 'Secure channel healthy' -Status 'fail' -Weight 1.5 )
-}
-   
+  if ($Data.SecureChannel -and $Data.SecureChannel -match 'False') {
+    $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Computer secure channel to domain is broken' -Evidence ($Data.SecureChannel.Trim()) )
+    $checks.Add( New-Check -Area $AreaName -Name 'Secure channel healthy' -Status 'fail' -Weight 1.5 -Evidence ($Data.SecureChannel.Trim()) )
+  }
 
-  # Example baseline: if we produced nothing, surface a neutral check so scoring doesn't divide by zero
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
     $cards.Add( New-GoodCard -Area $AreaName -Message 'ActiveDirectory: No issues detected by baseline heuristics.' )
     $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )

--- a/AutoL1/Modules/Hardware.psm1
+++ b/AutoL1/Modules/Hardware.psm1
@@ -8,53 +8,68 @@ using module ./Common.psm1
 $AreaName = 'Hardware'
 
 function Collect-HardwareData {
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName='FromFolder')]
   param(
     [Parameter(ParameterSetName='FromFolder', Mandatory)][string]$InputFolder,
     [Parameter(ParameterSetName='Live')][switch]$Live
   )
-  # Hints: dxdiag.txt, wmic/cim disk lists, memory, CPU
+
+  $result = [ordered]@{}
+
   if ($PSCmdlet.ParameterSetName -eq 'Live') {
-    '.*dxdiag.*\.txt$' {{ $result['DxDiag'] = Read-Text $f.FullName; break }}
-        '.*disk.*list.*\.txt$' {{ $result['DiskList'] = Read-Text $f.FullName; break }}
-  } else {
-    $result = [ordered]@{}
-    $files = Get-AllTextFiles -Root $InputFolder
-    foreach ($f in $files) {
-      $name = $f.Name.ToLowerInvariant()
-      switch -Regex ($name) {
-        '.*dxdiag.*\.txt$' {{ $result['DxDiag'] = Read-Text $f.FullName; break }}
-        '.*disk.*list.*\.txt$' {{ $result['DiskList'] = Read-Text $f.FullName; break }}
-        default { }
-      }
-    }
     return [pscustomobject]$result
   }
+
+  if (-not (Test-Path -LiteralPath $InputFolder)) {
+    return [pscustomobject]$result
+  }
+
+  $files = Get-AllTextFiles -Root $InputFolder
+  foreach ($f in $files) {
+    $name = $f.Name.ToLowerInvariant()
+    switch -Regex ($name) {
+      'dxdiag' {
+        if (-not $result.Contains('DxDiag')) {
+          $result['DxDiag'] = Read-Text $f.FullName
+        }
+        continue
+      }
+      'disk' {
+        if (-not $result.Contains('DiskList')) {
+          $result['DiskList'] = Read-Text $f.FullName
+        }
+        continue
+      }
+    }
+  }
+
+  return [pscustomobject]$result
 }
 
 function Analyze-Hardware {
   [CmdletBinding()]
   param(
-    [Parameter(Mandatory)][hashtable]$Context,  # shared context if needed across modules
-    [Parameter(Mandatory)][psobject]$Data       # output of Collect-HardwareData
+    [Parameter(Mandatory)][hashtable]$Context,
+    [Parameter(Mandatory)][psobject]$Data
   )
+
   $cards  = New-Object System.Collections.Generic.List[object]
   $checks = New-Object System.Collections.Generic.List[object]
 
-  
-if ($Data.DiskList -and $Data.DiskList -match 'Status\s*:\s*(\w+)') {
-  $status = $Matches[1]
-  if ($status -notin @('OK','Healthy','Good')) {
-    $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message "Disk SMART status indicates: $status" )
-    $checks.Add( New-Check -Area $AreaName -Name 'Disk health' -Status 'fail' -Weight 1.5 )
-  } else {
-    $cards.Add( New-GoodCard -Area $AreaName -Message 'Disk health appears OK' )
-    $checks.Add( New-Check -Area $AreaName -Name 'Disk health' -Status 'pass' -Weight 1.0 )
+  $diskList = $Data.DiskList
+  if ($diskList) {
+    if ($diskList -match 'Status\s*:\s*([A-Za-z]+)') {
+      $status = $Matches[1]
+      if ($status -notin @('OK','Healthy','Good')) {
+        $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message ("Disk SMART status indicates: {0}" -f $status) -Evidence ($diskList.Trim()) )
+        $checks.Add( New-Check -Area $AreaName -Name 'Disk health' -Status 'fail' -Weight 1.5 -Evidence ($diskList.Trim()) )
+      } else {
+        $cards.Add( New-GoodCard -Area $AreaName -Message 'Disk health appears OK' -Evidence ($diskList.Trim()) )
+        $checks.Add( New-Check -Area $AreaName -Name 'Disk health' -Status 'pass' -Weight 1.0 -Evidence ($diskList.Trim()) )
+      }
+    }
   }
-}
-   
 
-  # Example baseline: if we produced nothing, surface a neutral check so scoring doesn't divide by zero
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
     $cards.Add( New-GoodCard -Area $AreaName -Message 'Hardware: No issues detected by baseline heuristics.' )
     $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )

--- a/AutoL1/Modules/Network.psm1
+++ b/AutoL1/Modules/Network.psm1
@@ -8,52 +8,70 @@ using module ./Common.psm1
 $AreaName = 'Network'
 
 function Collect-NetworkData {
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName='FromFolder')]
   param(
     [Parameter(ParameterSetName='FromFolder', Mandatory)][string]$InputFolder,
     [Parameter(ParameterSetName='Live')][switch]$Live
   )
-  # Hints: ipconfig.txt, route print, netsh wlan show interfaces, DNS test logs
+
+  $result = [ordered]@{}
+
   if ($PSCmdlet.ParameterSetName -eq 'Live') {
-    '.*ipconfig.*\.txt$' {{ $result['IpConfig'] = Read-Text $f.FullName; break }}
-        '.*route.*print.*\.txt$' {{ $result['RoutePrint'] = Read-Text $f.FullName; break }}
-        '.*dns.*diag.*\.txt$' {{ $result['DnsDiag'] = Read-Text $f.FullName; break }}
-  } else {
-    $result = [ordered]@{}
-    $files = Get-AllTextFiles -Root $InputFolder
-    foreach ($f in $files) {
-      $name = $f.Name.ToLowerInvariant()
-      switch -Regex ($name) {
-        '.*ipconfig.*\.txt$' {{ $result['IpConfig'] = Read-Text $f.FullName; break }}
-        '.*route.*print.*\.txt$' {{ $result['RoutePrint'] = Read-Text $f.FullName; break }}
-        '.*dns.*diag.*\.txt$' {{ $result['DnsDiag'] = Read-Text $f.FullName; break }}
-        default { }
-      }
-    }
     return [pscustomobject]$result
   }
+
+  if (-not (Test-Path -LiteralPath $InputFolder)) {
+    return [pscustomobject]$result
+  }
+
+  $files = Get-AllTextFiles -Root $InputFolder
+  foreach ($f in $files) {
+    $name = $f.Name.ToLowerInvariant()
+    switch -Regex ($name) {
+      'ipconfig' {
+        if (-not $result.Contains('IpConfig')) {
+          $result['IpConfig'] = Read-Text $f.FullName
+        }
+        continue
+      }
+      'route' {
+        if (-not $result.Contains('RoutePrint')) {
+          $result['RoutePrint'] = Read-Text $f.FullName
+        }
+        continue
+      }
+      'dns' {
+        if (-not $result.Contains('DnsDiag')) {
+          $result['DnsDiag'] = Read-Text $f.FullName
+        }
+        continue
+      }
+    }
+  }
+
+  return [pscustomobject]$result
 }
 
 function Analyze-Network {
   [CmdletBinding()]
   param(
-    [Parameter(Mandatory)][hashtable]$Context,  # shared context if needed across modules
-    [Parameter(Mandatory)][psobject]$Data       # output of Collect-NetworkData
+    [Parameter(Mandatory)][hashtable]$Context,
+    [Parameter(Mandatory)][psobject]$Data
   )
+
   $cards  = New-Object System.Collections.Generic.List[object]
   $checks = New-Object System.Collections.Generic.List[object]
 
-  
-if ($Data.IpConfig -and $Data.IpConfig -match 'Autoconfiguration IPv4 Address\s*:\s*169\.254\.') {
-  $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Link-local address detected (likely DHCP failure)' )
-  $checks.Add( New-Check -Area $AreaName -Name 'Has valid DHCP lease' -Status 'fail' -Weight 1.2 )
-} elseif ($Data.IpConfig) {
-  $cards.Add( New-GoodCard -Area $AreaName -Message 'IP configuration present' )
-  $checks.Add( New-Check -Area $AreaName -Name 'Has valid DHCP lease' -Status 'pass' -Weight 0.8 )
-}
-   
+  if ($Data.IpConfig) {
+    if ($Data.IpConfig -match 'Autoconfiguration IPv4 Address\s*:\s*169\.254\.') {
+      $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Link-local address detected (likely DHCP failure)' -Evidence ($Data.IpConfig.Trim()) )
+      $checks.Add( New-Check -Area $AreaName -Name 'Has valid DHCP lease' -Status 'fail' -Weight 1.2 -Evidence ($Data.IpConfig.Trim()) )
+    } else {
+      $cards.Add( New-GoodCard -Area $AreaName -Message 'IP configuration present' -Evidence ($Data.IpConfig.Trim()) )
+      $checks.Add( New-Check -Area $AreaName -Name 'Has valid DHCP lease' -Status 'pass' -Weight 0.8 -Evidence ($Data.IpConfig.Trim()) )
+    }
+  }
 
-  # Example baseline: if we produced nothing, surface a neutral check so scoring doesn't divide by zero
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
     $cards.Add( New-GoodCard -Area $AreaName -Message 'Network: No issues detected by baseline heuristics.' )
     $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )

--- a/AutoL1/Modules/Office.psm1
+++ b/AutoL1/Modules/Office.psm1
@@ -8,47 +8,59 @@ using module ./Common.psm1
 $AreaName = 'Office'
 
 function Collect-OfficeData {
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName='FromFolder')]
   param(
     [Parameter(ParameterSetName='FromFolder', Mandatory)][string]$InputFolder,
     [Parameter(ParameterSetName='Live')][switch]$Live
   )
-  # Hints: Office/Outlook logs, licensing status, build channel
+
+  $result = [ordered]@{}
+
   if ($PSCmdlet.ParameterSetName -eq 'Live') {
-    '.*office.*licen.*\.txt$' {{ $result['OfficeLicense'] = Read-Text $f.FullName; break }}
-        '.*outlook.*connectivity.*\.txt$' {{ $result['Outlook'] = Read-Text $f.FullName; break }}
-  } else {
-    $result = [ordered]@{}
-    $files = Get-AllTextFiles -Root $InputFolder
-    foreach ($f in $files) {
-      $name = $f.Name.ToLowerInvariant()
-      switch -Regex ($name) {
-        '.*office.*licen.*\.txt$' {{ $result['OfficeLicense'] = Read-Text $f.FullName; break }}
-        '.*outlook.*connectivity.*\.txt$' {{ $result['Outlook'] = Read-Text $f.FullName; break }}
-        default { }
-      }
-    }
     return [pscustomobject]$result
   }
+
+  if (-not (Test-Path -LiteralPath $InputFolder)) {
+    return [pscustomobject]$result
+  }
+
+  $files = Get-AllTextFiles -Root $InputFolder
+  foreach ($f in $files) {
+    $name = $f.Name.ToLowerInvariant()
+    switch -Regex ($name) {
+      'office.*licen' {
+        if (-not $result.Contains('OfficeLicense')) {
+          $result['OfficeLicense'] = Read-Text $f.FullName
+        }
+        continue
+      }
+      'outlook.*connectivity' {
+        if (-not $result.Contains('Outlook')) {
+          $result['Outlook'] = Read-Text $f.FullName
+        }
+        continue
+      }
+    }
+  }
+
+  return [pscustomobject]$result
 }
 
 function Analyze-Office {
   [CmdletBinding()]
   param(
-    [Parameter(Mandatory)][hashtable]$Context,  # shared context if needed across modules
-    [Parameter(Mandatory)][psobject]$Data       # output of Collect-OfficeData
+    [Parameter(Mandatory)][hashtable]$Context,
+    [Parameter(Mandatory)][psobject]$Data
   )
+
   $cards  = New-Object System.Collections.Generic.List[object]
   $checks = New-Object System.Collections.Generic.List[object]
 
-  
-if ($Data.OfficeLicense -and $Data.OfficeLicense -match 'Licensed:\s*No') {
-  $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Office is not licensed' )
-  $checks.Add( New-Check -Area $AreaName -Name 'Office licensed' -Status 'fail' -Weight 1.3 )
-}
-   
+  if ($Data.OfficeLicense -and $Data.OfficeLicense -match 'Licensed\s*:\s*No') {
+    $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Office is not licensed' -Evidence ($Data.OfficeLicense.Trim()) )
+    $checks.Add( New-Check -Area $AreaName -Name 'Office licensed' -Status 'fail' -Weight 1.3 -Evidence ($Data.OfficeLicense.Trim()) )
+  }
 
-  # Example baseline: if we produced nothing, surface a neutral check so scoring doesn't divide by zero
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
     $cards.Add( New-GoodCard -Area $AreaName -Message 'Office: No issues detected by baseline heuristics.' )
     $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )

--- a/AutoL1/Modules/Printing.psm1
+++ b/AutoL1/Modules/Printing.psm1
@@ -8,47 +8,59 @@ using module ./Common.psm1
 $AreaName = 'Printing'
 
 function Collect-PrintingData {
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName='FromFolder')]
   param(
     [Parameter(ParameterSetName='FromFolder', Mandatory)][string]$InputFolder,
     [Parameter(ParameterSetName='Live')][switch]$Live
   )
-  # Hints: Get-Printer, spooler status, stuck queues
+
+  $result = [ordered]@{}
+
   if ($PSCmdlet.ParameterSetName -eq 'Live') {
-    '.*printers?.*\.txt$' {{ $result['Printers'] = Read-Text $f.FullName; break }}
-        '.*spooler.*status.*\.txt$' {{ $result['Spooler'] = Read-Text $f.FullName; break }}
-  } else {
-    $result = [ordered]@{}
-    $files = Get-AllTextFiles -Root $InputFolder
-    foreach ($f in $files) {
-      $name = $f.Name.ToLowerInvariant()
-      switch -Regex ($name) {
-        '.*printers?.*\.txt$' {{ $result['Printers'] = Read-Text $f.FullName; break }}
-        '.*spooler.*status.*\.txt$' {{ $result['Spooler'] = Read-Text $f.FullName; break }}
-        default { }
-      }
-    }
     return [pscustomobject]$result
   }
+
+  if (-not (Test-Path -LiteralPath $InputFolder)) {
+    return [pscustomobject]$result
+  }
+
+  $files = Get-AllTextFiles -Root $InputFolder
+  foreach ($f in $files) {
+    $name = $f.Name.ToLowerInvariant()
+    switch -Regex ($name) {
+      'printer' {
+        if (-not $result.Contains('Printers')) {
+          $result['Printers'] = Read-Text $f.FullName
+        }
+        continue
+      }
+      'spooler' {
+        if (-not $result.Contains('Spooler')) {
+          $result['Spooler'] = Read-Text $f.FullName
+        }
+        continue
+      }
+    }
+  }
+
+  return [pscustomobject]$result
 }
 
 function Analyze-Printing {
   [CmdletBinding()]
   param(
-    [Parameter(Mandatory)][hashtable]$Context,  # shared context if needed across modules
-    [Parameter(Mandatory)][psobject]$Data       # output of Collect-PrintingData
+    [Parameter(Mandatory)][hashtable]$Context,
+    [Parameter(Mandatory)][psobject]$Data
   )
+
   $cards  = New-Object System.Collections.Generic.List[object]
   $checks = New-Object System.Collections.Generic.List[object]
 
-  
-if ($Data.Spooler -and $Data.Spooler -match 'Stopped') {
-  $cards.Add( New-IssueCard -Area $AreaName -Severity 'medium' -Message 'Print Spooler service is stopped' )
-  $checks.Add( New-Check -Area $AreaName -Name 'Spooler running' -Status 'fail' -Weight 1.0 )
-}
-   
+  if ($Data.Spooler -and $Data.Spooler -match 'Stopped') {
+    $cards.Add( New-IssueCard -Area $AreaName -Severity 'medium' -Message 'Print Spooler service is stopped' -Evidence ($Data.Spooler.Trim()) )
+    $checks.Add( New-Check -Area $AreaName -Name 'Spooler running' -Status 'fail' -Weight 1.0 -Evidence ($Data.Spooler.Trim()) )
+  }
 
-  # Example baseline: if we produced nothing, surface a neutral check so scoring doesn't divide by zero
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
     $cards.Add( New-GoodCard -Area $AreaName -Message 'Printing: No issues detected by baseline heuristics.' )
     $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )

--- a/AutoL1/Modules/Security.psm1
+++ b/AutoL1/Modules/Security.psm1
@@ -8,53 +8,70 @@ using module ./Common.psm1
 $AreaName = 'Security'
 
 function Collect-SecurityData {
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName='FromFolder')]
   param(
     [Parameter(ParameterSetName='FromFolder', Mandatory)][string]$InputFolder,
     [Parameter(ParameterSetName='Live')][switch]$Live
   )
-  # Hints: Defender summary, BitLocker status, Secure Boot, SmartScreen
+
+  $result = [ordered]@{}
+
   if ($PSCmdlet.ParameterSetName -eq 'Live') {
-    '.*bitlocker.*status.*\.txt$' {{ $result['BitLocker'] = Read-Text $f.FullName; break }}
-        '.*defender.*summary.*\.txt$' {{ $result['Defender'] = Read-Text $f.FullName; break }}
-        '.*secure.*boot.*\.txt$' {{ $result['SecureBoot'] = Read-Text $f.FullName; break }}
-  } else {
-    $result = [ordered]@{}
-    $files = Get-AllTextFiles -Root $InputFolder
-    foreach ($f in $files) {
-      $name = $f.Name.ToLowerInvariant()
-      switch -Regex ($name) {
-        '.*bitlocker.*status.*\.txt$' {{ $result['BitLocker'] = Read-Text $f.FullName; break }}
-        '.*defender.*summary.*\.txt$' {{ $result['Defender'] = Read-Text $f.FullName; break }}
-        '.*secure.*boot.*\.txt$' {{ $result['SecureBoot'] = Read-Text $f.FullName; break }}
-        default { }
-      }
-    }
     return [pscustomobject]$result
   }
+
+  if (-not (Test-Path -LiteralPath $InputFolder)) {
+    return [pscustomobject]$result
+  }
+
+  $files = Get-AllTextFiles -Root $InputFolder
+  foreach ($f in $files) {
+    $name = $f.Name.ToLowerInvariant()
+    switch -Regex ($name) {
+      'bitlocker' {
+        if (-not $result.Contains('BitLocker')) {
+          $result['BitLocker'] = Read-Text $f.FullName
+        }
+        continue
+      }
+      'defender' {
+        if (-not $result.Contains('Defender')) {
+          $result['Defender'] = Read-Text $f.FullName
+        }
+        continue
+      }
+      'secure.*boot' {
+        if (-not $result.Contains('SecureBoot')) {
+          $result['SecureBoot'] = Read-Text $f.FullName
+        }
+        continue
+      }
+    }
+  }
+
+  return [pscustomobject]$result
 }
 
 function Analyze-Security {
   [CmdletBinding()]
   param(
-    [Parameter(Mandatory)][hashtable]$Context,  # shared context if needed across modules
-    [Parameter(Mandatory)][psobject]$Data       # output of Collect-SecurityData
+    [Parameter(Mandatory)][hashtable]$Context,
+    [Parameter(Mandatory)][psobject]$Data
   )
+
   $cards  = New-Object System.Collections.Generic.List[object]
   $checks = New-Object System.Collections.Generic.List[object]
 
-  
-if ($Data.BitLocker -and $Data.BitLocker -match 'Protection Status\s*:\s*Protection Off') {
-  $cards.Add( New-IssueCard -Area $AreaName -Severity 'critical' -Message 'BitLocker is OFF' )
-  $checks.Add( New-Check -Area $AreaName -Name 'BitLocker enabled' -Status 'fail' -Weight 2.0 )
-}
-if ($Data.SecureBoot -and $Data.SecureBoot -match 'Enabled\s*:\s*False') {
-  $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Secure Boot is disabled' )
-  $checks.Add( New-Check -Area $AreaName -Name 'Secure Boot enabled' -Status 'warn' -Weight 1.2 )
-}
-   
+  if ($Data.BitLocker -and $Data.BitLocker -match 'Protection Status\s*:\s*Protection Off') {
+    $cards.Add( New-IssueCard -Area $AreaName -Severity 'critical' -Message 'BitLocker is OFF' -Evidence ($Data.BitLocker.Trim()) )
+    $checks.Add( New-Check -Area $AreaName -Name 'BitLocker enabled' -Status 'fail' -Weight 2.0 -Evidence ($Data.BitLocker.Trim()) )
+  }
 
-  # Example baseline: if we produced nothing, surface a neutral check so scoring doesn't divide by zero
+  if ($Data.SecureBoot -and $Data.SecureBoot -match 'Enabled\s*:\s*False') {
+    $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Secure Boot is disabled' -Evidence ($Data.SecureBoot.Trim()) )
+    $checks.Add( New-Check -Area $AreaName -Name 'Secure Boot enabled' -Status 'warn' -Weight 1.2 -Evidence ($Data.SecureBoot.Trim()) )
+  }
+
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
     $cards.Add( New-GoodCard -Area $AreaName -Message 'Security: No issues detected by baseline heuristics.' )
     $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )

--- a/AutoL1/Modules/Services.psm1
+++ b/AutoL1/Modules/Services.psm1
@@ -8,45 +8,53 @@ using module ./Common.psm1
 $AreaName = 'Services'
 
 function Collect-ServicesData {
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName='FromFolder')]
   param(
     [Parameter(ParameterSetName='FromFolder', Mandatory)][string]$InputFolder,
     [Parameter(ParameterSetName='Live')][switch]$Live
   )
-  # Hints: services.txt snapshot (name, status, start type), startup impact
+
+  $result = [ordered]@{}
+
   if ($PSCmdlet.ParameterSetName -eq 'Live') {
-    '.*services.*snapshot.*\.txt$' {{ $result['Services'] = Read-Text $f.FullName; break }}
-  } else {
-    $result = [ordered]@{}
-    $files = Get-AllTextFiles -Root $InputFolder
-    foreach ($f in $files) {
-      $name = $f.Name.ToLowerInvariant()
-      switch -Regex ($name) {
-        '.*services.*snapshot.*\.txt$' {{ $result['Services'] = Read-Text $f.FullName; break }}
-        default { }
-      }
-    }
     return [pscustomobject]$result
   }
+
+  if (-not (Test-Path -LiteralPath $InputFolder)) {
+    return [pscustomobject]$result
+  }
+
+  $files = Get-AllTextFiles -Root $InputFolder
+  foreach ($f in $files) {
+    $name = $f.Name.ToLowerInvariant()
+    switch -Regex ($name) {
+      'services' {
+        if (-not $result.Contains('Services')) {
+          $result['Services'] = Read-Text $f.FullName
+        }
+        continue
+      }
+    }
+  }
+
+  return [pscustomobject]$result
 }
 
 function Analyze-Services {
   [CmdletBinding()]
   param(
-    [Parameter(Mandatory)][hashtable]$Context,  # shared context if needed across modules
-    [Parameter(Mandatory)][psobject]$Data       # output of Collect-ServicesData
+    [Parameter(Mandatory)][hashtable]$Context,
+    [Parameter(Mandatory)][psobject]$Data
   )
+
   $cards  = New-Object System.Collections.Generic.List[object]
   $checks = New-Object System.Collections.Generic.List[object]
 
-  
-if ($Data.Services -and $Data.Services -match 'Windows Update\s+Disabled') {
-  $cards.Add( New-IssueCard -Area $AreaName -Severity 'medium' -Message 'Windows Update service is disabled' )
-  $checks.Add( New-Check -Area $AreaName -Name 'WUSvc running' -Status 'fail' -Weight 1.0 )
-}
-   
+  if ($Data.Services -and $Data.Services -match 'Windows Update\s+Disabled') {
+    $cards.Add( New-IssueCard -Area $AreaName -Severity 'medium' -Message 'Windows Update service is disabled' -Evidence ($Data.Services.Trim()) )
+    $checks.Add( New-Check -Area $AreaName -Name 'WUSvc running' -Status 'fail' -Weight 1.0 -Evidence ($Data.Services.Trim()) )
+  }
 
-  # Example baseline: if we produced nothing, surface a neutral check so scoring doesn't divide by zero
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
     $cards.Add( New-GoodCard -Area $AreaName -Message 'Services: No issues detected by baseline heuristics.' )
     $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )

--- a/AutoL1/Modules/System.psm1
+++ b/AutoL1/Modules/System.psm1
@@ -8,28 +8,42 @@ using module ./Common.psm1
 $AreaName = 'System'
 
 function Collect-SystemData {
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName='FromFolder')]
   param(
     [Parameter(ParameterSetName='FromFolder', Mandatory)][string]$InputFolder,
     [Parameter(ParameterSetName='Live')][switch]$Live
   )
-  # Hints: systeminfo.txt, msinfo32.nfo (exported to txt), uptime, OS build
+
+  $result = [ordered]@{}
+
   if ($PSCmdlet.ParameterSetName -eq 'Live') {
-    '.*systeminfo.*\.txt$' {{ $result['SystemInfo'] = Read-Text $f.FullName; break }}
-        '.*uptime.*\.txt$' {{ $result['Uptime'] = Read-Text $f.FullName; break }}
-  } else {
-    $result = [ordered]@{}
-    $files = Get-AllTextFiles -Root $InputFolder
-    foreach ($f in $files) {
-      $name = $f.Name.ToLowerInvariant()
-      switch -Regex ($name) {
-        '.*systeminfo.*\.txt$' {{ $result['SystemInfo'] = Read-Text $f.FullName; break }}
-        '.*uptime.*\.txt$' {{ $result['Uptime'] = Read-Text $f.FullName; break }}
-        default { }
-      }
-    }
     return [pscustomobject]$result
   }
+
+  if (-not (Test-Path -LiteralPath $InputFolder)) {
+    return [pscustomobject]$result
+  }
+
+  $files = Get-AllTextFiles -Root $InputFolder
+  foreach ($f in $files) {
+    $name = $f.Name.ToLowerInvariant()
+    switch -Regex ($name) {
+      'systeminfo' {
+        if (-not $result.Contains('SystemInfo')) {
+          $result['SystemInfo'] = Read-Text $f.FullName
+        }
+        continue
+      }
+      'uptime' {
+        if (-not $result.Contains('Uptime')) {
+          $result['Uptime'] = Read-Text $f.FullName
+        }
+        continue
+      }
+    }
+  }
+
+  return [pscustomobject]$result
 }
 
 function Analyze-System {
@@ -38,23 +52,25 @@ function Analyze-System {
     [Parameter(Mandatory)][hashtable]$Context,  # shared context if needed across modules
     [Parameter(Mandatory)][psobject]$Data       # output of Collect-SystemData
   )
+
   $cards  = New-Object System.Collections.Generic.List[object]
   $checks = New-Object System.Collections.Generic.List[object]
 
-  
-# very simple uptime heuristic
-$uptime = $Data.Uptime
-if ($null -ne $uptime -and $uptime -match '(\d+)\s*day') {
-  $days = [int]$Matches[1]
-  if ($days -gt 14) {
-    $cards.Add( New-IssueCard -Area $AreaName -Severity 'medium' -Message "Uptime is $days days (consider rebooting)" -Evidence ($uptime.Trim()) )
-    $checks.Add( New-Check -Area $AreaName -Name 'Uptime < 14 days' -Status 'fail' -Weight 1 -Evidence ($uptime.Trim()) )
-  } else {
-    $cards.Add( New-GoodCard -Area $AreaName -Message "Healthy uptime ($days days)" )
-    $checks.Add( New-Check -Area $AreaName -Name 'Uptime < 14 days' -Status 'pass' -Weight 1 -Evidence ($uptime.Trim()) )
+  # very simple uptime heuristic
+  $uptime = $Data.Uptime
+  if ($null -ne $uptime) {
+    $uptimeText = $uptime.Trim()
+    if ($uptimeText -match '(\d+)\s*day') {
+      $days = [int]$Matches[1]
+      if ($days -gt 14) {
+        $cards.Add( New-IssueCard -Area $AreaName -Severity 'medium' -Message ("Uptime is {0} days (consider rebooting)" -f $days) -Evidence $uptimeText )
+        $checks.Add( New-Check -Area $AreaName -Name 'Uptime < 14 days' -Status 'fail' -Weight 1 -Evidence $uptimeText )
+      } else {
+        $cards.Add( New-GoodCard -Area $AreaName -Message ("Healthy uptime ({0} days)" -f $days) -Evidence $uptimeText )
+        $checks.Add( New-Check -Area $AreaName -Name 'Uptime < 14 days' -Status 'pass' -Weight 1 -Evidence $uptimeText )
+      }
+    }
   }
-}
-   
 
   # Example baseline: if we produced nothing, surface a neutral check so scoring doesn't divide by zero
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {


### PR DESCRIPTION
## Summary
- rewrite each AutoL1 analyzer module to restore valid PowerShell syntax
- harden collectors to guard against missing input folders and duplicate matches
- ensure analyzer checks include supporting evidence strings for generated cards and checks

## Testing
- not run (PowerShell is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d506b4aa88832dad9b5385fa45345d