### PR TITLE
Adjust low severity issue badge text

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -811,7 +811,7 @@ function Add-Issue(
         'critical' { $badgeText = 'CRITICAL'; $cssClass = 'critical' }
         'high'     { $badgeText = 'BAD';       $cssClass = 'bad' }
         'medium'   { $badgeText = 'WARNING';   $cssClass = 'warning' }
-        'low'      { $badgeText = 'OK';        $cssClass = 'ok' }
+        'low'      { $badgeText = 'LOW';       $cssClass = 'ok' }
         'info'     { $badgeText = 'GOOD';      $cssClass = 'good' }
         default    { $badgeText = $sevKey.ToUpperInvariant(); $cssClass = 'ok' }
     }


### PR DESCRIPTION
## Summary
- ensure low severity issue badges display the LOW label instead of OK

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5296d73e4832db0d0b5cc74ba5136