### PR TITLE
Fix card/check creation syntax in analyzer modules

### DIFF
--- a/AutoL1/Modules/ActiveDirectory.psm1
+++ b/AutoL1/Modules/ActiveDirectory.psm1
@@ -57,13 +57,13 @@ function Analyze-ActiveDirectory {
   $checks = New-Object System.Collections.Generic.List[object]
 
   if ($Data.SecureChannel -and $Data.SecureChannel -match 'False') {
-    $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Computer secure channel to domain is broken' -Evidence ($Data.SecureChannel.Trim()) )
-    $checks.Add( New-Check -Area $AreaName -Name 'Secure channel healthy' -Status 'fail' -Weight 1.5 -Evidence ($Data.SecureChannel.Trim()) )
+    $cards.Add( (New-IssueCard -Area $AreaName -Severity 'high' -Message 'Computer secure channel to domain is broken' -Evidence ($Data.SecureChannel.Trim())) )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Secure channel healthy' -Status 'fail' -Weight 1.5 -Evidence ($Data.SecureChannel.Trim())) )
   }
 
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
-    $cards.Add( New-GoodCard -Area $AreaName -Message 'ActiveDirectory: No issues detected by baseline heuristics.' )
-    $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )
+    $cards.Add( (New-GoodCard -Area $AreaName -Message 'ActiveDirectory: No issues detected by baseline heuristics.') )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1) )
   }
 
   [pscustomobject]@{

--- a/AutoL1/Modules/Hardware.psm1
+++ b/AutoL1/Modules/Hardware.psm1
@@ -61,18 +61,18 @@ function Analyze-Hardware {
     if ($diskList -match 'Status\s*:\s*([A-Za-z]+)') {
       $status = $Matches[1]
       if ($status -notin @('OK','Healthy','Good')) {
-        $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message ("Disk SMART status indicates: {0}" -f $status) -Evidence ($diskList.Trim()) )
-        $checks.Add( New-Check -Area $AreaName -Name 'Disk health' -Status 'fail' -Weight 1.5 -Evidence ($diskList.Trim()) )
+        $cards.Add( (New-IssueCard -Area $AreaName -Severity 'high' -Message ("Disk SMART status indicates: {0}" -f $status) -Evidence ($diskList.Trim())) )
+        $checks.Add( (New-Check -Area $AreaName -Name 'Disk health' -Status 'fail' -Weight 1.5 -Evidence ($diskList.Trim())) )
       } else {
-        $cards.Add( New-GoodCard -Area $AreaName -Message 'Disk health appears OK' -Evidence ($diskList.Trim()) )
-        $checks.Add( New-Check -Area $AreaName -Name 'Disk health' -Status 'pass' -Weight 1.0 -Evidence ($diskList.Trim()) )
+        $cards.Add( (New-GoodCard -Area $AreaName -Message 'Disk health appears OK' -Evidence ($diskList.Trim())) )
+        $checks.Add( (New-Check -Area $AreaName -Name 'Disk health' -Status 'pass' -Weight 1.0 -Evidence ($diskList.Trim())) )
       }
     }
   }
 
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
-    $cards.Add( New-GoodCard -Area $AreaName -Message 'Hardware: No issues detected by baseline heuristics.' )
-    $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )
+    $cards.Add( (New-GoodCard -Area $AreaName -Message 'Hardware: No issues detected by baseline heuristics.') )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1) )
   }
 
   [pscustomobject]@{

--- a/AutoL1/Modules/Network.psm1
+++ b/AutoL1/Modules/Network.psm1
@@ -64,17 +64,17 @@ function Analyze-Network {
 
   if ($Data.IpConfig) {
     if ($Data.IpConfig -match 'Autoconfiguration IPv4 Address\s*:\s*169\.254\.') {
-      $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Link-local address detected (likely DHCP failure)' -Evidence ($Data.IpConfig.Trim()) )
-      $checks.Add( New-Check -Area $AreaName -Name 'Has valid DHCP lease' -Status 'fail' -Weight 1.2 -Evidence ($Data.IpConfig.Trim()) )
+      $cards.Add( (New-IssueCard -Area $AreaName -Severity 'high' -Message 'Link-local address detected (likely DHCP failure)' -Evidence ($Data.IpConfig.Trim())) )
+      $checks.Add( (New-Check -Area $AreaName -Name 'Has valid DHCP lease' -Status 'fail' -Weight 1.2 -Evidence ($Data.IpConfig.Trim())) )
     } else {
-      $cards.Add( New-GoodCard -Area $AreaName -Message 'IP configuration present' -Evidence ($Data.IpConfig.Trim()) )
-      $checks.Add( New-Check -Area $AreaName -Name 'Has valid DHCP lease' -Status 'pass' -Weight 0.8 -Evidence ($Data.IpConfig.Trim()) )
+      $cards.Add( (New-GoodCard -Area $AreaName -Message 'IP configuration present' -Evidence ($Data.IpConfig.Trim())) )
+      $checks.Add( (New-Check -Area $AreaName -Name 'Has valid DHCP lease' -Status 'pass' -Weight 0.8 -Evidence ($Data.IpConfig.Trim())) )
     }
   }
 
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
-    $cards.Add( New-GoodCard -Area $AreaName -Message 'Network: No issues detected by baseline heuristics.' )
-    $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )
+    $cards.Add( (New-GoodCard -Area $AreaName -Message 'Network: No issues detected by baseline heuristics.') )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1) )
   }
 
   [pscustomobject]@{

--- a/AutoL1/Modules/Office.psm1
+++ b/AutoL1/Modules/Office.psm1
@@ -57,13 +57,13 @@ function Analyze-Office {
   $checks = New-Object System.Collections.Generic.List[object]
 
   if ($Data.OfficeLicense -and $Data.OfficeLicense -match 'Licensed\s*:\s*No') {
-    $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Office is not licensed' -Evidence ($Data.OfficeLicense.Trim()) )
-    $checks.Add( New-Check -Area $AreaName -Name 'Office licensed' -Status 'fail' -Weight 1.3 -Evidence ($Data.OfficeLicense.Trim()) )
+    $cards.Add( (New-IssueCard -Area $AreaName -Severity 'high' -Message 'Office is not licensed' -Evidence ($Data.OfficeLicense.Trim())) )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Office licensed' -Status 'fail' -Weight 1.3 -Evidence ($Data.OfficeLicense.Trim())) )
   }
 
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
-    $cards.Add( New-GoodCard -Area $AreaName -Message 'Office: No issues detected by baseline heuristics.' )
-    $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )
+    $cards.Add( (New-GoodCard -Area $AreaName -Message 'Office: No issues detected by baseline heuristics.') )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1) )
   }
 
   [pscustomobject]@{

--- a/AutoL1/Modules/Printing.psm1
+++ b/AutoL1/Modules/Printing.psm1
@@ -57,13 +57,13 @@ function Analyze-Printing {
   $checks = New-Object System.Collections.Generic.List[object]
 
   if ($Data.Spooler -and $Data.Spooler -match 'Stopped') {
-    $cards.Add( New-IssueCard -Area $AreaName -Severity 'medium' -Message 'Print Spooler service is stopped' -Evidence ($Data.Spooler.Trim()) )
-    $checks.Add( New-Check -Area $AreaName -Name 'Spooler running' -Status 'fail' -Weight 1.0 -Evidence ($Data.Spooler.Trim()) )
+    $cards.Add( (New-IssueCard -Area $AreaName -Severity 'medium' -Message 'Print Spooler service is stopped' -Evidence ($Data.Spooler.Trim())) )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Spooler running' -Status 'fail' -Weight 1.0 -Evidence ($Data.Spooler.Trim())) )
   }
 
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
-    $cards.Add( New-GoodCard -Area $AreaName -Message 'Printing: No issues detected by baseline heuristics.' )
-    $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )
+    $cards.Add( (New-GoodCard -Area $AreaName -Message 'Printing: No issues detected by baseline heuristics.') )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1) )
   }
 
   [pscustomobject]@{

--- a/AutoL1/Modules/Security.psm1
+++ b/AutoL1/Modules/Security.psm1
@@ -63,18 +63,18 @@ function Analyze-Security {
   $checks = New-Object System.Collections.Generic.List[object]
 
   if ($Data.BitLocker -and $Data.BitLocker -match 'Protection Status\s*:\s*Protection Off') {
-    $cards.Add( New-IssueCard -Area $AreaName -Severity 'critical' -Message 'BitLocker is OFF' -Evidence ($Data.BitLocker.Trim()) )
-    $checks.Add( New-Check -Area $AreaName -Name 'BitLocker enabled' -Status 'fail' -Weight 2.0 -Evidence ($Data.BitLocker.Trim()) )
+    $cards.Add( (New-IssueCard -Area $AreaName -Severity 'critical' -Message 'BitLocker is OFF' -Evidence ($Data.BitLocker.Trim())) )
+    $checks.Add( (New-Check -Area $AreaName -Name 'BitLocker enabled' -Status 'fail' -Weight 2.0 -Evidence ($Data.BitLocker.Trim())) )
   }
 
   if ($Data.SecureBoot -and $Data.SecureBoot -match 'Enabled\s*:\s*False') {
-    $cards.Add( New-IssueCard -Area $AreaName -Severity 'high' -Message 'Secure Boot is disabled' -Evidence ($Data.SecureBoot.Trim()) )
-    $checks.Add( New-Check -Area $AreaName -Name 'Secure Boot enabled' -Status 'warn' -Weight 1.2 -Evidence ($Data.SecureBoot.Trim()) )
+    $cards.Add( (New-IssueCard -Area $AreaName -Severity 'high' -Message 'Secure Boot is disabled' -Evidence ($Data.SecureBoot.Trim())) )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Secure Boot enabled' -Status 'warn' -Weight 1.2 -Evidence ($Data.SecureBoot.Trim())) )
   }
 
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
-    $cards.Add( New-GoodCard -Area $AreaName -Message 'Security: No issues detected by baseline heuristics.' )
-    $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )
+    $cards.Add( (New-GoodCard -Area $AreaName -Message 'Security: No issues detected by baseline heuristics.') )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1) )
   }
 
   [pscustomobject]@{

--- a/AutoL1/Modules/Services.psm1
+++ b/AutoL1/Modules/Services.psm1
@@ -51,13 +51,13 @@ function Analyze-Services {
   $checks = New-Object System.Collections.Generic.List[object]
 
   if ($Data.Services -and $Data.Services -match 'Windows Update\s+Disabled') {
-    $cards.Add( New-IssueCard -Area $AreaName -Severity 'medium' -Message 'Windows Update service is disabled' -Evidence ($Data.Services.Trim()) )
-    $checks.Add( New-Check -Area $AreaName -Name 'WUSvc running' -Status 'fail' -Weight 1.0 -Evidence ($Data.Services.Trim()) )
+    $cards.Add( (New-IssueCard -Area $AreaName -Severity 'medium' -Message 'Windows Update service is disabled' -Evidence ($Data.Services.Trim())) )
+    $checks.Add( (New-Check -Area $AreaName -Name 'WUSvc running' -Status 'fail' -Weight 1.0 -Evidence ($Data.Services.Trim())) )
   }
 
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
-    $cards.Add( New-GoodCard -Area $AreaName -Message 'Services: No issues detected by baseline heuristics.' )
-    $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )
+    $cards.Add( (New-GoodCard -Area $AreaName -Message 'Services: No issues detected by baseline heuristics.') )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1) )
   }
 
   [pscustomobject]@{

--- a/AutoL1/Modules/System.psm1
+++ b/AutoL1/Modules/System.psm1
@@ -63,19 +63,19 @@ function Analyze-System {
     if ($uptimeText -match '(\d+)\s*day') {
       $days = [int]$Matches[1]
       if ($days -gt 14) {
-        $cards.Add( New-IssueCard -Area $AreaName -Severity 'medium' -Message ("Uptime is {0} days (consider rebooting)" -f $days) -Evidence $uptimeText )
-        $checks.Add( New-Check -Area $AreaName -Name 'Uptime < 14 days' -Status 'fail' -Weight 1 -Evidence $uptimeText )
+        $cards.Add( (New-IssueCard -Area $AreaName -Severity 'medium' -Message ("Uptime is {0} days (consider rebooting)" -f $days) -Evidence $uptimeText) )
+        $checks.Add( (New-Check -Area $AreaName -Name 'Uptime < 14 days' -Status 'fail' -Weight 1 -Evidence $uptimeText) )
       } else {
-        $cards.Add( New-GoodCard -Area $AreaName -Message ("Healthy uptime ({0} days)" -f $days) -Evidence $uptimeText )
-        $checks.Add( New-Check -Area $AreaName -Name 'Uptime < 14 days' -Status 'pass' -Weight 1 -Evidence $uptimeText )
+        $cards.Add( (New-GoodCard -Area $AreaName -Message ("Healthy uptime ({0} days)" -f $days) -Evidence $uptimeText) )
+        $checks.Add( (New-Check -Area $AreaName -Name 'Uptime < 14 days' -Status 'pass' -Weight 1 -Evidence $uptimeText) )
       }
     }
   }
 
   # Example baseline: if we produced nothing, surface a neutral check so scoring doesn't divide by zero
   if ($cards.Count -eq 0 -and $checks.Count -eq 0) {
-    $cards.Add( New-GoodCard -Area $AreaName -Message 'System: No issues detected by baseline heuristics.' )
-    $checks.Add( New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1 )
+    $cards.Add( (New-GoodCard -Area $AreaName -Message 'System: No issues detected by baseline heuristics.') )
+    $checks.Add( (New-Check -Area $AreaName -Name 'Baseline' -Status 'info' -Weight 0.1) )
   }
 
   [pscustomobject]@{


### PR DESCRIPTION
## Summary
- wrap issue, good, and check card creation calls in parentheses before adding them to module lists so that PowerShell parses the method calls correctly

## Testing
- Not run (PowerShell `pwsh` is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d50bda6688832d92ca6c6746ec4355