### PR TITLE
Add report generation timestamp to device health report

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -4356,8 +4356,11 @@ $osHtml = "$(Encode-Html ($summary.OS)) | $(Encode-Html ($summary.OS_Version))"
 $ipv4Html = Encode-Html ($summary.IPv4)
 $gatewayHtml = Encode-Html ($summary.Gateway)
 $dnsHtml = Encode-Html ($summary.DNS)
+$reportGeneratedAt = Get-Date
+$reportGeneratedAtHtml = Encode-Html ($reportGeneratedAt.ToString("dddd, MMMM d, yyyy 'at' h:mm tt"))
 $sumTable = @"
 <h1>Device Health Report</h1>
+<h2 class='report-subtitle'>Generated $reportGeneratedAtHtml</h2>
 <div class='report-card'>
   <div class='report-badge-group'>
     <span class='report-badge report-badge--score'><span class='report-badge__label'>SCORE</span><span class='report-badge__value'>$score</span><span class='report-badge__suffix'>/100</span></span>

--- a/AutoL1/styles/device-health-report.css
+++ b/AutoL1/styles/device-health-report.css
@@ -19,6 +19,13 @@
   color: var(--color-heading);
 }
 
+.report-page .report-subtitle {
+  margin: calc(var(--space-xs)) 0 var(--space-md);
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: var(--color-heading);
+}
+
 .report-card {
   margin-bottom: var(--space-md);
   padding: var(--space-md);


### PR DESCRIPTION
## Summary
- add timestamp metadata to the device health report header
- style the new report subtitle to appear just below the main title

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d52d1b27bc832db6724367bbcf4278