### PR TITLE
Add time sync and spooler health checks

### DIFF
--- a/AutoL1/Collect-SystemDiagnostics.ps1
+++ b/AutoL1/Collect-SystemDiagnostics.ps1
@@ -240,6 +240,18 @@ $capturePlan = @(
   @{ Name = "NetIPAddresses"; Description = "Current IP assignments (Get-NetIPAddress)"; Action = { try { Get-NetIPAddress -ErrorAction Stop | Format-List * } catch { "Get-NetIPAddress missing or failed: $_" } } },
   @{ Name = "NetAdapters"; Description = "Network adapter status"; Action = { try { Get-NetAdapter -ErrorAction Stop | Format-List * } catch { Get-CimInstance Win32_NetworkAdapter | Select-Object Name,NetConnectionStatus,MACAddress,Speed | Format-List * } } },
   @{ Name = "WinHttpProxy"; Description = "WinHTTP proxy configuration"; Action = { netsh winhttp show proxy } },
+  @{ Name = "Time_W32tmStatus"; Description = "Time synchronization status"; Action = {
+      $w32tmCmd = Get-Command w32tm -ErrorAction SilentlyContinue
+      if (-not $w32tmCmd) {
+        "w32tm.exe not available."
+      } else {
+        try {
+          w32tm /query /status
+        } catch {
+          Write-Output ("w32tm /query /status failed: {0}" -f $_)
+        }
+      }
+    } },
   @{ Name = "Disk_Drives"; Description = "Physical disk inventory (wmic diskdrive)"; Action = { wmic diskdrive get model,serialNumber,status,size } },
   @{ Name = "Volumes"; Description = "Volume overview (Get-Volume)"; Action = { Get-Volume | Format-Table -AutoSize } },
   @{ Name = "Disks"; Description = "Disk layout (Get-Disk)"; Action = { Get-Disk | Format-List * } },

--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -122,6 +122,35 @@ function ConvertTo-NullableInt {
   return $null
 }
 
+function ConvertTo-NullableDouble {
+  param($Value)
+
+  if ($Value -is [double]) { return [double]$Value }
+  if ($Value -is [single]) { return [double]$Value }
+  if ($null -eq $Value) { return $null }
+
+  $stringValue = [string]$Value
+  if (-not $stringValue) { return $null }
+
+  $trimmed = $stringValue.Trim()
+  if (-not $trimmed) { return $null }
+
+  $parsed = 0.0
+  if ([double]::TryParse($trimmed, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsed)) {
+    return $parsed
+  }
+
+  $normalized = ($trimmed -replace '(?i)[^0-9eE\+\-\.,]', '')
+  if ([string]::IsNullOrWhiteSpace($normalized)) { return $null }
+  $normalized = $normalized -replace ',', '.'
+
+  if ([double]::TryParse($normalized, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsed)) {
+    return $parsed
+  }
+
+  return $null
+}
+
 function ConvertFrom-JsonSafe {
   param([string]$Text)
 


### PR DESCRIPTION
## Summary
- capture w32tm /query /status output during collection so the analyzer can reason about clock skew
- flag workstations where the Print Spooler service is running without need and surface spooler guidance in the services table
- add a reusable helper to parse floating-point strings to support the new time synchronization heuristic

## Testing
- `pwsh -NoProfile -Command "Import-Module ./Modules/Common.psm1; ConvertTo-NullableDouble '1.23s'"` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d548328830832dacef1dc8fc737c91