### PR TITLE
Add Normalize-Severity helper and reuse it

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -770,8 +770,9 @@ function Get-IssueExplanation {
     return "Broken Autodiscover SCP records keep domain-joined PCs from finding the right Exchange endpoints. Outlook may connect to the wrong place or fail to sign in on the internal network." 
   }
 
-  $severityWord = if ($Severity) { $Severity.ToLowerInvariant() } else { 'issue' }
-  return "This $severityWord points to something outside the normal health baseline. Reviewing the evidence and correcting it will help keep the device stable and secure." 
+  $severityWord = Normalize-Severity $Severity
+  if (-not $severityWord) { $severityWord = 'issue' }
+  return "This $severityWord points to something outside the normal health baseline. Reviewing the evidence and correcting it will help keep the device stable and secure."
 }
 
 function Add-Issue(
@@ -791,7 +792,7 @@ function Add-Issue(
     }
 
     # normalize
-    $sevKey = if ($null -ne $Severity) { $Severity.Trim().ToLowerInvariant() } else { "" }
+    $sevKey = Normalize-Severity $Severity
     switch -regex ($sevKey){
         '^(crit(ical)?)$' { $sevKey = 'critical' }
         '^(hi(gh)?)$'     { $sevKey = 'high' }
@@ -4556,7 +4557,7 @@ if ($issues.Count -eq 0){
 
   foreach ($entry in $sortedIssues) {
     $cardHtml = New-IssueCardHtml -Entry $entry
-    $severityKey = if ($entry.Severity) { $entry.Severity.ToLowerInvariant() } else { '' }
+    $severityKey = Normalize-Severity $entry.Severity
     if ($severityKey -and $groupedIssues.ContainsKey($severityKey)) {
       $groupedIssues[$severityKey].Add($cardHtml)
     } else {

--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -1,19 +1,36 @@
 # Common helper functions shared across analyzer scripts
 $script:SeverityOrder = @('low','medium','high','critical')
 
+function Normalize-Severity {
+  param($Severity)
+
+  if ($null -eq $Severity) { return '' }
+
+  try {
+    $text = [string]$Severity
+  } catch {
+    $text = [string]$Severity
+  }
+
+  if (-not $text) { return '' }
+
+  $trimmed = $text.Trim()
+  if (-not $trimmed) { return '' }
+
+  try {
+    return $trimmed.ToLowerInvariant()
+  } catch {
+    return $trimmed.ToLowerInvariant()
+  }
+}
+
 function Get-SeverityIndex {
   param([string]$Severity)
 
   if (-not $Severity) { return -1 }
 
-  try {
-    $normalized = $Severity.ToLowerInvariant()
-  } catch {
-    $normalized = [string]$Severity
-    if ($normalized) {
-      $normalized = $normalized.ToLowerInvariant()
-    }
-  }
+  $normalized = Normalize-Severity $Severity
+  if (-not $normalized) { return -1 }
 
   return $script:SeverityOrder.IndexOf($normalized)
 }


### PR DESCRIPTION
## Summary
- add a Normalize-Severity helper in Common.psm1 to trim and lowercase severity values consistently
- refactor Analyze-Diagnostics.ps1 to call Normalize-Severity instead of manually lower-casing severities

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./Modules/Common.psm1 -Force; 'module loaded'"` *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_68d532ed0e70832da32546c16e0dba00