### PR TITLE
Raise event log error summary severity

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -3881,7 +3881,7 @@ function Add-EventStats($txt,$name){
       $evidenceParts += "Sample contained $err entries with 'Error'."
     }
     $evidenceText = $evidenceParts -join "`n`n"
-    Add-Issue "info" "Events" "$name log shows many errors ($err in recent sample)." $evidenceText
+    Add-Issue "medium" "Events" "$name log shows many errors ($err in recent sample)." $evidenceText
   }
   elseif ($warn -ge 10){
     $highlights = Get-EventHighlights -Text $txt -TargetLevels @('Warning') -Max 3


### PR DESCRIPTION
## Summary
- escalate the severity of event log error summaries so they render with a warning badge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5299c6090832d8bf4250f7887e540