### PR TITLE
Update severity naming and colors

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -805,15 +805,15 @@ function Add-Issue(
     if ([string]::IsNullOrEmpty($Evidence)) { $Evidence = 'No additional details captured.' }
     $evShort = if ($Evidence.Length -gt 1500) { $Evidence.Substring(0,1500) } else { $Evidence }
 
-    $badgeText = 'ISSUE'
-    $cssClass  = 'ok'
+    $badgeText = if ([string]::IsNullOrWhiteSpace($sevKey)) { 'INFO' } else { $sevKey.ToUpperInvariant() }
+    $cssClass  = 'info'
     switch ($sevKey) {
         'critical' { $badgeText = 'CRITICAL'; $cssClass = 'critical' }
-        'high'     { $badgeText = 'BAD';       $cssClass = 'bad' }
-        'medium'   { $badgeText = 'WARNING';   $cssClass = 'warning' }
-        'low'      { $badgeText = 'LOW';       $cssClass = 'ok' }
-        'info'     { $badgeText = 'GOOD';      $cssClass = 'good' }
-        default    { $badgeText = $sevKey.ToUpperInvariant(); $cssClass = 'ok' }
+        'high'     { $badgeText = 'HIGH';     $cssClass = 'high' }
+        'medium'   { $badgeText = 'MEDIUM';   $cssClass = 'medium' }
+        'low'      { $badgeText = 'LOW';      $cssClass = 'low' }
+        'info'     { $badgeText = 'INFO';     $cssClass = 'info' }
+        default    { if ([string]::IsNullOrWhiteSpace($badgeText)) { $badgeText = 'INFO' } }
     }
 
     # Add to cards
@@ -4542,10 +4542,10 @@ if ($issues.Count -eq 0){
 
   $severityDefinitions = @(
     @{ Key = 'critical'; Label = 'Critical'; BadgeClass = 'critical' },
-    @{ Key = 'high';     Label = 'High';     BadgeClass = 'bad' },
-    @{ Key = 'medium';   Label = 'Medium';   BadgeClass = 'warning' },
-    @{ Key = 'low';      Label = 'Low';      BadgeClass = 'ok' },
-    @{ Key = 'info';     Label = 'Info';     BadgeClass = 'good' }
+    @{ Key = 'high';     Label = 'High';     BadgeClass = 'high' },
+    @{ Key = 'medium';   Label = 'Medium';   BadgeClass = 'medium' },
+    @{ Key = 'low';      Label = 'Low';      BadgeClass = 'low' },
+    @{ Key = 'info';     Label = 'Info';     BadgeClass = 'info' }
   )
 
   $groupedIssues = [ordered]@{}
@@ -4572,7 +4572,7 @@ if ($issues.Count -eq 0){
   }
   if ($otherIssues.Count -gt 0) {
     $groupedIssues['other'] = $otherIssues
-    $activeDefinitions += ,@{ Key = 'other'; Label = 'Other'; BadgeClass = 'ok' }
+    $activeDefinitions += ,@{ Key = 'other'; Label = 'Other'; BadgeClass = 'info' }
   }
 
   if ($activeDefinitions.Count -eq 0) {

--- a/AutoL1/styles/device-health-report.css
+++ b/AutoL1/styles/device-health-report.css
@@ -314,10 +314,23 @@ details.report-card[open] > summary {
   color: var(--color-state-good-text);
 }
 
+.report-badge--info {
+  background-color: var(--color-state-info-bg);
+  border-color: var(--color-state-info-border);
+  color: var(--color-state-info-text);
+}
+
+.report-badge--low,
 .report-badge--ok {
   background-color: var(--color-state-ok-bg);
   border-color: var(--color-state-ok-border);
   color: var(--color-state-ok-text);
+}
+
+.report-badge--medium {
+  background-color: var(--color-state-medium-bg);
+  border-color: var(--color-state-medium-border);
+  color: var(--color-state-medium-text);
 }
 
 .report-badge--warning {
@@ -326,6 +339,7 @@ details.report-card[open] > summary {
   color: var(--color-state-warning-text);
 }
 
+.report-badge--high,
 .report-badge--bad {
   background-color: var(--color-state-bad-bg);
   border-color: var(--color-state-bad-border);
@@ -367,9 +381,21 @@ details.report-card[open] > summary {
   background-color: var(--color-state-good-bg);
 }
 
+.report-card--info {
+  border-color: var(--color-state-info-border);
+  background-color: var(--color-state-info-bg);
+  color: var(--color-state-info-text);
+}
+
+.report-card--low,
 .report-card--ok {
   border-color: var(--color-state-ok-border);
   background-color: var(--color-state-ok-bg);
+}
+
+.report-card--medium {
+  border-color: var(--color-state-medium-border);
+  background-color: var(--color-state-medium-bg);
 }
 
 .report-card--warning {
@@ -377,6 +403,7 @@ details.report-card[open] > summary {
   background-color: var(--color-state-warning-bg);
 }
 
+.report-card--high,
 .report-card--bad {
   border-color: var(--color-state-bad-border);
   background-color: var(--color-state-bad-bg);

--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -379,7 +379,7 @@ function New-IssueCardHtml {
     [pscustomobject]$Entry
   )
 
-  $cardClass = if ($Entry.CssClass) { $Entry.CssClass } else { 'ok' }
+  $cardClass = if ($Entry.CssClass) { $Entry.CssClass } else { 'info' }
   $badgeText = if ($Entry.BadgeText) { $Entry.BadgeText } elseif ($Entry.Severity) { $Entry.Severity.ToUpperInvariant() } else { 'ISSUE' }
   $badgeHtml = Encode-Html $badgeText
   $areaHtml = Encode-Html $Entry.Area

--- a/styles/base.css
+++ b/styles/base.css
@@ -30,13 +30,21 @@
   --color-state-good-border: #43a047;
   --color-state-good-text: #1b5e20;
 
-  --color-state-ok-bg: #e3f2fd;
-  --color-state-ok-border: #1e88e5;
-  --color-state-ok-text: #0d47a1;
+  --color-state-ok-bg: #fff9c4;
+  --color-state-ok-border: #fbc02d;
+  --color-state-ok-text: #7f6000;
 
-  --color-state-warning-bg: #fff3e0;
-  --color-state-warning-border: #ef6c00;
-  --color-state-warning-text: #8c6d1f;
+  --color-state-warning-bg: #e3f2fd;
+  --color-state-warning-border: #1e88e5;
+  --color-state-warning-text: #0d47a1;
+
+  --color-state-medium-bg: #fff3e0;
+  --color-state-medium-border: #ef6c00;
+  --color-state-medium-text: #8c6d1f;
+
+  --color-state-info-bg: #ffffff;
+  --color-state-info-border: #cfd8dc;
+  --color-state-info-text: #1f2933;
 
   --color-state-bad-bg: #ffebee;
   --color-state-bad-border: #d32f2f;


### PR DESCRIPTION
## Summary
- align issue badge text and CSS classes with the Critical/High/Medium/Low/Info naming scheme
- refresh report styling so each severity uses the requested color palette and keep legacy classes as aliases
- default issue cards to the new neutral info styling when no explicit class is provided

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d52c92b5c0832daacd1f3652007acc