### PR TITLE
Add modular collector scripts

### DIFF
--- a/Collectors/Collect-All.ps1
+++ b/Collectors/Collect-All.ps1
@@ -1,0 +1,77 @@
+<#!
+.SYNOPSIS
+    Runs all collector scripts and writes JSON output per area.
+.DESCRIPTION
+    Discovers collector scripts under the Collectors directory (excluding Collect-All.ps1 and shared helpers),
+    executes each script, and groups the JSON artifacts by area (Security/System/Network/Office/etc.).
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputRoot = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath 'output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath 'CollectorCommon.ps1')
+
+function Get-CollectorScripts {
+    param([string]$Root)
+    Get-ChildItem -Path $Root -Filter 'Collect-*.ps1' -Recurse |
+        Where-Object { $_.FullName -ne $PSCommandPath -and $_.Name -notin @('Collect-All.ps1') } |
+        Sort-Object DirectoryName, Name
+}
+
+function Invoke-CollectorScript {
+    param(
+        [Parameter(Mandatory)]
+        [System.IO.FileInfo]$Script,
+
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory
+    )
+
+    Write-Verbose "Running collector: $($Script.FullName)"
+    try {
+        $result = & $Script.FullName -OutputDirectory $OutputDirectory -ErrorAction Stop
+        return [PSCustomObject]@{
+            Script      = $Script.FullName
+            Output      = $result
+            Success     = $true
+            Error       = $null
+        }
+    } catch {
+        Write-Warning "Collector failed: $($Script.FullName) - $($_.Exception.Message)"
+        return [PSCustomObject]@{
+            Script  = $Script.FullName
+            Output  = $null
+            Success = $false
+            Error   = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-AllCollectors {
+    $resolvedOutputRoot = Resolve-CollectorOutputDirectory -RequestedPath $OutputRoot
+    $collectors = Get-CollectorScripts -Root $PSScriptRoot
+
+    $results = @()
+    foreach ($collector in $collectors) {
+        $areaName = Split-Path -Path $collector.DirectoryName -Leaf
+        if ($areaName -eq 'Collectors') {
+            $areaName = 'Misc'
+        }
+        $areaOutput = Join-Path -Path $resolvedOutputRoot -ChildPath $areaName
+        $null = Resolve-CollectorOutputDirectory -RequestedPath $areaOutput
+        $results += Invoke-CollectorScript -Script $collector -OutputDirectory $areaOutput
+    }
+
+    $summary = [ordered]@{
+        CollectedAt = (Get-Date).ToString('o')
+        OutputRoot  = $resolvedOutputRoot
+        Results     = $results
+    }
+
+    $summaryPath = Export-CollectorResult -OutputDirectory $resolvedOutputRoot -FileName 'collection-summary.json' -Data $summary -Depth 6
+    Write-Output $summaryPath
+}
+
+Invoke-AllCollectors

--- a/Collectors/CollectorCommon.ps1
+++ b/Collectors/CollectorCommon.ps1
@@ -1,0 +1,49 @@
+<#!
+.SYNOPSIS
+    Provides shared helper functions for collector scripts.
+#>
+
+function Resolve-CollectorOutputDirectory {
+    param(
+        [Parameter(Mandatory)]
+        [string]$RequestedPath
+    )
+
+    if (-not (Test-Path -Path $RequestedPath)) {
+        $null = New-Item -Path $RequestedPath -ItemType Directory -Force
+    }
+
+    return (Resolve-Path -Path $RequestedPath).ProviderPath
+}
+
+function Export-CollectorResult {
+    param(
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory,
+
+        [Parameter(Mandatory)]
+        [string]$FileName,
+
+        [Parameter(Mandatory)]
+        [object]$Data,
+
+        [int]$Depth = 6
+    )
+
+    $resolved = Resolve-CollectorOutputDirectory -RequestedPath $OutputDirectory
+    $path = Join-Path -Path $resolved -ChildPath $FileName
+    $Data | ConvertTo-Json -Depth $Depth | Out-File -FilePath $path -Encoding UTF8
+    return $path
+}
+
+function New-CollectorMetadata {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Payload
+    )
+
+    return [ordered]@{
+        CollectedAt = (Get-Date).ToString('o')
+        Payload     = $Payload
+    }
+}

--- a/Collectors/Network/Collect-DNS.ps1
+++ b/Collectors/Network/Collect-DNS.ps1
@@ -1,0 +1,103 @@
+<#!
+.SYNOPSIS
+    Collects DNS diagnostic data including resolution tests and connectivity checks.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Test-DnsResolution {
+    param(
+        [string[]]$Names = @('www.microsoft.com','outlook.office365.com','autodiscover.outlook.com')
+    )
+
+    $results = @()
+    foreach ($name in $Names) {
+        try {
+            $records = Resolve-DnsName -Name $name -ErrorAction Stop
+            $results += [PSCustomObject]@{
+                Name    = $name
+                Success = $true
+                Records = $records | Select-Object Name, Type, IPAddress
+            }
+        } catch {
+            $results += [PSCustomObject]@{
+                Name    = $name
+                Success = $false
+                Error   = $_.Exception.Message
+            }
+        }
+    }
+    return $results
+}
+
+function Trace-NetworkPath {
+    param([string]$Target = 'outlook.office365.com')
+    try {
+        return tracert.exe $Target 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Target = $Target
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Test-Latency {
+    param([string]$Target = '8.8.8.8')
+    try {
+        return Test-NetConnection -ComputerName $Target -WarningAction SilentlyContinue
+    } catch {
+        try {
+            return ping.exe $Target 2>$null
+        } catch {
+            return [PSCustomObject]@{
+                Target = $Target
+                Error  = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Resolve-AutodiscoverRecords {
+    param(
+        [string[]]$Domains = @('autodiscover', 'enterpriseenrollment', 'enterpriseregistration')
+    )
+
+    $results = @()
+    foreach ($domain in $Domains) {
+        try {
+            $records = Resolve-DnsName -Type CNAME -Name "$domain.outlook.com" -ErrorAction Stop
+            $results += [PSCustomObject]@{
+                Query   = "$domain.outlook.com"
+                Records = $records | Select-Object Name, Type, NameHost
+            }
+        } catch {
+            $results += [PSCustomObject]@{
+                Query = "$domain.outlook.com"
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $results
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Resolution = Test-DnsResolution
+        Traceroute = Trace-NetworkPath
+        Latency    = Test-Latency
+        Autodiscover = Resolve-AutodiscoverRecords
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'dns.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-Network.ps1
+++ b/Collectors/Network/Collect-Network.ps1
@@ -1,0 +1,70 @@
+<#!
+.SYNOPSIS
+    Collects core network diagnostics including IP configuration, routing table, netstat, and ARP cache.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-IpConfiguration {
+    try {
+        return ipconfig.exe /all 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'ipconfig.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-RoutingTable {
+    try {
+        return route.exe print 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'route.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-NetstatSnapshot {
+    try {
+        return netstat.exe -ano 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'netstat.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-ArpCache {
+    try {
+        return arp.exe -a 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'arp.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        IpConfig = Get-IpConfiguration
+        Route    = Get-RoutingTable
+        Netstat  = Get-NetstatSnapshot
+        Arp      = Get-ArpCache
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'network.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-NetworkAdapters.ps1
+++ b/Collectors/Network/Collect-NetworkAdapters.ps1
@@ -1,0 +1,58 @@
+<#!
+.SYNOPSIS
+    Collects network adapter configuration, IP assignments, and operational state.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-AdapterConfigurations {
+    try {
+        return Get-NetAdapter -ErrorAction Stop | Select-Object Name, InterfaceDescription, Status, LinkSpeed, MacAddress, DriverInformation
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-NetAdapter'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-NetIPAssignments {
+    try {
+        return Get-NetIPConfiguration -ErrorAction Stop | Select-Object InterfaceAlias, InterfaceDescription, IPv4Address, IPv6Address, DNSServer, IPv4DefaultGateway
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-NetIPConfiguration'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-NetworkAdapterState {
+    try {
+        return Get-NetAdapterAdvancedProperty -ErrorAction Stop | Select-Object Name, DisplayName, DisplayValue
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-NetAdapterAdvancedProperty'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Adapters   = Get-AdapterConfigurations
+        IPConfig   = Get-NetIPAssignments
+        Properties = Get-NetworkAdapterState
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'network-adapters.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-NetworkShares.ps1
+++ b/Collectors/Network/Collect-NetworkShares.ps1
@@ -1,0 +1,34 @@
+<#!
+.SYNOPSIS
+    Collects network share configuration using net share.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-NetShares {
+    try {
+        return net.exe share 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'net share'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Shares = Get-NetShares
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'network-shares.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-OutlookConnectivity.ps1
+++ b/Collectors/Network/Collect-OutlookConnectivity.ps1
@@ -1,0 +1,67 @@
+<#!
+.SYNOPSIS
+    Collects Outlook connectivity diagnostics including HTTPS tests, OST inventory, and Autodiscover SCP entries.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Test-Outlook443 {
+    param([string]$Target = 'outlook.office365.com')
+    try {
+        return Test-NetConnection -ComputerName $Target -Port 443 -WarningAction SilentlyContinue
+    } catch {
+        return [PSCustomObject]@{
+            Target = $Target
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-OstInventory {
+    try {
+        $profilesPath = Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Microsoft\Outlook'
+        if (Test-Path -Path $profilesPath) {
+            return Get-ChildItem -Path $profilesPath -Filter '*.ost' -Recurse -ErrorAction Stop | Select-Object Name, FullName, Length, LastWriteTime
+        }
+        return @()
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'OSTInventory'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-AutodiscoverScp {
+    try {
+        $regPath = 'HKLM:\SOFTWARE\Microsoft\Office\16.0\Outlook\AutoDiscover'
+        if (Test-Path -Path $regPath) {
+            return Get-ItemProperty -Path $regPath | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+        }
+        return $null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'AutodiscoverSCP'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Connectivity = Test-Outlook443
+        OstFiles     = Get-OstInventory
+        Autodiscover = Get-AutodiscoverScp
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'outlook-connectivity.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-Proxy.ps1
+++ b/Collectors/Network/Collect-Proxy.ps1
@@ -1,0 +1,50 @@
+<#!
+.SYNOPSIS
+    Collects proxy configuration for WinHTTP and Windows settings.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-WinHttpProxy {
+    try {
+        return netsh.exe winhttp show proxy 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'netsh winhttp'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-InternetSettings {
+    try {
+        $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings'
+        if (Test-Path -Path $path) {
+            return Get-ItemProperty -Path $path | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+        }
+        return $null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'InternetSettings'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        WinHttp  = Get-WinHttpProxy
+        Internet = Get-InternetSettings
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'proxy.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Office/Collect-OfficePolicies.ps1
+++ b/Collectors/Office/Collect-OfficePolicies.ps1
@@ -1,0 +1,52 @@
+<#!
+.SYNOPSIS
+    Collects Microsoft Office security policy configuration from registry locations.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-OfficeSecurityPolicies {
+    $paths = @(
+        'HKCU:\SOFTWARE\Policies\Microsoft\Office\16.0\Common\Security',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Office\16.0\Common\Security',
+        'HKCU:\SOFTWARE\Microsoft\Office\16.0\Word\Security',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Office\16.0\Word\Security'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            if (Test-Path -Path $path) {
+                $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+                $result += [PSCustomObject]@{
+                    Path   = $path
+                    Values = $values
+                }
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policies = Get-OfficeSecurityPolicies
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'office-policies.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Office/Collect-OutlookCaches.ps1
+++ b/Collectors/Office/Collect-OutlookCaches.ps1
@@ -1,0 +1,45 @@
+<#!
+.SYNOPSIS
+    Collects Outlook cache file inventory (OST/PST).
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-OstFiles {
+    try {
+        $rootPaths = @(
+            (Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Microsoft\Outlook'),
+            (Join-Path -Path $env:USERPROFILE -ChildPath 'Documents\Outlook Files')
+        ) | Where-Object { $_ }
+
+        $results = @()
+        foreach ($path in $rootPaths) {
+            if (Test-Path -Path $path) {
+                $results += Get-ChildItem -Path $path -Include '*.ost','*.pst' -Recurse -ErrorAction Stop | Select-Object Name, FullName, Length, LastWriteTime
+            }
+        }
+        return $results
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'OutlookCacheScan'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Caches = Get-OstFiles
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'outlook-caches.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-ASR.ps1
+++ b/Collectors/Security/Collect-ASR.ps1
@@ -1,0 +1,57 @@
+<#!
+.SYNOPSIS
+    Collects Microsoft Defender Attack Surface Reduction configuration and exclusions.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Convert-AsrRules {
+    param(
+        [Parameter()]$Rules
+    )
+
+    $result = @()
+    if ($Rules) {
+        foreach ($entry in $Rules.GetEnumerator()) {
+            $result += [PSCustomObject]@{
+                RuleId = $entry.Key
+                Action = $entry.Value
+            }
+        }
+    }
+
+    return $result
+}
+
+function Get-AsrPolicy {
+    try {
+        $prefs = Get-MpPreference -ErrorAction Stop
+        return [PSCustomObject]@{
+            Rules          = Convert-AsrRules -Rules $prefs.AttackSurfaceReductionRules_Actions
+            OnlyExclusions = $prefs.AttackSurfaceReductionOnlyExclusions
+            ProcessExclusions = $prefs.AttackSurfaceReductionRules_Ids
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-MpPreference'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policy = Get-AsrPolicy
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'asr.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-BitLocker.ps1
+++ b/Collectors/Security/Collect-BitLocker.ps1
@@ -1,0 +1,36 @@
+<#!
+.SYNOPSIS
+    Collects BitLocker drive protection status for all volumes.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-BitLockerVolumes {
+    try {
+        $volumes = Get-BitLockerVolume -ErrorAction Stop
+        return $volumes | Select-Object MountPoint, VolumeType, CapacityGB, EncryptionMethod, ProtectionStatus, LockStatus, AutoUnlockEnabled, KeyProtector
+    } catch {
+        Write-Verbose "Get-BitLockerVolume failed: $($_.Exception.Message)"
+        return [PSCustomObject]@{
+            Source = 'Get-BitLockerVolume'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Volumes = Get-BitLockerVolumes
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'bitlocker.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-Defender.ps1
+++ b/Collectors/Security/Collect-Defender.ps1
@@ -1,0 +1,64 @@
+<#!
+.SYNOPSIS
+    Collects Microsoft Defender Antivirus health and configuration data.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DefenderStatus {
+    try {
+        $status = Get-MpComputerStatus -ErrorAction Stop
+        return $status | Select-Object AMServiceEnabled, AntispywareEnabled, AntivirusEnabled, IoavProtectionEnabled, RealTimeProtectionEnabled, TamperProtectionEnabled, IsTamperProtected, NISEnabled, QuickScanEndTime, FullScanEndTime, ProductStatus, AntivirusSignatureVersion, AntispywareSignatureVersion
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-MpComputerStatus'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-DefenderThreatStatistics {
+    try {
+        return Get-MpThreat -ErrorAction Stop | Select-Object ThreatID, ThreatName, SeverityID, CategoryID, Resources, ActionSuccess, LastThreatStatusChangeTime
+    } catch {
+        if ($_.Exception -and $_.Exception.Message -like '*No threats found*') {
+            return @()
+        }
+
+        return [PSCustomObject]@{
+            Source = 'Get-MpThreat'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-DefenderPreferences {
+    try {
+        $prefs = Get-MpPreference -ErrorAction Stop
+        return $prefs | Select-Object DisableRealtimeMonitoring, DisableIOAVProtection, DisablePrivacyMode, DisableIntrusionPreventionSystem, DisableScriptScanning, ScanScheduleDay, ScanScheduleTime, SignatureScheduleDay, SignatureScheduleTime, MAPSReporting, SubmitSamplesConsent, EnableNetworkProtection, UILockdownMode
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-MpPreference'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Status       = Get-DefenderStatus
+        Threats      = Get-DefenderThreatStatistics
+        Preferences  = Get-DefenderPreferences
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'defender.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-ExploitProtection.ps1
+++ b/Collectors/Security/Collect-ExploitProtection.ps1
@@ -1,0 +1,34 @@
+<#!
+.SYNOPSIS
+    Collects system-wide exploit protection (process mitigation) configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-ExploitMitigations {
+    try {
+        return Get-ProcessMitigation -System -ErrorAction Stop
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-ProcessMitigation'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Mitigations = Get-ExploitMitigations
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'exploit-protection.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-Firewall.ps1
+++ b/Collectors/Security/Collect-Firewall.ps1
@@ -1,0 +1,59 @@
+<#!
+.SYNOPSIS
+    Collects Windows Firewall configuration and rules into a structured JSON artifact.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-FirewallProfiles {
+    try {
+        return Get-NetFirewallProfile -ErrorAction Stop | Select-Object Name, Enabled, DefaultInboundAction, DefaultOutboundAction, NotifyOnListen, AllowInboundRules, AllowLocalFirewallRules, AllowLocalIPsecRules
+    } catch {
+        Write-Verbose "Get-NetFirewallProfile failed: $($_.Exception.Message)"
+        try {
+            $raw = & netsh advfirewall show allprofiles 2>$null
+            return [PSCustomObject]@{
+                Source    = 'netsh'
+                RawOutput = $raw -join [Environment]::NewLine
+                Error     = $null
+            }
+        } catch {
+            return [PSCustomObject]@{
+                Source    = 'netsh'
+                RawOutput = $null
+                Error     = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Get-FirewallRules {
+    try {
+        return Get-NetFirewallRule -All -ErrorAction Stop |
+            Select-Object DisplayName, Direction, Action, Enabled, Profile, @{Name='PolicyStore';Expression={$_.PolicyStoreSourceType}}, Program, Service, Group, Description
+    } catch {
+        Write-Verbose "Get-NetFirewallRule failed: $($_.Exception.Message)"
+        return [PSCustomObject]@{
+            Source = 'Get-NetFirewallRule'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Profiles = Get-FirewallProfiles
+        Rules    = Get-FirewallRules
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'firewall.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-FirmwareSecurity.ps1
+++ b/Collectors/Security/Collect-FirmwareSecurity.ps1
@@ -1,0 +1,58 @@
+<#!
+.SYNOPSIS
+    Collects firmware and chassis security metadata.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-ComputerSystemSecurity {
+    try {
+        return Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop | Select-Object Manufacturer, Model, Domain, PartOfDomain, NumberOfProcessors, TotalPhysicalMemory
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_ComputerSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-BiosInformation {
+    try {
+        return Get-CimInstance -ClassName Win32_BIOS -ErrorAction Stop | Select-Object Manufacturer, Name, Version, SMBIOSBIOSVersion, SerialNumber, ReleaseDate
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_BIOS'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-SystemEnclosure {
+    try {
+        return Get-CimInstance -ClassName Win32_SystemEnclosure -ErrorAction Stop | Select-Object ChassisTypes, SecurityStatus, SerialNumber, SMBIOSAssetTag, LockPresent
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_SystemEnclosure'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        ComputerSystem = Get-ComputerSystemSecurity
+        Bios           = Get-BiosInformation
+        Enclosure      = Get-SystemEnclosure
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'firmware.json' -Data $result -Depth 5
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-KernelDMA.ps1
+++ b/Collectors/Security/Collect-KernelDMA.ps1
@@ -1,0 +1,65 @@
+<#!
+.SYNOPSIS
+    Collects Kernel DMA protection configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-KernelDMAConfiguration {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\KernelDMAProtection',
+        'HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Get-MsInfoKernelDmaSection {
+    try {
+        $tempPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString() + '.txt')
+        $process = Start-Process -FilePath 'msinfo32.exe' -ArgumentList '/report', $tempPath, '/categories', 'Hardware Resources\DMA' -PassThru -WindowStyle Hidden
+        $process.WaitForExit()
+        $content = Get-Content -Path $tempPath -ErrorAction SilentlyContinue
+        Remove-Item -Path $tempPath -ErrorAction SilentlyContinue
+        return $content
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'msinfo32.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-KernelDMAConfiguration
+        MsInfo   = Get-MsInfoKernelDmaSection
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'kerneldma.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-LDAP.ps1
+++ b/Collectors/Security/Collect-LDAP.ps1
@@ -1,0 +1,48 @@
+<#!
+.SYNOPSIS
+    Collects LDAP signing and channel binding configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-LdapSigningSettings {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Services\LDAP',
+        'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-LdapSigningSettings
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'ldap.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-LSA.ps1
+++ b/Collectors/Security/Collect-LSA.ps1
@@ -1,0 +1,48 @@
+<#!
+.SYNOPSIS
+    Collects LSA hardening and NTLM authentication configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-LsaRegistryValues {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa',
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-LsaRegistryValues
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'lsa.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-LocalAdmins.ps1
+++ b/Collectors/Security/Collect-LocalAdmins.ps1
@@ -1,0 +1,43 @@
+<#!
+.SYNOPSIS
+    Collects local Administrators group membership.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-LocalAdmins {
+    try {
+        return Get-LocalGroupMember -Group 'Administrators' -ErrorAction Stop | Select-Object Name, ObjectClass, PrincipalSource
+    } catch {
+        Write-Verbose "Get-LocalGroupMember failed: $($_.Exception.Message)"
+        try {
+            $output = & net localgroup Administrators 2>$null
+            return [PSCustomObject]@{
+                Source    = 'net localgroup'
+                RawOutput = $output -join [Environment]::NewLine
+            }
+        } catch {
+            return [PSCustomObject]@{
+                Source = 'Get-LocalGroupMember'
+                Error  = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Members = Get-LocalAdmins
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'local-admins.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-PowerShellLogging.ps1
+++ b/Collectors/Security/Collect-PowerShellLogging.ps1
@@ -1,0 +1,50 @@
+<#!
+.SYNOPSIS
+    Collects PowerShell logging policy configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-PowerShellPolicy {
+    $paths = @(
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ModuleLogging',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policies = Get-PowerShellPolicy
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'powershell-logging.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-RDP.ps1
+++ b/Collectors/Security/Collect-RDP.ps1
@@ -1,0 +1,49 @@
+<#!
+.SYNOPSIS
+    Collects Remote Desktop Protocol configuration from the registry.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-RdpConfiguration {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server',
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-RdpConfiguration
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'rdp.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-SMB.ps1
+++ b/Collectors/Security/Collect-SMB.ps1
@@ -1,0 +1,34 @@
+<#!
+.SYNOPSIS
+    Collects SMB server configuration for security review.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-SmbServerConfig {
+    try {
+        return Get-SmbServerConfiguration -ErrorAction Stop | Select-Object EnableSMB1Protocol, EnableSMB2Protocol, EncryptData, RejectUnencryptedAccess, EnableLeasing, EnableStrictNameChecking, EnableAuthenticateUserSharing, EnableSecuritySignature
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-SmbServerConfiguration'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Configuration = Get-SmbServerConfig
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'smb.json' -Data $result -Depth 4
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-SmartScreen.ps1
+++ b/Collectors/Security/Collect-SmartScreen.ps1
@@ -1,0 +1,50 @@
+<#!
+.SYNOPSIS
+    Collects SmartScreen and app control policy configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-SmartScreenPolicies {
+    $paths = @(
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System',
+        'HKCU:\SOFTWARE\Policies\Microsoft\Windows\System',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Edge',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppHost'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policies = Get-SmartScreenPolicies
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'smartscreen.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-TPM.ps1
+++ b/Collectors/Security/Collect-TPM.ps1
@@ -1,0 +1,35 @@
+<#!
+.SYNOPSIS
+    Collects Trusted Platform Module (TPM) status information.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-TpmStatus {
+    try {
+        $tpm = Get-Tpm -ErrorAction Stop
+        return $tpm | Select-Object TpmPresent, TpmReady, TpmEnabled, TpmActivated, ManagedAuthLevel, ManufacturerId, ManufacturerVersion, LockoutHealTime, LockoutCount, LockedOut
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Tpm'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Tpm = Get-TpmStatus
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'tpm.json' -Data $result -Depth 4
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-UAC.ps1
+++ b/Collectors/Security/Collect-UAC.ps1
@@ -1,0 +1,35 @@
+<#!
+.SYNOPSIS
+    Collects User Account Control (UAC) policy configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-UacPolicy {
+    try {
+        $values = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+        return $values
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Policies\\System'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policy = Get-UacPolicy
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'uac.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-VBSHVCI.ps1
+++ b/Collectors/Security/Collect-VBSHVCI.ps1
@@ -1,0 +1,61 @@
+<#!
+.SYNOPSIS
+    Collects virtualization-based security and HVCI configuration details.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DeviceGuardState {
+    try {
+        $dg = Get-CimInstance -Namespace 'root/Microsoft/Windows/DeviceGuard' -ClassName Win32_DeviceGuard -ErrorAction Stop
+        return $dg | Select-Object SecurityServicesRunning, SecurityServicesConfigured, RequiredSecurityProperties, AvailableSecurityProperties
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_DeviceGuard'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-WDACRegistry {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\CI',
+        'HKLM:\SOFTWARE\Microsoft\Windows Defender\SmartScreen'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        DeviceGuard = Get-DeviceGuardState
+        Registry    = Get-WDACRegistry
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'vbshvci.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-WDAC.ps1
+++ b/Collectors/Security/Collect-WDAC.ps1
@@ -1,0 +1,61 @@
+<#!
+.SYNOPSIS
+    Collects Windows Defender Application Control (WDAC) configuration data.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DeviceGuardPolicy {
+    try {
+        $dg = Get-CimInstance -Namespace 'root/Microsoft/Windows/DeviceGuard' -ClassName Win32_DeviceGuard -ErrorAction Stop
+        return $dg | Select-Object SecurityServicesRunning, SecurityServicesConfigured, RequiredSecurityProperties, AvailableSecurityProperties, Version
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_DeviceGuard'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-WdacRegistrySnapshot {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy',
+        'HKLM:\SYSTEM\CurrentControlSet\Control\CI'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        DeviceGuard = Get-DeviceGuardPolicy
+        Registry    = Get-WdacRegistrySnapshot
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'wdac.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Drivers.ps1
+++ b/Collectors/System/Collect-Drivers.ps1
@@ -1,0 +1,38 @@
+<#!
+.SYNOPSIS
+    Collects installed driver inventory with signing details.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DriverInventory {
+    try {
+        $temp = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString() + '.txt')
+        driverquery.exe /v /fo list > $temp
+        $content = Get-Content -Path $temp -ErrorAction Stop
+        Remove-Item -Path $temp -ErrorAction SilentlyContinue
+        return $content
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'driverquery.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        DriverQuery = Get-DriverInventory
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'drivers.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -1,0 +1,40 @@
+<#!
+.SYNOPSIS
+    Collects recent Application and System event log entries.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-RecentEvents {
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogName
+    )
+
+    try {
+        return Get-WinEvent -LogName $LogName -MaxEvents 100 -ErrorAction Stop | Select-Object TimeCreated, Id, LevelDisplayName, ProviderName, Message
+    } catch {
+        return [PSCustomObject]@{
+            LogName = $LogName
+            Error   = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        System      = Get-RecentEvents -LogName 'System'
+        Application = Get-RecentEvents -LogName 'Application'
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'events.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Hotfixes.ps1
+++ b/Collectors/System/Collect-Hotfixes.ps1
@@ -1,0 +1,34 @@
+<#!
+.SYNOPSIS
+    Collects installed hotfix metadata for recent updates.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-RecentHotfixes {
+    try {
+        return Get-HotFix -ErrorAction Stop | Sort-Object -Property InstalledOn -Descending | Select-Object -First 50 HotFixID, Description, InstalledOn, InstalledBy
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-HotFix'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Hotfixes = Get-RecentHotfixes
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'hotfixes.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Identity.ps1
+++ b/Collectors/System/Collect-Identity.ps1
@@ -1,0 +1,46 @@
+<#!
+.SYNOPSIS
+    Collects device identity posture including Azure AD registration and current user context.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-AzureAdJoinStatus {
+    try {
+        return dsregcmd.exe /status 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'dsregcmd.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-WhoAmIContext {
+    try {
+        return whoami.exe /all 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'whoami.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        DsRegCmd = Get-AzureAdJoinStatus
+        WhoAmI   = Get-WhoAmIContext
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'identity.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Performance.ps1
+++ b/Collectors/System/Collect-Performance.ps1
@@ -1,0 +1,52 @@
+<#!
+.SYNOPSIS
+    Collects lightweight performance snapshot including top CPU consumers and memory usage.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-TopCpuProcesses {
+    try {
+        return Get-Process | Sort-Object -Property CPU -Descending | Select-Object -First 10 Name, Id, CPU, @{Name='WorkingSetMB';Expression={[math]::Round($_.WorkingSet64 / 1MB,2)}}
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Process'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-MemorySummary {
+    try {
+        $os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
+        return [PSCustomObject]@{
+            TotalVisibleMemory = $os.TotalVisibleMemorySize
+            FreePhysicalMemory  = $os.FreePhysicalMemory
+            TotalVirtualMemory  = $os.TotalVirtualMemorySize
+            FreeVirtualMemory   = $os.FreeVirtualMemory
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_OperatingSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        TopCpuProcesses = Get-TopCpuProcesses
+        Memory          = Get-MemorySummary
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'performance.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Power.ps1
+++ b/Collectors/System/Collect-Power.ps1
@@ -1,0 +1,47 @@
+<#!
+.SYNOPSIS
+    Collects power configuration including sleep state availability and fast startup settings.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-PowerStates {
+    try {
+        return powercfg.exe /a 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'powercfg /a'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-FastStartupConfig {
+    try {
+        $values = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power' -ErrorAction Stop | Select-Object HiberbootEnabled, HibernateEnabled, HiberFileType
+        return $values
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Power Registry'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        SleepStates    = Get-PowerStates
+        FastStartup    = Get-FastStartupConfig
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'power.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Processes.ps1
+++ b/Collectors/System/Collect-Processes.ps1
@@ -1,0 +1,46 @@
+<#!
+.SYNOPSIS
+    Collects running process snapshot with resource usage.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-ProcessSnapshot {
+    try {
+        return Get-Process | Select-Object Name, Id, CPU, WorkingSet, StartTime, Path
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Process'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-TaskListVerbose {
+    try {
+        return tasklist.exe /v 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'tasklist /v'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Processes = Get-ProcessSnapshot
+        Tasklist  = Get-TaskListVerbose
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'processes.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-ScheduledTasks.ps1
+++ b/Collectors/System/Collect-ScheduledTasks.ps1
@@ -1,0 +1,38 @@
+<#!
+.SYNOPSIS
+    Collects scheduled task inventory and run status.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-TaskInventory {
+    try {
+        $temp = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString() + '.txt')
+        schtasks.exe /query /fo LIST /v > $temp
+        $content = Get-Content -Path $temp -ErrorAction Stop
+        Remove-Item -Path $temp -ErrorAction SilentlyContinue
+        return $content
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'schtasks.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Tasks = Get-TaskInventory
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'scheduled-tasks.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Services.ps1
+++ b/Collectors/System/Collect-Services.ps1
@@ -1,0 +1,38 @@
+<#!
+.SYNOPSIS
+    Collects Windows service configuration and current state.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-ServiceMatrix {
+    try {
+        return Get-CimInstance -ClassName Win32_Service -ErrorAction Stop | Select-Object Name, DisplayName, StartMode, State, Status, StartName, ServiceType
+    } catch {
+        try {
+            return Get-Service | Select-Object Name, DisplayName, Status, StartType
+        } catch {
+            return [PSCustomObject]@{
+                Source = 'ServiceQuery'
+                Error  = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Services = Get-ServiceMatrix
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'services.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Software.ps1
+++ b/Collectors/System/Collect-Software.ps1
@@ -1,0 +1,42 @@
+<#!
+.SYNOPSIS
+    Collects installed software inventory from 32-bit and 64-bit registry locations.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-UninstallEntries {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    try {
+        return Get-ItemProperty -Path $Path -ErrorAction Stop | ForEach-Object {
+            $_ | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate, EstimatedSize, UninstallString
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Source = $Path
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Programs64 = Get-UninstallEntries -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+        Programs32 = Get-UninstallEntries -Path 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'software.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Storage.ps1
+++ b/Collectors/System/Collect-Storage.ps1
@@ -1,0 +1,58 @@
+<#!
+.SYNOPSIS
+    Collects disk, volume, and physical storage inventory.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DiskInventory {
+    try {
+        return Get-Disk -ErrorAction Stop | Select-Object Number, FriendlyName, SerialNumber, HealthStatus, OperationalStatus, Size, PartitionStyle
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Disk'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-VolumeLayout {
+    try {
+        return Get-Volume -ErrorAction Stop | Select-Object DriveLetter, FileSystem, FileSystemLabel, HealthStatus, SizeRemaining, Size
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Volume'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-PhysicalDisks {
+    try {
+        return Get-PhysicalDisk -ErrorAction Stop | Select-Object DeviceId, FriendlyName, SerialNumber, MediaType, CanPool, Size, HealthStatus, OperationalStatus
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-PhysicalDisk'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Disks        = Get-DiskInventory
+        Volumes      = Get-VolumeLayout
+        PhysicalDisks = Get-PhysicalDisks
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'storage.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-System.ps1
+++ b/Collectors/System/Collect-System.ps1
@@ -1,0 +1,59 @@
+<#!
+.SYNOPSIS
+    Collects core system inventory information including OS details and hardware metadata.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-SystemInfoText {
+    try {
+        $output = systeminfo.exe 2>$null
+        return $output
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'systeminfo.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-OperatingSystemInventory {
+    try {
+        return Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop | Select-Object Caption, Version, BuildNumber, OSArchitecture, InstallDate, LastBootUpTime, RegisteredUser, SerialNumber
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_OperatingSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-ComputerSystemInventory {
+    try {
+        return Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop | Select-Object Manufacturer, Model, Domain, PartOfDomain, TotalPhysicalMemory, NumberOfLogicalProcessors, NumberOfProcessors
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_ComputerSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        SystemInfoText = Get-SystemInfoText
+        OperatingSystem = Get-OperatingSystemInventory
+        ComputerSystem  = Get-ComputerSystemInventory
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'system.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Uptime.ps1
+++ b/Collectors/System/Collect-Uptime.ps1
@@ -1,0 +1,40 @@
+<#!
+.SYNOPSIS
+    Collects device uptime details.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-Uptime {
+    try {
+        $os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
+        $lastBoot = $os.LastBootUpTime
+        $uptime = (Get-Date) - $lastBoot
+        return [PSCustomObject]@{
+            LastBootUpTime = $lastBoot
+            Uptime         = $uptime.ToString()
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_OperatingSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Uptime = Get-Uptime
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'uptime.json' -Data $result -Depth 4
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add shared collector helper and a Collect-All orchestrator to drive all endpoint data gathering scripts
- implement modular security collectors that gather firewall, Defender, BitLocker, TPM, WDAC, and related hardening data
- add system, network, and Office collectors for inventory, diagnostics, and policy export into JSON artifacts

## Testing
- not run (PowerShell collectors)

------
https://chatgpt.com/codex/tasks/task_e_68d542efb290832d87df6fb77e5c9c85