### PR TITLE
Add structured LAPS collector and update analyzer logic

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -19,6 +19,8 @@ $ErrorActionPreference = 'SilentlyContinue'
 $commonModulePath = Join-Path (Split-Path $PSScriptRoot -Parent) 'Modules/Common.psm1'
 Import-Module $commonModulePath -Force
 
+$Root = $InputFolder
+
 # DNS heuristics configuration (override in-line as needed)
 [string[]]$AnycastDnsAllow = @()
 
@@ -2939,34 +2941,125 @@ if ($isCurrentUserAdmin) {
   Add-SecurityHeuristic 'Local admin rights' 'Least privilege verified' 'good' $memberSummary ($localAdminEvidence)
 }
 
-$lapsData = ConvertFrom-JsonSafe $raw['security_laps']
-$lapsEnabled = $false
-$lapsEvidenceLines = @()
-if ($lapsData) {
-  if ($lapsData.PSObject.Properties['Legacy']) {
-    $legacy = $lapsData.Legacy
-    if ($legacy -and $legacy.PSObject.Properties['AdmPwdEnabled']) {
-      $legacyEnabled = ConvertTo-NullableInt $legacy.AdmPwdEnabled
-      $lapsEvidenceLines += "Legacy AdmPwdEnabled: $legacyEnabled"
-      if ($legacyEnabled -eq 1) { $lapsEnabled = $true }
-    }
-  }
-  if ($lapsData.PSObject.Properties['WindowsLAPS']) {
-    $modern = $lapsData.WindowsLAPS
-    foreach ($prop in $modern.PSObject.Properties) {
-      $lapsEvidenceLines += "WindowsLAPS {0}: {1}" -f $prop.Name, $prop.Value
-      if ($prop.Name -eq 'BackupDirectory' -and $prop.Value -ne $null) { $lapsEnabled = $true }
-      if ($prop.Name -match 'Enabled' -and (ConvertTo-NullableInt $prop.Value) -eq 1) { $lapsEnabled = $true }
-    }
-  }
-  if ($lapsData.PSObject.Properties['Status']) { $lapsEvidenceLines += $lapsData.Status }
+$lapsDoc = $null
+$lapsCollectorPath = Join-Path $Root 'collectors\laps_localadmin.json'
+if (Test-Path $lapsCollectorPath) {
+  try {
+    $lapsDoc = Get-Content $lapsCollectorPath -Raw | ConvertFrom-Json
+  } catch {}
 }
-$lapsEvidence = $lapsEvidenceLines -join "`n"
-if ($lapsEnabled) {
-  Add-SecurityHeuristic 'LAPS/PLAP' 'Policy detected' 'good' '' $lapsEvidence
+
+if ($lapsDoc -and $lapsDoc.Checks) {
+  $pol  = $lapsDoc.Checks | Where-Object { $_.Id -eq 'LAPS.Policy' } | Select-Object -First 1
+  $list = $lapsDoc.Checks | Where-Object { $_.Id -eq 'LocalAdmins.List' } | Select-Object -First 1
+  $users = @()
+    if ($list -and $list.Data -and $list.Data.PSObject.Properties['Users']) {
+      $users = @($list.Data.Users | Where-Object { $_ })
+  }
+
+  $lapsPresent = $false
+  if ($pol -and $pol.Data) {
+    $lapsPresent = [bool]($pol.Data.WindowsLapsPolicy -or $pol.Data.WindowsLapsState -or $pol.Data.LegacyAdmPwdPolicy)
+  }
+
+  $builtin = @($users | Where-Object { $_.IsBuiltInAdmin })
+  $builtinEnabled = $false
+  if ($builtin.Count -gt 0) {
+    $builtinEnabled = [bool]$builtin[0].Enabled
+  }
+
+  $otherEnabled = @($users | Where-Object { -not $_.IsBuiltInAdmin -and $_.Enabled })
+  $standingLocalAdmin = $builtinEnabled -or ($otherEnabled.Count -gt 0)
+
+  $staleDays = 30
+  $now = (Get-Date).ToUniversalTime()
+  $persistence = $false
+
+  if ($builtinEnabled) {
+    $persistence = $true
+  } else {
+    foreach ($u in $otherEnabled) {
+      if ($u.PasswordNeverExpires) { $persistence = $true; break }
+      if (-not $u.LastPasswordSet) { $persistence = $true; break }
+      $lastSet = $null
+      if ($u.LastPasswordSet) {
+        try {
+          $lastSet = [datetime]::Parse($u.LastPasswordSet).ToUniversalTime()
+        } catch {
+          $lastSet = $null
+        }
+      }
+      if (-not $lastSet) { $persistence = $true; break }
+      if (($now - $lastSet).TotalDays -gt $staleDays) { $persistence = $true; break }
+    }
+  }
+
+  $otherEnabledNames = if ($otherEnabled.Count -gt 0) { $otherEnabled | ForEach-Object { $_.Name } } else { @() }
+  $otherEnabledSummary = if ($otherEnabledNames.Count -gt 0) { $otherEnabledNames -join ', ' } else { 'None' }
+
+  $userLines = @()
+  foreach ($u in $users) {
+    $lastSetText = if ($u.LastPasswordSet) { [string]$u.LastPasswordSet } else { 'null' }
+    $userLines += "User: {0}; Enabled={1}; PasswordNeverExpires={2}; LastPasswordSet={3}; BuiltInAdmin={4}" -f `
+      $u.Name, $u.Enabled, $u.PasswordNeverExpires, $lastSetText, $u.IsBuiltInAdmin
+  }
+
+  $evidenceLines = @(
+    "LAPS footprints present: $lapsPresent",
+    "Built-in Administrator enabled: $builtinEnabled",
+    "Other enabled local admins: $otherEnabledSummary",
+    "Persistence indicators present: $persistence",
+    "Password stale threshold (days): $staleDays"
+  )
+
+  $evidenceLines += $userLines
+  $lapsEvidence = ($evidenceLines | Where-Object { $_ }) -join "`n"
+
+  if (-not $standingLocalAdmin) {
+    Add-SecurityHeuristic 'LAPS coverage' 'No standing local admins' 'good' 'No enabled local admin accounts detected.' $lapsEvidence -Area 'Security/LAPS'
+    Add-Issue 'info' 'Security/LAPS' 'LAPS not deployed – no standing local admins; absence of LAPS is low risk.' $lapsEvidence
+  } elseif (-not $lapsPresent) {
+    if ($persistence) {
+      Add-SecurityHeuristic 'LAPS coverage' 'Standing admin without rotation (persistent password indicators).' 'bad' 'Standing local admin detected; rotation controls absent.' $lapsEvidence -Area 'Security/LAPS' -SkipIssue
+      Add-Issue 'high' 'Security/LAPS' 'Local admin risk: No rotation/escrow control. Standing local admin detected; no LAPS/PAM and password appears persistent.' $lapsEvidence
+    } else {
+      Add-SecurityHeuristic 'LAPS coverage' 'Standing admin without rotation control.' 'warning' 'Standing local admin detected without LAPS/PAM policy.' $lapsEvidence -Area 'Security/LAPS' -SkipIssue
+      Add-Issue 'medium' 'Security/LAPS' 'Local admin risk: No rotation/escrow control. Standing local admin detected; no LAPS/PAM but password not stale.' $lapsEvidence
+    }
+  } else {
+    Add-SecurityHeuristic 'LAPS coverage' 'Standing admin with rotation control.' 'good' 'LAPS or equivalent protections detected.' $lapsEvidence -Area 'Security/LAPS'
+    Add-Issue 'low' 'Security/LAPS' 'Local admin present: LAPS/PAM in place. Rotation/escrow control detected (Windows LAPS/AdmPwd or PAM/JIT).' $lapsEvidence
+  }
 } else {
-  Add-SecurityHeuristic 'LAPS/PLAP' 'Not detected' 'warning' 'No LAPS policy detected.' $lapsEvidence -SkipIssue
-  Add-Issue 'high' 'Security/LAPS' 'LAPS/PLAP not detected. Enforce password management policy.' $lapsEvidence
+  $lapsData = ConvertFrom-JsonSafe $raw['security_laps']
+  $lapsEnabled = $false
+  $lapsEvidenceLines = @()
+  if ($lapsData) {
+    if ($lapsData.PSObject.Properties['Legacy']) {
+      $legacy = $lapsData.Legacy
+      if ($legacy -and $legacy.PSObject.Properties['AdmPwdEnabled']) {
+        $legacyEnabled = ConvertTo-NullableInt $legacy.AdmPwdEnabled
+        $lapsEvidenceLines += "Legacy AdmPwdEnabled: $legacyEnabled"
+        if ($legacyEnabled -eq 1) { $lapsEnabled = $true }
+      }
+    }
+    if ($lapsData.PSObject.Properties['WindowsLAPS']) {
+      $modern = $lapsData.WindowsLAPS
+      foreach ($prop in $modern.PSObject.Properties) {
+        $lapsEvidenceLines += "WindowsLAPS {0}: {1}" -f $prop.Name, $prop.Value
+        if ($prop.Name -eq 'BackupDirectory' -and $prop.Value -ne $null) { $lapsEnabled = $true }
+        if ($prop.Name -match 'Enabled' -and (ConvertTo-NullableInt $prop.Value) -eq 1) { $lapsEnabled = $true }
+      }
+    }
+    if ($lapsData.PSObject.Properties['Status']) { $lapsEvidenceLines += $lapsData.Status }
+  }
+  $lapsEvidence = $lapsEvidenceLines -join "`n"
+  if ($lapsEnabled) {
+    Add-SecurityHeuristic 'LAPS/PLAP' 'Policy detected' 'good' '' $lapsEvidence
+  } else {
+    Add-SecurityHeuristic 'LAPS/PLAP' 'Not detected' 'warning' 'No LAPS policy detected.' $lapsEvidence -SkipIssue
+    Add-Issue 'high' 'Security/LAPS' 'LAPS/PLAP not detected. Enforce password management policy.' $lapsEvidence
+  }
 }
 
 # 13. UAC

--- a/AutoL1/Collect-SystemDiagnostics.ps1
+++ b/AutoL1/Collect-SystemDiagnostics.ps1
@@ -859,6 +859,17 @@ Write-Progress -Activity $activity -Completed
 # Save copies of the core raw outputs too
 Copy-Item -Path $files -Destination $reportDir -Force -ErrorAction SilentlyContinue
 
+# Run structured collectors (JSON outputs)
+$lapsCollectorScript = Join-Path (Split-Path $PSScriptRoot -Parent) 'Collectors/Security/Collect-LAPS.ps1'
+if (Test-Path $lapsCollectorScript) {
+  Write-Host "Running LAPS/local admin collector..."
+  try {
+    & $lapsCollectorScript -ReportRoot $reportDir
+  } catch {
+    Write-Warning ("LAPS collector failed: {0}" -f $_)
+  }
+}
+
 # Simple parser: extract key fields from ipconfig /all
 Write-Host "Building quick summary from ipconfig_all.txt..."
 $ipOut = Get-Content (Join-Path $reportDir "ipconfig_all.txt") -Raw

--- a/Collectors/Security/Collect-LAPS.ps1
+++ b/Collectors/Security/Collect-LAPS.ps1
@@ -1,0 +1,69 @@
+param([string]$ReportRoot)
+
+function Try-GetItemProperty($path) {
+  try { Get-ItemProperty -Path $path -ErrorAction Stop } catch { $null }
+}
+
+if (-not $ReportRoot) {
+  throw "ReportRoot parameter is required."
+}
+
+# Ensure collectors directory exists
+$collectorDir = Join-Path $ReportRoot 'collectors'
+if (-not (Test-Path $collectorDir)) {
+  New-Item -Path $collectorDir -ItemType Directory -Force | Out-Null
+}
+
+# 1) LAPS footprints
+$winLapsPol   = Try-GetItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\LAPS'
+$winLapsState = Try-GetItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\LAPS\State'
+$admPwdPolicy = Try-GetItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft Services\AdmPwd'
+
+# 2) Local admins + metadata
+$localAdmins = @(Get-LocalGroupMember -Group 'Administrators' -ErrorAction SilentlyContinue)
+$localUsers  = @(Get-LocalUser -ErrorAction SilentlyContinue)
+
+$users = @()
+foreach ($m in $localAdmins) {
+  if ($m.ObjectClass -ne 'User' -or $m.PrincipalSource -notin @('Local','MicrosoftAccount')) { continue }
+  $u = $localUsers | Where-Object Name -eq $m.Name
+  if (-not $u) { continue }
+
+  $sid = $u.SID.Value
+  $users += [pscustomobject]@{
+    Name                 = $u.Name
+    Sid                  = $sid
+    Enabled              = [bool]$u.Enabled
+    PasswordNeverExpires = [bool]$u.PasswordNeverExpires
+    LastPasswordSet      = if ($u.LastPasswordSet) { $u.LastPasswordSet.ToUniversalTime().ToString('o') } else { $null }
+    IsBuiltInAdmin       = ($sid -match '-500$')   # RID 500
+  }
+}
+
+# 3) Emit JSON
+$checks = @(
+  [pscustomobject]@{
+    Id='LAPS.Policy'; Status='OK'; Data=@{
+      WindowsLapsPolicy   = $winLapsPol
+      WindowsLapsState    = $winLapsState
+      LegacyAdmPwdPolicy  = $admPwdPolicy
+    }
+    Notes = if ($winLapsPol -or $winLapsState -or $admPwdPolicy) { 'LAPS footprints present' } else { 'No LAPS footprints' }
+  },
+  [pscustomobject]@{
+    Id='LocalAdmins.List'; Status='OK'; Data=@{ Users = $users }
+    Notes = "Count=$($users.Count)"
+  }
+)
+
+$doc = [pscustomobject]@{
+  SchemaVersion = 1
+  Host          = $env:COMPUTERNAME
+  CollectedAt   = (Get-Date).ToUniversalTime().ToString('o')
+  CheckGroup    = 'LAPSLocalAdmin'
+  Checks        = $checks
+}
+
+$path = Join-Path $collectorDir 'laps_localadmin.json'
+$doc  | ConvertTo-Json -Depth 8 | Set-Content -Path $path -Encoding UTF8
+Write-Output "Wrote $path"


### PR DESCRIPTION
## Summary
- add a dedicated collector that exports Windows and legacy LAPS footprints plus local administrator account metadata to `collectors/laps_localadmin.json`
- invoke the new collector from the diagnostics gathering workflow so JSON evidence is always produced alongside existing text captures
- update the analyzer to consume the structured JSON, compute standing admin and persistence indicators, and grade LAPS risk according to the new severity rules with a 30-day staleness window

## Testing
- not run (PowerShell tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d54225be64832dbafa74db843b4d0f