### PR TITLE
Add modular analyzer orchestration and heuristics

### DIFF
--- a/Analyzers/Analyze-Diagnostics.ps1
+++ b/Analyzers/Analyze-Diagnostics.ps1
@@ -1,0 +1,64 @@
+<#!
+.SYNOPSIS
+    Analyzer orchestrator that loads JSON artifacts, runs heuristic modules, and generates an HTML report.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$InputFolder,
+
+    [Parameter()]
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$commonModulePath = Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'Modules/Common.psm1'
+if (Test-Path -Path $commonModulePath) {
+    Import-Module $commonModulePath -Force
+}
+
+. (Join-Path -Path $PSScriptRoot -ChildPath 'AnalyzerCommon.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/System.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Security.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Network.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/AD.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Office.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Storage.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Events.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Services.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'HtmlComposer.ps1')
+
+$context = New-AnalyzerContext -InputFolder $InputFolder
+
+$categories = @()
+$categories += Invoke-SystemHeuristics   -Context $context
+$categories += Invoke-SecurityHeuristics -Context $context
+$categories += Invoke-NetworkHeuristics  -Context $context
+$categories += Invoke-ADHeuristics       -Context $context
+$categories += Invoke-OfficeHeuristics   -Context $context
+$categories += Invoke-StorageHeuristics  -Context $context
+$categories += Invoke-EventsHeuristics   -Context $context
+$categories += Invoke-ServicesHeuristics -Context $context
+
+$merged = Merge-AnalyzerResults -Categories $categories
+
+$html = New-AnalyzerHtml -Categories $categories
+
+if (-not $OutputPath) {
+    $OutputPath = Join-Path -Path $InputFolder -ChildPath 'diagnostics-report.html'
+}
+
+$directory = Split-Path -Path $OutputPath -Parent
+if (-not (Test-Path -Path $directory)) {
+    $null = New-Item -Path $directory -ItemType Directory -Force
+}
+
+$html | Out-File -FilePath $OutputPath -Encoding UTF8
+
+[pscustomobject]@{
+    HtmlPath = (Resolve-Path -Path $OutputPath).ProviderPath
+    Issues   = $merged.Issues
+    Normals  = $merged.Normals
+    Checks   = $merged.Checks
+}

--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -1,0 +1,199 @@
+<#!
+.SYNOPSIS
+    Shared helper functions for analyzer modules.
+#>
+
+function New-AnalyzerContext {
+    param(
+        [Parameter(Mandatory)]
+        [string]$InputFolder
+    )
+
+    if (-not (Test-Path -LiteralPath $InputFolder)) {
+        throw "Input folder '$InputFolder' not found."
+    }
+
+    $resolved = (Resolve-Path -LiteralPath $InputFolder).ProviderPath
+    $artifactMap = @{}
+
+    Get-ChildItem -Path $resolved -Recurse -Filter '*.json' -File -ErrorAction SilentlyContinue | ForEach-Object {
+        $content = Get-Content -Path $_.FullName -Raw -ErrorAction SilentlyContinue
+        $data = $null
+        if ($content) {
+            try {
+                $data = $content | ConvertFrom-Json -ErrorAction Stop
+            } catch {
+                $data = [pscustomobject]@{ Error = $_.Exception.Message }
+            }
+        }
+
+        $key = $_.BaseName.ToLowerInvariant()
+        if ($artifactMap.ContainsKey($key)) {
+            $artifactMap[$key] = @($artifactMap[$key]) + ,([pscustomobject]@{
+                    Path = $_.FullName
+                    Data = $data
+                })
+        } else {
+            $artifactMap[$key] = @([pscustomobject]@{
+                    Path = $_.FullName
+                    Data = $data
+                })
+        }
+    }
+
+    return [pscustomobject]@{
+        InputFolder = $resolved
+        Artifacts   = $artifactMap
+    }
+}
+
+function Get-AnalyzerArtifact {
+    param(
+        [Parameter(Mandatory)]
+        $Context,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    if (-not $Context -or -not $Context.Artifacts) { return $null }
+    $key = $Name.ToLowerInvariant()
+    if (-not $Context.Artifacts.ContainsKey($key)) { return $null }
+
+    $entries = $Context.Artifacts[$key]
+    if (-not $entries) { return $null }
+
+    if ($entries.Count -gt 1) { return $entries }
+    return $entries[0]
+}
+
+function New-CategoryResult {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    return [pscustomobject]@{
+        Name    = $Name
+        Issues  = New-Object System.Collections.Generic.List[pscustomobject]
+        Normals = New-Object System.Collections.Generic.List[pscustomobject]
+        Checks  = New-Object System.Collections.Generic.List[pscustomobject]
+    }
+}
+
+function Add-CategoryIssue {
+    param(
+        [Parameter(Mandatory)]
+        $CategoryResult,
+
+        [Parameter(Mandatory)]
+        [string]$Severity,
+
+        [Parameter(Mandatory)]
+        [string]$Title,
+
+        [string]$Evidence = ''
+    )
+
+    $CategoryResult.Issues.Add([pscustomobject]@{
+            Severity = $Severity
+            Title    = $Title
+            Evidence = $Evidence
+        }) | Out-Null
+}
+
+function Add-CategoryNormal {
+    param(
+        [Parameter(Mandatory)]
+        $CategoryResult,
+
+        [Parameter(Mandatory)]
+        [string]$Title,
+
+        [string]$Evidence = ''
+    )
+
+    $CategoryResult.Normals.Add([pscustomobject]@{
+            Title    = $Title
+            Evidence = $Evidence
+        }) | Out-Null
+}
+
+function Add-CategoryCheck {
+    param(
+        [Parameter(Mandatory)]
+        $CategoryResult,
+
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [string]$Status,
+
+        [string]$Details = ''
+    )
+
+    $CategoryResult.Checks.Add([pscustomobject]@{
+            Name    = $Name
+            Status  = $Status
+            Details = $Details
+        }) | Out-Null
+}
+
+function Merge-AnalyzerResults {
+    param(
+        [Parameter(Mandatory)]
+        [System.Collections.Generic.IEnumerable[object]]$Categories
+    )
+
+    $issues = New-Object System.Collections.Generic.List[pscustomobject]
+    $normals = New-Object System.Collections.Generic.List[pscustomobject]
+    $checks = New-Object System.Collections.Generic.List[pscustomobject]
+
+    foreach ($category in $Categories) {
+        if (-not $category) { continue }
+        foreach ($item in $category.Issues) { $issues.Add($item) | Out-Null }
+        foreach ($item in $category.Normals) { $normals.Add($item) | Out-Null }
+        foreach ($item in $category.Checks) { $checks.Add($item) | Out-Null }
+    }
+
+    return [pscustomobject]@{
+        Issues  = $issues
+        Normals = $normals
+        Checks  = $checks
+    }
+}
+
+function Get-ArtifactPayload {
+    param(
+        [Parameter(Mandatory)]
+        $Artifact
+    )
+
+    if (-not $Artifact) { return $null }
+
+    if ($Artifact -is [System.Collections.IEnumerable] -and -not ($Artifact -is [string])) {
+        return $Artifact | ForEach-Object { $_.Data.Payload }
+    }
+
+    if ($Artifact.Data -and $Artifact.Data.PSObject.Properties['Payload']) {
+        return $Artifact.Data.Payload
+    }
+
+    return $null
+}
+
+function Resolve-SinglePayload {
+    param(
+        [Parameter(Mandatory)]
+        $Payload
+    )
+
+    if ($null -eq $Payload) { return $null }
+
+    if ($Payload -is [System.Collections.IEnumerable] -and -not ($Payload -is [string])) {
+        return ($Payload | Select-Object -First 1)
+    }
+
+    return $Payload
+}

--- a/Analyzers/Heuristics/AD.ps1
+++ b/Analyzers/Heuristics/AD.ps1
@@ -1,0 +1,60 @@
+<#!
+.SYNOPSIS
+    Active Directory heuristics focused on domain membership and identity posture.
+#>
+
+. (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+
+function Invoke-ADHeuristics {
+    param(
+        [Parameter(Mandatory)]
+        $Context
+    )
+
+    $result = New-CategoryResult -Name 'Active Directory'
+
+    $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
+    $computerSystem = $null
+    if ($systemArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact)
+        if ($payload -and $payload.ComputerSystem -and -not $payload.ComputerSystem.Error) {
+            $computerSystem = $payload.ComputerSystem
+        }
+    }
+
+    if ($computerSystem) {
+        if ($computerSystem.PartOfDomain -eq $true) {
+            Add-CategoryNormal -CategoryResult $result -Title ("Domain joined: {0}" -f $computerSystem.Domain)
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Device not joined to an Active Directory domain'
+        }
+    }
+
+    $identityArtifact = Get-AnalyzerArtifact -Context $Context -Name 'identity'
+    if ($identityArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $identityArtifact)
+        if ($payload -and $payload.DsRegCmd) {
+            $text = if ($payload.DsRegCmd -is [string[]]) { $payload.DsRegCmd -join "`n" } else { [string]$payload.DsRegCmd }
+            if ($text -match 'AzureAdJoined\s*:\s*YES') {
+                Add-CategoryNormal -CategoryResult $result -Title 'Azure AD join detected'
+            }
+            if ($text -match 'DomainJoined\s*:\s*NO' -and $computerSystem.PartOfDomain -ne $true) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Device not domain joined per dsregcmd'
+            }
+        }
+    }
+
+    $dnsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'dns'
+    if ($dnsArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $dnsArtifact)
+        if ($payload -and $payload.Resolution) {
+            $adLookups = $payload.Resolution | Where-Object { $_.Name -like '*.outlook.com' -or $_.Name -like '*.microsoft.com' }
+            $failures = $adLookups | Where-Object { $_.Success -eq $false }
+            if ($failures.Count -gt 0 -and $computerSystem -and $computerSystem.PartOfDomain -eq $true) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Domain joined but core DNS lookups failed' -Evidence ($failures | Select-Object -ExpandProperty Name -join ', ')
+            }
+        }
+    }
+
+    return $result
+}

--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -1,0 +1,44 @@
+<#!
+.SYNOPSIS
+    Event log heuristics summarizing recent error and warning volume.
+#>
+
+. (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+
+function Invoke-EventsHeuristics {
+    param(
+        [Parameter(Mandatory)]
+        $Context
+    )
+
+    $result = New-CategoryResult -Name 'Events'
+
+    $eventsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'events'
+    if ($eventsArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $eventsArtifact)
+        if ($payload) {
+            foreach ($logName in @('System','Application')) {
+                if (-not $payload.PSObject.Properties[$logName]) { continue }
+                $entries = $payload.$logName
+                if ($entries -and -not $entries.Error) {
+                    $errorCount = ($entries | Where-Object { $_.LevelDisplayName -eq 'Error' }).Count
+                    $warnCount = ($entries | Where-Object { $_.LevelDisplayName -eq 'Warning' }).Count
+                    Add-CategoryCheck -CategoryResult $result -Name ("{0} log errors" -f $logName) -Status ([string]$errorCount)
+                    Add-CategoryCheck -CategoryResult $result -Name ("{0} log warnings" -f $logName) -Status ([string]$warnCount)
+                    if ($errorCount -gt 20) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ("High error volume in {0} log" -f $logName) -Evidence ("Recent errors: {0}" -f $errorCount)
+                    }
+                    if ($warnCount -gt 40) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title ("Many warnings in {0} log" -f $logName)
+                    }
+                } elseif ($entries.Error) {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title ("Unable to read {0} event log" -f $logName) -Evidence $entries.Error
+                }
+            }
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Event log artifact missing'
+    }
+
+    return $result
+}

--- a/Analyzers/Heuristics/Network.ps1
+++ b/Analyzers/Heuristics/Network.ps1
@@ -1,0 +1,136 @@
+<#!
+.SYNOPSIS
+    Network diagnostics heuristics covering connectivity, DNS, proxy, and Outlook health.
+#>
+
+. (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+
+function Invoke-NetworkHeuristics {
+    param(
+        [Parameter(Mandatory)]
+        $Context
+    )
+
+    $result = New-CategoryResult -Name 'Network'
+
+    $networkArtifact = Get-AnalyzerArtifact -Context $Context -Name 'network'
+    if ($networkArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $networkArtifact)
+        if ($payload -and $payload.IpConfig) {
+            $ipText = if ($payload.IpConfig -is [string[]]) { $payload.IpConfig -join "`n" } else { [string]$payload.IpConfig }
+            if ($ipText -match 'IPv4 Address') {
+                Add-CategoryNormal -CategoryResult $result -Title 'IPv4 addressing detected'
+            } else {
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'No IPv4 configuration found' -Evidence 'ipconfig /all output did not include IPv4 details.'
+            }
+        }
+
+        if ($payload -and $payload.Route) {
+            $routeText = if ($payload.Route -is [string[]]) { $payload.Route -join "`n" } else { [string]$payload.Route }
+            if ($routeText -notmatch '0\.0\.0\.0') {
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Routing table missing default route' -Evidence 'route print output did not include 0.0.0.0/0.'
+            }
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Network base diagnostics not collected'
+    }
+
+    $dnsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'dns'
+    if ($dnsArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $dnsArtifact)
+        if ($payload -and $payload.Resolution) {
+            $failures = $payload.Resolution | Where-Object { $_.Success -eq $false }
+            if ($failures.Count -gt 0) {
+                $names = $failures | Select-Object -ExpandProperty Name
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ('DNS lookup failures: {0}' -f ($names -join ', '))
+            } else {
+                Add-CategoryNormal -CategoryResult $result -Title 'DNS lookups succeeded'
+            }
+        }
+
+        if ($payload -and $payload.Latency) {
+            $latency = $payload.Latency
+            if ($latency.PSObject.Properties['PingSucceeded']) {
+                if (-not $latency.PingSucceeded) {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ('Ping to {0} failed' -f $latency.RemoteAddress)
+                } else {
+                    Add-CategoryNormal -CategoryResult $result -Title ('Ping to {0} succeeded' -f $latency.RemoteAddress)
+                }
+            } elseif ($latency -is [string] -and $latency -match 'Request timed out') {
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Latency test reported timeouts'
+            }
+        }
+
+        if ($payload -and $payload.Autodiscover) {
+            $autoErrors = $payload.Autodiscover | Where-Object { $_.Error }
+            if ($autoErrors.Count -gt 0) {
+                $details = $autoErrors | Select-Object -ExpandProperty Error -First 3
+                Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Autodiscover DNS queries failed' -Evidence ($details -join "`n")
+            }
+        }
+    }
+
+    $outlookArtifact = Get-AnalyzerArtifact -Context $Context -Name 'outlook-connectivity'
+    if ($outlookArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $outlookArtifact)
+        if ($payload -and $payload.Connectivity) {
+            $conn = $payload.Connectivity
+            if ($conn.PSObject.Properties['TcpTestSucceeded']) {
+                if (-not $conn.TcpTestSucceeded) {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Outlook HTTPS connectivity failed' -Evidence ('TcpTestSucceeded reported False for {0}' -f $conn.RemoteAddress)
+                } else {
+                    Add-CategoryNormal -CategoryResult $result -Title 'Outlook HTTPS connectivity succeeded'
+                }
+            } elseif ($conn.Error) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Unable to test Outlook connectivity' -Evidence $conn.Error
+            }
+        }
+
+        if ($payload -and $payload.OstFiles) {
+            $largeOst = $payload.OstFiles | Where-Object { $_.Length -gt 25GB }
+            if ($largeOst.Count -gt 0) {
+                $names = $largeOst | Select-Object -ExpandProperty Name
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ('Large OST files detected: {0}' -f ($names -join ', '))
+            } elseif ($payload.OstFiles.Count -gt 0) {
+                Add-CategoryNormal -CategoryResult $result -Title ('OST files present ({0})' -f $payload.OstFiles.Count)
+            }
+        }
+    }
+
+    $adapterArtifact = Get-AnalyzerArtifact -Context $Context -Name 'network-adapters'
+    if ($adapterArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $adapterArtifact)
+        if ($payload -and $payload.Adapters -and -not $payload.Adapters.Error) {
+            $upAdapters = $payload.Adapters | Where-Object { $_.Status -eq 'Up' }
+            if ($upAdapters.Count -gt 0) {
+                Add-CategoryNormal -CategoryResult $result -Title ('Active adapters: {0}' -f ($upAdapters | Select-Object -ExpandProperty Name -join ', '))
+            } else {
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'No active network adapters reported'
+            }
+        }
+    }
+
+    $proxyArtifact = Get-AnalyzerArtifact -Context $Context -Name 'proxy'
+    if ($proxyArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $proxyArtifact)
+        if ($payload -and $payload.Internet) {
+            $internet = $payload.Internet
+            if ($internet.ProxyEnable -eq 1 -and $internet.ProxyServer) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title ('User proxy enabled: {0}' -f $internet.ProxyServer)
+            } elseif ($internet.ProxyEnable -eq 0) {
+                Add-CategoryNormal -CategoryResult $result -Title 'User proxy disabled'
+            }
+        }
+
+        if ($payload -and $payload.WinHttp) {
+            $winHttpText = if ($payload.WinHttp -is [string[]]) { $payload.WinHttp -join "`n" } else { [string]$payload.WinHttp }
+            if ($winHttpText -match 'Direct access') {
+                Add-CategoryNormal -CategoryResult $result -Title 'WinHTTP proxy: Direct access'
+            } elseif ($winHttpText) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'WinHTTP proxy configured' -Evidence $winHttpText
+            }
+        }
+    }
+
+    return $result
+}

--- a/Analyzers/Heuristics/Office.ps1
+++ b/Analyzers/Heuristics/Office.ps1
@@ -1,0 +1,66 @@
+<#!
+.SYNOPSIS
+    Office security heuristics covering macro and Protected View policies along with cache sizing.
+#>
+
+. (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+
+function Invoke-OfficeHeuristics {
+    param(
+        [Parameter(Mandatory)]
+        $Context
+    )
+
+    $result = New-CategoryResult -Name 'Office'
+
+    $policiesArtifact = Get-AnalyzerArtifact -Context $Context -Name 'office-policies'
+    if ($policiesArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $policiesArtifact)
+        if ($payload -and $payload.Policies) {
+            $macroBlocked = $false
+            foreach ($policy in $payload.Policies) {
+                if ($policy.Values -and $policy.Values.PSObject.Properties['VBAWarnings']) {
+                    $value = [int]$policy.Values.VBAWarnings
+                    if ($value -ge 4) {
+                        $macroBlocked = $true
+                    } else {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Office macros allowed' -Evidence ("VBAWarnings={0} at {1}" -f $value, $policy.Path)
+                    }
+                }
+                if ($policy.Values -and $policy.Values.PSObject.Properties['DisableTrustBarNotificationsFromUnsignedMacros']) {
+                    $setting = [int]$policy.Values.DisableTrustBarNotificationsFromUnsignedMacros
+                    if ($setting -eq 1) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Trust Bar notifications disabled' -Evidence $policy.Path
+                    }
+                }
+                if ($policy.Values -and $policy.Values.PSObject.Properties['DisableProtectedViewForAttachments']) {
+                    if ([int]$policy.Values.DisableProtectedViewForAttachments -eq 1) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Protected View disabled for attachments' -Evidence $policy.Path
+                    }
+                }
+            }
+
+            if ($macroBlocked) {
+                Add-CategoryNormal -CategoryResult $result -Title 'Macro runtime blocked by policy'
+            }
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'No Office policy data collected'
+        }
+    }
+
+    $cacheArtifact = Get-AnalyzerArtifact -Context $Context -Name 'outlook-caches'
+    if ($cacheArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $cacheArtifact)
+        if ($payload -and $payload.Caches -and -not $payload.Caches.Error) {
+            $largeCaches = $payload.Caches | Where-Object { $_.Length -gt 25GB }
+            if ($largeCaches.Count -gt 0) {
+                $names = $largeCaches | Select-Object -ExpandProperty FullName -First 5
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Large Outlook cache files detected' -Evidence ($names -join "`n")
+            } elseif ($payload.Caches.Count -gt 0) {
+                Add-CategoryNormal -CategoryResult $result -Title ('Outlook cache files present ({0})' -f $payload.Caches.Count)
+            }
+        }
+    }
+
+    return $result
+}

--- a/Analyzers/Heuristics/Security.ps1
+++ b/Analyzers/Heuristics/Security.ps1
@@ -1,0 +1,147 @@
+<#!
+.SYNOPSIS
+    Security-focused heuristic evaluations based on collected JSON artifacts.
+#>
+
+. (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+
+function Invoke-SecurityHeuristics {
+    param(
+        [Parameter(Mandatory)]
+        $Context
+    )
+
+    $result = New-CategoryResult -Name 'Security'
+
+    $defenderArtifact = Get-AnalyzerArtifact -Context $Context -Name 'defender'
+    if ($defenderArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $defenderArtifact)
+        if ($payload -and $payload.Status -and -not $payload.Status.Error) {
+            $status = $payload.Status
+            $rtp = ConvertTo-NullableBool $status.RealTimeProtectionEnabled
+            if ($rtp -eq $false) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Defender real-time protection disabled' -Evidence 'Get-MpComputerStatus reports RealTimeProtectionEnabled = False.'
+            }
+
+            $av = ConvertTo-NullableBool $status.AntivirusEnabled
+            if ($av -eq $false) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'critical' -Title 'Defender antivirus engine disabled' -Evidence 'Get-MpComputerStatus reports AntivirusEnabled = False.'
+            }
+
+            $tamper = ConvertTo-NullableBool $status.TamperProtectionEnabled
+            if ($tamper -eq $false) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Tamper protection not enabled' -Evidence 'Get-MpComputerStatus indicates tamper protection is disabled.'
+            }
+
+            $definitions = @($status.AntivirusSignatureVersion, $status.AntispywareSignatureVersion) | Where-Object { $_ }
+            if ($definitions.Count -gt 0) {
+                Add-CategoryNormal -CategoryResult $result -Title ('Defender signatures present ({0})' -f ($definitions -join ', '))
+            }
+
+            if ($payload.Threats -and $payload.Threats.Count -gt 0 -and -not ($payload.Threats[0] -is [string])) {
+                $threatNames = $payload.Threats | Where-Object { $_.ThreatName } | Select-Object -First 5 -ExpandProperty ThreatName
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ('Recent threats detected: {0}' -f ($threatNames -join ', ')) -Evidence 'Get-MpThreat returned recent detections; confirm remediation.'
+            } else {
+                Add-CategoryNormal -CategoryResult $result -Title 'No recent Defender detections'
+            }
+        } elseif ($payload -and $payload.Status -and $payload.Status.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Unable to query Defender status' -Evidence $payload.Status.Error
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Defender artifact missing expected structure'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Defender artifact not collected'
+    }
+
+    $firewallArtifact = Get-AnalyzerArtifact -Context $Context -Name 'firewall'
+    if ($firewallArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $firewallArtifact)
+        if ($payload -and $payload.Profiles) {
+            $disabledProfiles = @()
+            foreach ($profile in $payload.Profiles) {
+                if ($profile.PSObject.Properties['Enabled']) {
+                    $enabled = ConvertTo-NullableBool $profile.Enabled
+                    if ($enabled -eq $false) {
+                        $disabledProfiles += $profile.Name
+                    }
+                    Add-CategoryCheck -CategoryResult $result -Name ("Firewall profile: {0}" -f $profile.Name) -Status ($(if ($enabled) { 'Enabled' } elseif ($enabled -eq $false) { 'Disabled' } else { 'Unknown' })) -Details ("Inbound: {0}; Outbound: {1}" -f $profile.DefaultInboundAction, $profile.DefaultOutboundAction)
+                }
+            }
+
+            if ($disabledProfiles.Count -gt 0) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ('Firewall profiles disabled: {0}' -f ($disabledProfiles -join ', '))
+            } else {
+                Add-CategoryNormal -CategoryResult $result -Title 'All firewall profiles enabled'
+            }
+        } elseif ($payload -and $payload.Profiles -and $payload.Profiles.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Firewall profile query failed' -Evidence $payload.Profiles.Error
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Firewall data missing expected profile list'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Firewall artifact not collected'
+    }
+
+    $bitlockerArtifact = Get-AnalyzerArtifact -Context $Context -Name 'bitlocker'
+    if ($bitlockerArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $bitlockerArtifact)
+        if ($payload -and $payload.Volumes) {
+            $unprotected = @()
+            foreach ($volume in $payload.Volumes) {
+                $status = $volume.ProtectionStatus
+                $mount = if ($volume.MountPoint) { $volume.MountPoint } else { $volume.VolumeType }
+                Add-CategoryCheck -CategoryResult $result -Name ("BitLocker: {0}" -f $mount) -Status ($status)
+                if ($status -and ($status -eq 0 -or $status -eq 'Off' -or $status -like '*Off*')) {
+                    $unprotected += $mount
+                }
+            }
+
+            if ($unprotected.Count -gt 0) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ('BitLocker disabled on {0}' -f ($unprotected -join ', '))
+            } else {
+                Add-CategoryNormal -CategoryResult $result -Title 'BitLocker protection present'
+            }
+        } elseif ($payload -and $payload.Volumes -and $payload.Volumes.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'BitLocker query failed' -Evidence $payload.Volumes.Error
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'BitLocker data missing expected structure'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'BitLocker artifact not collected'
+    }
+
+    $tpmArtifact = Get-AnalyzerArtifact -Context $Context -Name 'tpm'
+    if ($tpmArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $tpmArtifact)
+        if ($payload -and $payload.Tpm -and -not $payload.Tpm.Error) {
+            $tpm = $payload.Tpm
+            $present = ConvertTo-NullableBool $tpm.TpmPresent
+            $ready = ConvertTo-NullableBool $tpm.TpmReady
+            if ($present -eq $false) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'No TPM detected' -Evidence 'Get-Tpm reported TpmPresent = False.'
+            } elseif ($ready -eq $false) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'TPM not initialized' -Evidence 'Get-Tpm reported TpmReady = False.'
+            } else {
+                Add-CategoryNormal -CategoryResult $result -Title 'TPM present and ready'
+            }
+        } elseif ($payload -and $payload.Tpm -and $payload.Tpm.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Unable to query TPM status' -Evidence $payload.Tpm.Error
+        }
+    }
+
+    $lapsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'laps'
+    if ($lapsArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $lapsArtifact)
+        if ($payload -and $payload.LocalAdministrators) {
+            $admins = $payload.LocalAdministrators | Where-Object { $_.AccountName -and -not $_.IsBuiltIn }
+            if ($admins.Count -gt 0) {
+                $names = $admins | Select-Object -First 5 -ExpandProperty AccountName
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ('Standing local administrators detected: {0}' -f ($names -join ', '))
+            } else {
+                Add-CategoryNormal -CategoryResult $result -Title 'No additional local administrators detected'
+            }
+        }
+    }
+
+    return $result
+}

--- a/Analyzers/Heuristics/Services.ps1
+++ b/Analyzers/Heuristics/Services.ps1
@@ -1,0 +1,37 @@
+<#!
+.SYNOPSIS
+    Service health heuristics reviewing stopped automatic services and query errors.
+#>
+
+. (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+
+function Invoke-ServicesHeuristics {
+    param(
+        [Parameter(Mandatory)]
+        $Context
+    )
+
+    $result = New-CategoryResult -Name 'Services'
+
+    $servicesArtifact = Get-AnalyzerArtifact -Context $Context -Name 'services'
+    if ($servicesArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $servicesArtifact)
+        if ($payload -and $payload.Services -and -not $payload.Services.Error) {
+            $stoppedAuto = $payload.Services | Where-Object {
+                ($_.StartMode -eq 'Auto' -or $_.StartType -eq 'Automatic') -and ($_.State -ne 'Running' -and $_.Status -ne 'Running')
+            }
+            if ($stoppedAuto.Count -gt 0) {
+                $summary = $stoppedAuto | Select-Object -First 5 | ForEach-Object { "{0} ({1})" -f $_.DisplayName, ($_.State ? $_.State : $_.Status) }
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Automatic services not running' -Evidence ($summary -join "`n")
+            } else {
+                Add-CategoryNormal -CategoryResult $result -Title 'Automatic services running'
+            }
+        } elseif ($payload.Services.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to query services' -Evidence $payload.Services.Error
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Services artifact missing'
+    }
+
+    return $result
+}

--- a/Analyzers/Heuristics/Storage.ps1
+++ b/Analyzers/Heuristics/Storage.ps1
@@ -1,0 +1,52 @@
+<#!
+.SYNOPSIS
+    Storage heuristics evaluating disk health and free space thresholds.
+#>
+
+. (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+
+function Invoke-StorageHeuristics {
+    param(
+        [Parameter(Mandatory)]
+        $Context
+    )
+
+    $result = New-CategoryResult -Name 'Storage'
+
+    $storageArtifact = Get-AnalyzerArtifact -Context $Context -Name 'storage'
+    if ($storageArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $storageArtifact)
+        if ($payload -and $payload.Disks -and -not $payload.Disks.Error) {
+            $unhealthy = $payload.Disks | Where-Object { $_.HealthStatus -and $_.HealthStatus -ne 'Healthy' }
+            if ($unhealthy.Count -gt 0) {
+                $details = $unhealthy | ForEach-Object { "Disk $($_.Number): $($_.HealthStatus) ($($_.OperationalStatus))" }
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Disks reporting degraded health' -Evidence ($details -join "`n")
+            } else {
+                Add-CategoryNormal -CategoryResult $result -Title 'Disk health reports healthy'
+            }
+        }
+
+        if ($payload -and $payload.Volumes -and -not $payload.Volumes.Error) {
+            $lowSpace = @()
+            foreach ($volume in $payload.Volumes) {
+                if (-not $volume.Size -or -not $volume.SizeRemaining) { continue }
+                $size = [double]$volume.Size
+                $free = [double]$volume.SizeRemaining
+                if ($size -le 0) { continue }
+                $freePct = ($free / $size) * 100
+                $label = if ($volume.DriveLetter) { $volume.DriveLetter } elseif ($volume.FileSystemLabel) { $volume.FileSystemLabel } else { 'Unknown' }
+                Add-CategoryCheck -CategoryResult $result -Name ("Volume {0}" -f $label) -Status ([string][math]::Round($freePct,1)) -Details 'Free space percent'
+                if ($freePct -lt 10) {
+                    $lowSpace += ("{0} ({1}% free)" -f $label, [math]::Round($freePct,1))
+                }
+            }
+            if ($lowSpace.Count -gt 0) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Volumes critically low on space' -Evidence ($lowSpace -join ', ')
+            }
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Storage artifact missing'
+    }
+
+    return $result
+}

--- a/Analyzers/Heuristics/System.ps1
+++ b/Analyzers/Heuristics/System.ps1
@@ -1,0 +1,120 @@
+<#!
+.SYNOPSIS
+    System state heuristics covering uptime, power configuration, and hardware inventory.
+#>
+
+. (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+
+function Invoke-SystemHeuristics {
+    param(
+        [Parameter(Mandatory)]
+        $Context
+    )
+
+    $result = New-CategoryResult -Name 'System'
+
+    $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
+    if ($systemArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact)
+        if ($payload -and $payload.OperatingSystem -and -not $payload.OperatingSystem.Error) {
+            $os = $payload.OperatingSystem
+            $caption = $os.Caption
+            $build = $os.BuildNumber
+            if ($caption) {
+                Add-CategoryNormal -CategoryResult $result -Title ("Operating system: {0} (build {1})" -f $caption, $build)
+            }
+            if ($os.LastBootUpTime) {
+                Add-CategoryCheck -CategoryResult $result -Name 'Last boot time' -Status ([string]$os.LastBootUpTime)
+            }
+        } elseif ($payload -and $payload.OperatingSystem -and $payload.OperatingSystem.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to read OS inventory' -Evidence ($payload.OperatingSystem.Error)
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Operating system inventory not available'
+        }
+
+        if ($payload -and $payload.ComputerSystem -and -not $payload.ComputerSystem.Error) {
+            $cs = $payload.ComputerSystem
+            if ($cs.Manufacturer -or $cs.Model) {
+                Add-CategoryNormal -CategoryResult $result -Title ("Hardware: {0} {1}" -f $cs.Manufacturer, $cs.Model)
+            }
+            if ($cs.TotalPhysicalMemory) {
+                $gb = [math]::Round($cs.TotalPhysicalMemory / 1GB, 2)
+                Add-CategoryCheck -CategoryResult $result -Name 'Physical memory (GB)' -Status ([string]$gb)
+            }
+        } elseif ($payload -and $payload.ComputerSystem -and $payload.ComputerSystem.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to query computer system details' -Evidence $payload.ComputerSystem.Error
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'System inventory artifact missing'
+    }
+
+    $uptimeArtifact = Get-AnalyzerArtifact -Context $Context -Name 'uptime'
+    if ($uptimeArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $uptimeArtifact)
+        if ($payload -and $payload.Uptime -and -not $payload.Uptime.Error) {
+            $uptimeRecord = $payload.Uptime
+            $uptimeText = $uptimeRecord.Uptime
+            $span = $null
+            if ($uptimeText) {
+                try { $span = [TimeSpan]::Parse($uptimeText) } catch { $span = $null }
+            }
+
+            if ($span) {
+                $days = [math]::Floor($span.TotalDays)
+                Add-CategoryCheck -CategoryResult $result -Name 'Current uptime (days)' -Status ([string][math]::Round($span.TotalDays,2))
+                if ($span.TotalDays -gt 30) {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Device has not rebooted in over 30 days' -Evidence ("Reported uptime: {0}" -f $uptimeText)
+                } elseif ($span.TotalDays -lt 1) {
+                    Add-CategoryNormal -CategoryResult $result -Title 'Recent reboot detected'
+                }
+            }
+        }
+    }
+
+    $powerArtifact = Get-AnalyzerArtifact -Context $Context -Name 'power'
+    if ($powerArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $powerArtifact)
+        if ($payload -and $payload.FastStartup -and -not $payload.FastStartup.Error) {
+            $fast = $payload.FastStartup
+            if ($fast.HiberbootEnabled -eq 1) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Fast Startup enabled' -Evidence 'Fast Startup (hiberboot) can interfere with troubleshooting; consider disabling.'
+            } else {
+                Add-CategoryNormal -CategoryResult $result -Title 'Fast Startup disabled'
+            }
+        } elseif ($payload -and $payload.FastStartup -and $payload.FastStartup.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to read Fast Startup configuration' -Evidence $payload.FastStartup.Error
+        }
+    }
+
+    $performanceArtifact = Get-AnalyzerArtifact -Context $Context -Name 'performance'
+    if ($performanceArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $performanceArtifact)
+        if ($payload -and $payload.Memory -and -not $payload.Memory.Error) {
+            $memory = $payload.Memory
+            if ($memory.TotalVisibleMemory -and $memory.FreePhysicalMemory) {
+                $totalMb = [double]$memory.TotalVisibleMemory
+                $freeMb = [double]$memory.FreePhysicalMemory
+                if ($totalMb -gt 0) {
+                    $usedPct = [math]::Round((($totalMb - $freeMb) / $totalMb) * 100, 1)
+                    Add-CategoryCheck -CategoryResult $result -Name 'Memory utilization (%)' -Status ([string]$usedPct)
+                    if ($usedPct -ge 90) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'High memory utilization detected' -Evidence ("Used memory percentage: {0}%" -f $usedPct)
+                    }
+                }
+            }
+        }
+
+        if ($payload -and $payload.TopCpuProcesses) {
+            if (($payload.TopCpuProcesses | Where-Object { $_.Error }).Count -gt 0) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to enumerate running processes'
+            } else {
+            $topProcess = $payload.TopCpuProcesses | Select-Object -First 1
+            if ($topProcess -and $topProcess.CPU -gt 0) {
+                Add-CategoryCheck -CategoryResult $result -Name 'Top CPU process' -Status ($topProcess.Name) -Details ("CPU time: {0}" -f $topProcess.CPU)
+            }
+            }
+        }
+    }
+
+    return $result
+}

--- a/Analyzers/HtmlComposer.ps1
+++ b/Analyzers/HtmlComposer.ps1
@@ -1,0 +1,85 @@
+<#!
+.SYNOPSIS
+    Renders analyzer findings into an HTML report.
+#>
+
+Add-Type -AssemblyName System.Web -ErrorAction SilentlyContinue
+
+function Convert-SeverityToColor {
+    param([string]$Severity)
+
+    switch ($Severity.ToLowerInvariant()) {
+        'critical' { return '#b91c1c' }
+        'high'     { return '#dc2626' }
+        'medium'   { return '#f97316' }
+        'low'      { return '#fbbf24' }
+        'warning'  { return '#facc15' }
+        default    { return '#2563eb' }
+    }
+}
+
+function New-AnalyzerHtml {
+    param(
+        [Parameter(Mandatory)]
+        [System.Collections.Generic.IEnumerable[object]]$Categories
+    )
+
+    $sb = New-Object System.Text.StringBuilder
+    $null = $sb.AppendLine('<!DOCTYPE html>')
+    $null = $sb.AppendLine('<html lang="en">')
+    $null = $sb.AppendLine('<head>')
+    $null = $sb.AppendLine('<meta charset="utf-8" />')
+    $null = $sb.AppendLine('<title>Device Diagnostics</title>')
+    $null = $sb.AppendLine('<style>body{font-family:Segoe UI,Arial,sans-serif;background:#f8fafc;color:#0f172a;margin:32px;}h1{font-size:28px;margin-bottom:4px;}h2{margin-top:32px;}table{border-collapse:collapse;width:100%;margin-top:12px;}th,td{border:1px solid #cbd5f5;padding:8px;text-align:left;}th{background:#e2e8f0;text-transform:uppercase;font-size:12px;letter-spacing:0.05em;}tr:nth-child(even){background:#f1f5f9;}span.badge{display:inline-block;padding:2px 8px;border-radius:12px;color:#fff;font-size:11px;margin-right:6px;}section{margin-bottom:32px;}p.small{font-size:12px;color:#64748b;margin-top:4px;}ul{margin:8px 0 0 18px;}li{margin-bottom:6px;}</style>')
+    $null = $sb.AppendLine('</head>')
+    $null = $sb.AppendLine('<body>')
+    $null = $sb.AppendLine('<h1>Device Diagnostics</h1>')
+    $null = $sb.AppendLine('<p class="small">Generated at ' + (Get-Date).ToString('u') + '</p>')
+
+    foreach ($category in $Categories) {
+        $null = $sb.AppendLine(("<section><h2>{0}</h2>" -f [System.Web.HttpUtility]::HtmlEncode($category.Name)))
+        if ($category.Issues.Count -gt 0) {
+            $null = $sb.AppendLine('<table><thead><tr><th>Severity</th><th>Finding</th><th>Evidence</th></tr></thead><tbody>')
+            foreach ($issue in $category.Issues) {
+                $color = Convert-SeverityToColor -Severity $issue.Severity
+                $badge = "<span class='badge' style='background:$color'>{0}</span>" -f ([System.Web.HttpUtility]::HtmlEncode(($issue.Severity)))
+                $title = [System.Web.HttpUtility]::HtmlEncode($issue.Title)
+                $evidence = [System.Web.HttpUtility]::HtmlEncode($issue.Evidence)
+                $null = $sb.AppendLine("<tr><td>$badge</td><td>$title</td><td>$evidence</td></tr>")
+            }
+            $null = $sb.AppendLine('</tbody></table>')
+        } else {
+            $null = $sb.AppendLine('<p>No issues detected.</p>')
+        }
+
+        if ($category.Normals.Count -gt 0) {
+            $null = $sb.AppendLine('<h3>Healthy signals</h3><ul>')
+            foreach ($normal in $category.Normals) {
+                $text = [System.Web.HttpUtility]::HtmlEncode($normal.Title)
+                if ($normal.Evidence) {
+                    $detail = [System.Web.HttpUtility]::HtmlEncode($normal.Evidence)
+                    $null = $sb.AppendLine("<li><strong>$text</strong><br/><span class='small'>$detail</span></li>")
+                } else {
+                    $null = $sb.AppendLine("<li>$text</li>")
+                }
+            }
+            $null = $sb.AppendLine('</ul>')
+        }
+
+        if ($category.Checks.Count -gt 0) {
+            $null = $sb.AppendLine('<h3>Checks</h3><table><thead><tr><th>Check</th><th>Status</th><th>Details</th></tr></thead><tbody>')
+            foreach ($check in $category.Checks) {
+                $name = [System.Web.HttpUtility]::HtmlEncode($check.Name)
+                $status = [System.Web.HttpUtility]::HtmlEncode($check.Status)
+                $details = [System.Web.HttpUtility]::HtmlEncode($check.Details)
+                $null = $sb.AppendLine("<tr><td>$name</td><td>$status</td><td>$details</td></tr>")
+            }
+            $null = $sb.AppendLine('</tbody></table>')
+        }
+
+        $null = $sb.AppendLine('</section>')
+    }
+
+    $null = $sb.AppendLine('</body></html>')
+    return $sb.ToString()
+}

--- a/Collectors/Collect-All.ps1
+++ b/Collectors/Collect-All.ps1
@@ -1,0 +1,77 @@
+<#!
+.SYNOPSIS
+    Runs all collector scripts and writes JSON output per area.
+.DESCRIPTION
+    Discovers collector scripts under the Collectors directory (excluding Collect-All.ps1 and shared helpers),
+    executes each script, and groups the JSON artifacts by area (Security/System/Network/Office/etc.).
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputRoot = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath 'output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath 'CollectorCommon.ps1')
+
+function Get-CollectorScripts {
+    param([string]$Root)
+    Get-ChildItem -Path $Root -Filter 'Collect-*.ps1' -Recurse |
+        Where-Object { $_.FullName -ne $PSCommandPath -and $_.Name -notin @('Collect-All.ps1') } |
+        Sort-Object DirectoryName, Name
+}
+
+function Invoke-CollectorScript {
+    param(
+        [Parameter(Mandatory)]
+        [System.IO.FileInfo]$Script,
+
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory
+    )
+
+    Write-Verbose "Running collector: $($Script.FullName)"
+    try {
+        $result = & $Script.FullName -OutputDirectory $OutputDirectory -ErrorAction Stop
+        return [PSCustomObject]@{
+            Script      = $Script.FullName
+            Output      = $result
+            Success     = $true
+            Error       = $null
+        }
+    } catch {
+        Write-Warning "Collector failed: $($Script.FullName) - $($_.Exception.Message)"
+        return [PSCustomObject]@{
+            Script  = $Script.FullName
+            Output  = $null
+            Success = $false
+            Error   = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-AllCollectors {
+    $resolvedOutputRoot = Resolve-CollectorOutputDirectory -RequestedPath $OutputRoot
+    $collectors = Get-CollectorScripts -Root $PSScriptRoot
+
+    $results = @()
+    foreach ($collector in $collectors) {
+        $areaName = Split-Path -Path $collector.DirectoryName -Leaf
+        if ($areaName -eq 'Collectors') {
+            $areaName = 'Misc'
+        }
+        $areaOutput = Join-Path -Path $resolvedOutputRoot -ChildPath $areaName
+        $null = Resolve-CollectorOutputDirectory -RequestedPath $areaOutput
+        $results += Invoke-CollectorScript -Script $collector -OutputDirectory $areaOutput
+    }
+
+    $summary = [ordered]@{
+        CollectedAt = (Get-Date).ToString('o')
+        OutputRoot  = $resolvedOutputRoot
+        Results     = $results
+    }
+
+    $summaryPath = Export-CollectorResult -OutputDirectory $resolvedOutputRoot -FileName 'collection-summary.json' -Data $summary -Depth 6
+    Write-Output $summaryPath
+}
+
+Invoke-AllCollectors

--- a/Collectors/CollectorCommon.ps1
+++ b/Collectors/CollectorCommon.ps1
@@ -1,0 +1,49 @@
+<#!
+.SYNOPSIS
+    Provides shared helper functions for collector scripts.
+#>
+
+function Resolve-CollectorOutputDirectory {
+    param(
+        [Parameter(Mandatory)]
+        [string]$RequestedPath
+    )
+
+    if (-not (Test-Path -Path $RequestedPath)) {
+        $null = New-Item -Path $RequestedPath -ItemType Directory -Force
+    }
+
+    return (Resolve-Path -Path $RequestedPath).ProviderPath
+}
+
+function Export-CollectorResult {
+    param(
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory,
+
+        [Parameter(Mandatory)]
+        [string]$FileName,
+
+        [Parameter(Mandatory)]
+        [object]$Data,
+
+        [int]$Depth = 6
+    )
+
+    $resolved = Resolve-CollectorOutputDirectory -RequestedPath $OutputDirectory
+    $path = Join-Path -Path $resolved -ChildPath $FileName
+    $Data | ConvertTo-Json -Depth $Depth | Out-File -FilePath $path -Encoding UTF8
+    return $path
+}
+
+function New-CollectorMetadata {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Payload
+    )
+
+    return [ordered]@{
+        CollectedAt = (Get-Date).ToString('o')
+        Payload     = $Payload
+    }
+}

--- a/Collectors/Network/Collect-DNS.ps1
+++ b/Collectors/Network/Collect-DNS.ps1
@@ -1,0 +1,103 @@
+<#!
+.SYNOPSIS
+    Collects DNS diagnostic data including resolution tests and connectivity checks.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Test-DnsResolution {
+    param(
+        [string[]]$Names = @('www.microsoft.com','outlook.office365.com','autodiscover.outlook.com')
+    )
+
+    $results = @()
+    foreach ($name in $Names) {
+        try {
+            $records = Resolve-DnsName -Name $name -ErrorAction Stop
+            $results += [PSCustomObject]@{
+                Name    = $name
+                Success = $true
+                Records = $records | Select-Object Name, Type, IPAddress
+            }
+        } catch {
+            $results += [PSCustomObject]@{
+                Name    = $name
+                Success = $false
+                Error   = $_.Exception.Message
+            }
+        }
+    }
+    return $results
+}
+
+function Trace-NetworkPath {
+    param([string]$Target = 'outlook.office365.com')
+    try {
+        return tracert.exe $Target 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Target = $Target
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Test-Latency {
+    param([string]$Target = '8.8.8.8')
+    try {
+        return Test-NetConnection -ComputerName $Target -WarningAction SilentlyContinue
+    } catch {
+        try {
+            return ping.exe $Target 2>$null
+        } catch {
+            return [PSCustomObject]@{
+                Target = $Target
+                Error  = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Resolve-AutodiscoverRecords {
+    param(
+        [string[]]$Domains = @('autodiscover', 'enterpriseenrollment', 'enterpriseregistration')
+    )
+
+    $results = @()
+    foreach ($domain in $Domains) {
+        try {
+            $records = Resolve-DnsName -Type CNAME -Name "$domain.outlook.com" -ErrorAction Stop
+            $results += [PSCustomObject]@{
+                Query   = "$domain.outlook.com"
+                Records = $records | Select-Object Name, Type, NameHost
+            }
+        } catch {
+            $results += [PSCustomObject]@{
+                Query = "$domain.outlook.com"
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $results
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Resolution = Test-DnsResolution
+        Traceroute = Trace-NetworkPath
+        Latency    = Test-Latency
+        Autodiscover = Resolve-AutodiscoverRecords
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'dns.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-Network.ps1
+++ b/Collectors/Network/Collect-Network.ps1
@@ -1,0 +1,70 @@
+<#!
+.SYNOPSIS
+    Collects core network diagnostics including IP configuration, routing table, netstat, and ARP cache.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-IpConfiguration {
+    try {
+        return ipconfig.exe /all 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'ipconfig.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-RoutingTable {
+    try {
+        return route.exe print 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'route.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-NetstatSnapshot {
+    try {
+        return netstat.exe -ano 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'netstat.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-ArpCache {
+    try {
+        return arp.exe -a 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'arp.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        IpConfig = Get-IpConfiguration
+        Route    = Get-RoutingTable
+        Netstat  = Get-NetstatSnapshot
+        Arp      = Get-ArpCache
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'network.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-NetworkAdapters.ps1
+++ b/Collectors/Network/Collect-NetworkAdapters.ps1
@@ -1,0 +1,58 @@
+<#!
+.SYNOPSIS
+    Collects network adapter configuration, IP assignments, and operational state.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-AdapterConfigurations {
+    try {
+        return Get-NetAdapter -ErrorAction Stop | Select-Object Name, InterfaceDescription, Status, LinkSpeed, MacAddress, DriverInformation
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-NetAdapter'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-NetIPAssignments {
+    try {
+        return Get-NetIPConfiguration -ErrorAction Stop | Select-Object InterfaceAlias, InterfaceDescription, IPv4Address, IPv6Address, DNSServer, IPv4DefaultGateway
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-NetIPConfiguration'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-NetworkAdapterState {
+    try {
+        return Get-NetAdapterAdvancedProperty -ErrorAction Stop | Select-Object Name, DisplayName, DisplayValue
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-NetAdapterAdvancedProperty'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Adapters   = Get-AdapterConfigurations
+        IPConfig   = Get-NetIPAssignments
+        Properties = Get-NetworkAdapterState
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'network-adapters.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-NetworkShares.ps1
+++ b/Collectors/Network/Collect-NetworkShares.ps1
@@ -1,0 +1,34 @@
+<#!
+.SYNOPSIS
+    Collects network share configuration using net share.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-NetShares {
+    try {
+        return net.exe share 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'net share'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Shares = Get-NetShares
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'network-shares.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-OutlookConnectivity.ps1
+++ b/Collectors/Network/Collect-OutlookConnectivity.ps1
@@ -1,0 +1,67 @@
+<#!
+.SYNOPSIS
+    Collects Outlook connectivity diagnostics including HTTPS tests, OST inventory, and Autodiscover SCP entries.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Test-Outlook443 {
+    param([string]$Target = 'outlook.office365.com')
+    try {
+        return Test-NetConnection -ComputerName $Target -Port 443 -WarningAction SilentlyContinue
+    } catch {
+        return [PSCustomObject]@{
+            Target = $Target
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-OstInventory {
+    try {
+        $profilesPath = Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Microsoft\Outlook'
+        if (Test-Path -Path $profilesPath) {
+            return Get-ChildItem -Path $profilesPath -Filter '*.ost' -Recurse -ErrorAction Stop | Select-Object Name, FullName, Length, LastWriteTime
+        }
+        return @()
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'OSTInventory'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-AutodiscoverScp {
+    try {
+        $regPath = 'HKLM:\SOFTWARE\Microsoft\Office\16.0\Outlook\AutoDiscover'
+        if (Test-Path -Path $regPath) {
+            return Get-ItemProperty -Path $regPath | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+        }
+        return $null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'AutodiscoverSCP'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Connectivity = Test-Outlook443
+        OstFiles     = Get-OstInventory
+        Autodiscover = Get-AutodiscoverScp
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'outlook-connectivity.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Network/Collect-Proxy.ps1
+++ b/Collectors/Network/Collect-Proxy.ps1
@@ -1,0 +1,50 @@
+<#!
+.SYNOPSIS
+    Collects proxy configuration for WinHTTP and Windows settings.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-WinHttpProxy {
+    try {
+        return netsh.exe winhttp show proxy 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'netsh winhttp'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-InternetSettings {
+    try {
+        $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings'
+        if (Test-Path -Path $path) {
+            return Get-ItemProperty -Path $path | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+        }
+        return $null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'InternetSettings'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        WinHttp  = Get-WinHttpProxy
+        Internet = Get-InternetSettings
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'proxy.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Office/Collect-OfficePolicies.ps1
+++ b/Collectors/Office/Collect-OfficePolicies.ps1
@@ -1,0 +1,52 @@
+<#!
+.SYNOPSIS
+    Collects Microsoft Office security policy configuration from registry locations.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-OfficeSecurityPolicies {
+    $paths = @(
+        'HKCU:\SOFTWARE\Policies\Microsoft\Office\16.0\Common\Security',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Office\16.0\Common\Security',
+        'HKCU:\SOFTWARE\Microsoft\Office\16.0\Word\Security',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Office\16.0\Word\Security'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            if (Test-Path -Path $path) {
+                $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+                $result += [PSCustomObject]@{
+                    Path   = $path
+                    Values = $values
+                }
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policies = Get-OfficeSecurityPolicies
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'office-policies.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Office/Collect-OutlookCaches.ps1
+++ b/Collectors/Office/Collect-OutlookCaches.ps1
@@ -1,0 +1,45 @@
+<#!
+.SYNOPSIS
+    Collects Outlook cache file inventory (OST/PST).
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-OstFiles {
+    try {
+        $rootPaths = @(
+            (Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Microsoft\Outlook'),
+            (Join-Path -Path $env:USERPROFILE -ChildPath 'Documents\Outlook Files')
+        ) | Where-Object { $_ }
+
+        $results = @()
+        foreach ($path in $rootPaths) {
+            if (Test-Path -Path $path) {
+                $results += Get-ChildItem -Path $path -Include '*.ost','*.pst' -Recurse -ErrorAction Stop | Select-Object Name, FullName, Length, LastWriteTime
+            }
+        }
+        return $results
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'OutlookCacheScan'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Caches = Get-OstFiles
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'outlook-caches.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-ASR.ps1
+++ b/Collectors/Security/Collect-ASR.ps1
@@ -1,0 +1,57 @@
+<#!
+.SYNOPSIS
+    Collects Microsoft Defender Attack Surface Reduction configuration and exclusions.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Convert-AsrRules {
+    param(
+        [Parameter()]$Rules
+    )
+
+    $result = @()
+    if ($Rules) {
+        foreach ($entry in $Rules.GetEnumerator()) {
+            $result += [PSCustomObject]@{
+                RuleId = $entry.Key
+                Action = $entry.Value
+            }
+        }
+    }
+
+    return $result
+}
+
+function Get-AsrPolicy {
+    try {
+        $prefs = Get-MpPreference -ErrorAction Stop
+        return [PSCustomObject]@{
+            Rules          = Convert-AsrRules -Rules $prefs.AttackSurfaceReductionRules_Actions
+            OnlyExclusions = $prefs.AttackSurfaceReductionOnlyExclusions
+            ProcessExclusions = $prefs.AttackSurfaceReductionRules_Ids
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-MpPreference'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policy = Get-AsrPolicy
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'asr.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-BitLocker.ps1
+++ b/Collectors/Security/Collect-BitLocker.ps1
@@ -1,0 +1,36 @@
+<#!
+.SYNOPSIS
+    Collects BitLocker drive protection status for all volumes.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-BitLockerVolumes {
+    try {
+        $volumes = Get-BitLockerVolume -ErrorAction Stop
+        return $volumes | Select-Object MountPoint, VolumeType, CapacityGB, EncryptionMethod, ProtectionStatus, LockStatus, AutoUnlockEnabled, KeyProtector
+    } catch {
+        Write-Verbose "Get-BitLockerVolume failed: $($_.Exception.Message)"
+        return [PSCustomObject]@{
+            Source = 'Get-BitLockerVolume'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Volumes = Get-BitLockerVolumes
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'bitlocker.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-Defender.ps1
+++ b/Collectors/Security/Collect-Defender.ps1
@@ -1,0 +1,64 @@
+<#!
+.SYNOPSIS
+    Collects Microsoft Defender Antivirus health and configuration data.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DefenderStatus {
+    try {
+        $status = Get-MpComputerStatus -ErrorAction Stop
+        return $status | Select-Object AMServiceEnabled, AntispywareEnabled, AntivirusEnabled, IoavProtectionEnabled, RealTimeProtectionEnabled, TamperProtectionEnabled, IsTamperProtected, NISEnabled, QuickScanEndTime, FullScanEndTime, ProductStatus, AntivirusSignatureVersion, AntispywareSignatureVersion
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-MpComputerStatus'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-DefenderThreatStatistics {
+    try {
+        return Get-MpThreat -ErrorAction Stop | Select-Object ThreatID, ThreatName, SeverityID, CategoryID, Resources, ActionSuccess, LastThreatStatusChangeTime
+    } catch {
+        if ($_.Exception -and $_.Exception.Message -like '*No threats found*') {
+            return @()
+        }
+
+        return [PSCustomObject]@{
+            Source = 'Get-MpThreat'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-DefenderPreferences {
+    try {
+        $prefs = Get-MpPreference -ErrorAction Stop
+        return $prefs | Select-Object DisableRealtimeMonitoring, DisableIOAVProtection, DisablePrivacyMode, DisableIntrusionPreventionSystem, DisableScriptScanning, ScanScheduleDay, ScanScheduleTime, SignatureScheduleDay, SignatureScheduleTime, MAPSReporting, SubmitSamplesConsent, EnableNetworkProtection, UILockdownMode
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-MpPreference'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Status       = Get-DefenderStatus
+        Threats      = Get-DefenderThreatStatistics
+        Preferences  = Get-DefenderPreferences
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'defender.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-ExploitProtection.ps1
+++ b/Collectors/Security/Collect-ExploitProtection.ps1
@@ -1,0 +1,34 @@
+<#!
+.SYNOPSIS
+    Collects system-wide exploit protection (process mitigation) configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-ExploitMitigations {
+    try {
+        return Get-ProcessMitigation -System -ErrorAction Stop
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-ProcessMitigation'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Mitigations = Get-ExploitMitigations
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'exploit-protection.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-Firewall.ps1
+++ b/Collectors/Security/Collect-Firewall.ps1
@@ -1,0 +1,59 @@
+<#!
+.SYNOPSIS
+    Collects Windows Firewall configuration and rules into a structured JSON artifact.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-FirewallProfiles {
+    try {
+        return Get-NetFirewallProfile -ErrorAction Stop | Select-Object Name, Enabled, DefaultInboundAction, DefaultOutboundAction, NotifyOnListen, AllowInboundRules, AllowLocalFirewallRules, AllowLocalIPsecRules
+    } catch {
+        Write-Verbose "Get-NetFirewallProfile failed: $($_.Exception.Message)"
+        try {
+            $raw = & netsh advfirewall show allprofiles 2>$null
+            return [PSCustomObject]@{
+                Source    = 'netsh'
+                RawOutput = $raw -join [Environment]::NewLine
+                Error     = $null
+            }
+        } catch {
+            return [PSCustomObject]@{
+                Source    = 'netsh'
+                RawOutput = $null
+                Error     = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Get-FirewallRules {
+    try {
+        return Get-NetFirewallRule -All -ErrorAction Stop |
+            Select-Object DisplayName, Direction, Action, Enabled, Profile, @{Name='PolicyStore';Expression={$_.PolicyStoreSourceType}}, Program, Service, Group, Description
+    } catch {
+        Write-Verbose "Get-NetFirewallRule failed: $($_.Exception.Message)"
+        return [PSCustomObject]@{
+            Source = 'Get-NetFirewallRule'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Profiles = Get-FirewallProfiles
+        Rules    = Get-FirewallRules
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'firewall.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-FirmwareSecurity.ps1
+++ b/Collectors/Security/Collect-FirmwareSecurity.ps1
@@ -1,0 +1,58 @@
+<#!
+.SYNOPSIS
+    Collects firmware and chassis security metadata.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-ComputerSystemSecurity {
+    try {
+        return Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop | Select-Object Manufacturer, Model, Domain, PartOfDomain, NumberOfProcessors, TotalPhysicalMemory
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_ComputerSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-BiosInformation {
+    try {
+        return Get-CimInstance -ClassName Win32_BIOS -ErrorAction Stop | Select-Object Manufacturer, Name, Version, SMBIOSBIOSVersion, SerialNumber, ReleaseDate
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_BIOS'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-SystemEnclosure {
+    try {
+        return Get-CimInstance -ClassName Win32_SystemEnclosure -ErrorAction Stop | Select-Object ChassisTypes, SecurityStatus, SerialNumber, SMBIOSAssetTag, LockPresent
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_SystemEnclosure'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        ComputerSystem = Get-ComputerSystemSecurity
+        Bios           = Get-BiosInformation
+        Enclosure      = Get-SystemEnclosure
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'firmware.json' -Data $result -Depth 5
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-KernelDMA.ps1
+++ b/Collectors/Security/Collect-KernelDMA.ps1
@@ -1,0 +1,65 @@
+<#!
+.SYNOPSIS
+    Collects Kernel DMA protection configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-KernelDMAConfiguration {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\KernelDMAProtection',
+        'HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Get-MsInfoKernelDmaSection {
+    try {
+        $tempPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString() + '.txt')
+        $process = Start-Process -FilePath 'msinfo32.exe' -ArgumentList '/report', $tempPath, '/categories', 'Hardware Resources\DMA' -PassThru -WindowStyle Hidden
+        $process.WaitForExit()
+        $content = Get-Content -Path $tempPath -ErrorAction SilentlyContinue
+        Remove-Item -Path $tempPath -ErrorAction SilentlyContinue
+        return $content
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'msinfo32.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-KernelDMAConfiguration
+        MsInfo   = Get-MsInfoKernelDmaSection
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'kerneldma.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-LAPS.ps1
+++ b/Collectors/Security/Collect-LAPS.ps1
@@ -1,69 +1,108 @@
-param([string]$ReportRoot)
-
-function Try-GetItemProperty($path) {
-  try { Get-ItemProperty -Path $path -ErrorAction Stop } catch { $null }
-}
-
-if (-not $ReportRoot) {
-  throw "ReportRoot parameter is required."
-}
-
-# Ensure collectors directory exists
-$collectorDir = Join-Path $ReportRoot 'collectors'
-if (-not (Test-Path $collectorDir)) {
-  New-Item -Path $collectorDir -ItemType Directory -Force | Out-Null
-}
-
-# 1) LAPS footprints
-$winLapsPol   = Try-GetItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\LAPS'
-$winLapsState = Try-GetItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\LAPS\State'
-$admPwdPolicy = Try-GetItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft Services\AdmPwd'
-
-# 2) Local admins + metadata
-$localAdmins = @(Get-LocalGroupMember -Group 'Administrators' -ErrorAction SilentlyContinue)
-$localUsers  = @(Get-LocalUser -ErrorAction SilentlyContinue)
-
-$users = @()
-foreach ($m in $localAdmins) {
-  if ($m.ObjectClass -ne 'User' -or $m.PrincipalSource -notin @('Local','MicrosoftAccount')) { continue }
-  $u = $localUsers | Where-Object Name -eq $m.Name
-  if (-not $u) { continue }
-
-  $sid = $u.SID.Value
-  $users += [pscustomobject]@{
-    Name                 = $u.Name
-    Sid                  = $sid
-    Enabled              = [bool]$u.Enabled
-    PasswordNeverExpires = [bool]$u.PasswordNeverExpires
-    LastPasswordSet      = if ($u.LastPasswordSet) { $u.LastPasswordSet.ToUniversalTime().ToString('o') } else { $null }
-    IsBuiltInAdmin       = ($sid -match '-500$')   # RID 500
-  }
-}
-
-# 3) Emit JSON
-$checks = @(
-  [pscustomobject]@{
-    Id='LAPS.Policy'; Status='OK'; Data=@{
-      WindowsLapsPolicy   = $winLapsPol
-      WindowsLapsState    = $winLapsState
-      LegacyAdmPwdPolicy  = $admPwdPolicy
-    }
-    Notes = if ($winLapsPol -or $winLapsState -or $admPwdPolicy) { 'LAPS footprints present' } else { 'No LAPS footprints' }
-  },
-  [pscustomobject]@{
-    Id='LocalAdmins.List'; Status='OK'; Data=@{ Users = $users }
-    Notes = "Count=$($users.Count)"
-  }
+<#!
+.SYNOPSIS
+    Collects Local Administrator Password Solution (LAPS) policy and local administrator inventory.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
 )
 
-$doc = [pscustomobject]@{
-  SchemaVersion = 1
-  Host          = $env:COMPUTERNAME
-  CollectedAt   = (Get-Date).ToUniversalTime().ToString('o')
-  CheckGroup    = 'LAPSLocalAdmin'
-  Checks        = $checks
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-RegistryObject {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    try {
+        return Get-ItemProperty -Path $Path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+    } catch {
+        return $null
+    }
 }
 
-$path = Join-Path $collectorDir 'laps_localadmin.json'
-$doc  | ConvertTo-Json -Depth 8 | Set-Content -Path $path -Encoding UTF8
-Write-Output "Wrote $path"
+function Get-LapsPolicyFootprints {
+    $policy = Get-RegistryObject -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\LAPS'
+    $state  = Get-RegistryObject -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\LAPS\State'
+    $legacy = Get-RegistryObject -Path 'HKLM:\SOFTWARE\Policies\Microsoft Services\AdmPwd'
+
+    return [ordered]@{
+        WindowsLapsPolicy  = $policy
+        WindowsLapsState   = $state
+        LegacyAdmPwdPolicy = $legacy
+    }
+}
+
+function Get-LocalAdminInventory {
+    try {
+        $members = @(Get-LocalGroupMember -Group 'Administrators' -ErrorAction Stop)
+        $localUsers = @()
+        try {
+            $localUsers = @(Get-LocalUser -ErrorAction Stop)
+        } catch {
+            $localUsers = @()
+        }
+
+        $inventory = @()
+        foreach ($member in $members) {
+            $isLocalUser = ($member.ObjectClass -eq 'User' -and $member.PrincipalSource -in @('Local', 'MicrosoftAccount'))
+            $userDetails = $null
+            if ($isLocalUser -and $localUsers) {
+                $matched = $localUsers | Where-Object Name -eq $member.Name | Select-Object -First 1
+                if ($matched) {
+                    $lastSet = $null
+                    if ($matched.LastPasswordSet) {
+                        try { $lastSet = $matched.LastPasswordSet.ToUniversalTime().ToString('o') } catch { $lastSet = $matched.LastPasswordSet }
+                    }
+
+                    $userDetails = [PSCustomObject]@{
+                        Sid                  = $matched.SID.Value
+                        Enabled              = [bool]$matched.Enabled
+                        PasswordNeverExpires = [bool]$matched.PasswordNeverExpires
+                        LastPasswordSet      = $lastSet
+                        IsBuiltInAdmin       = ($matched.SID.Value -match '-500$')
+                    }
+                }
+            }
+
+            $inventory += [PSCustomObject]@{
+                Name             = $member.Name
+                ObjectClass      = $member.ObjectClass
+                PrincipalSource  = $member.PrincipalSource
+                IsLocalUser      = [bool]$isLocalUser
+                LocalUserDetails = $userDetails
+            }
+        }
+
+        return $inventory
+    } catch {
+        try {
+            $output = net.exe localgroup administrators 2>&1
+            return [PSCustomObject]@{
+                Source = 'net localgroup administrators'
+                Output = $output
+            }
+        } catch {
+            return [PSCustomObject]@{
+                Source = 'LocalAdministrators'
+                Error  = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Host             = $env:COMPUTERNAME
+        LapsPolicies     = Get-LapsPolicyFootprints
+        LocalAdministrators = Get-LocalAdminInventory
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'laps_localadmin.json' -Data $result -Depth 8
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-LDAP.ps1
+++ b/Collectors/Security/Collect-LDAP.ps1
@@ -1,0 +1,48 @@
+<#!
+.SYNOPSIS
+    Collects LDAP signing and channel binding configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-LdapSigningSettings {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Services\LDAP',
+        'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-LdapSigningSettings
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'ldap.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-LSA.ps1
+++ b/Collectors/Security/Collect-LSA.ps1
@@ -1,0 +1,48 @@
+<#!
+.SYNOPSIS
+    Collects LSA hardening and NTLM authentication configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-LsaRegistryValues {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa',
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-LsaRegistryValues
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'lsa.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-LocalAdmins.ps1
+++ b/Collectors/Security/Collect-LocalAdmins.ps1
@@ -1,0 +1,43 @@
+<#!
+.SYNOPSIS
+    Collects local Administrators group membership.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-LocalAdmins {
+    try {
+        return Get-LocalGroupMember -Group 'Administrators' -ErrorAction Stop | Select-Object Name, ObjectClass, PrincipalSource
+    } catch {
+        Write-Verbose "Get-LocalGroupMember failed: $($_.Exception.Message)"
+        try {
+            $output = & net localgroup Administrators 2>$null
+            return [PSCustomObject]@{
+                Source    = 'net localgroup'
+                RawOutput = $output -join [Environment]::NewLine
+            }
+        } catch {
+            return [PSCustomObject]@{
+                Source = 'Get-LocalGroupMember'
+                Error  = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Members = Get-LocalAdmins
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'local-admins.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-PowerShellLogging.ps1
+++ b/Collectors/Security/Collect-PowerShellLogging.ps1
@@ -1,0 +1,50 @@
+<#!
+.SYNOPSIS
+    Collects PowerShell logging policy configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-PowerShellPolicy {
+    $paths = @(
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ModuleLogging',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policies = Get-PowerShellPolicy
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'powershell-logging.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-RDP.ps1
+++ b/Collectors/Security/Collect-RDP.ps1
@@ -1,0 +1,49 @@
+<#!
+.SYNOPSIS
+    Collects Remote Desktop Protocol configuration from the registry.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-RdpConfiguration {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server',
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-RdpConfiguration
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'rdp.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-SMB.ps1
+++ b/Collectors/Security/Collect-SMB.ps1
@@ -1,0 +1,34 @@
+<#!
+.SYNOPSIS
+    Collects SMB server configuration for security review.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-SmbServerConfig {
+    try {
+        return Get-SmbServerConfiguration -ErrorAction Stop | Select-Object EnableSMB1Protocol, EnableSMB2Protocol, EncryptData, RejectUnencryptedAccess, EnableLeasing, EnableStrictNameChecking, EnableAuthenticateUserSharing, EnableSecuritySignature
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-SmbServerConfiguration'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Configuration = Get-SmbServerConfig
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'smb.json' -Data $result -Depth 4
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-SmartScreen.ps1
+++ b/Collectors/Security/Collect-SmartScreen.ps1
@@ -1,0 +1,50 @@
+<#!
+.SYNOPSIS
+    Collects SmartScreen and app control policy configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-SmartScreenPolicies {
+    $paths = @(
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System',
+        'HKCU:\SOFTWARE\Policies\Microsoft\Windows\System',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Edge',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppHost'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policies = Get-SmartScreenPolicies
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'smartscreen.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-TPM.ps1
+++ b/Collectors/Security/Collect-TPM.ps1
@@ -1,0 +1,35 @@
+<#!
+.SYNOPSIS
+    Collects Trusted Platform Module (TPM) status information.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-TpmStatus {
+    try {
+        $tpm = Get-Tpm -ErrorAction Stop
+        return $tpm | Select-Object TpmPresent, TpmReady, TpmEnabled, TpmActivated, ManagedAuthLevel, ManufacturerId, ManufacturerVersion, LockoutHealTime, LockoutCount, LockedOut
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Tpm'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Tpm = Get-TpmStatus
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'tpm.json' -Data $result -Depth 4
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-UAC.ps1
+++ b/Collectors/Security/Collect-UAC.ps1
@@ -1,0 +1,35 @@
+<#!
+.SYNOPSIS
+    Collects User Account Control (UAC) policy configuration.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-UacPolicy {
+    try {
+        $values = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+        return $values
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Policies\\System'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Policy = Get-UacPolicy
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'uac.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-VBSHVCI.ps1
+++ b/Collectors/Security/Collect-VBSHVCI.ps1
@@ -1,0 +1,61 @@
+<#!
+.SYNOPSIS
+    Collects virtualization-based security and HVCI configuration details.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DeviceGuardState {
+    try {
+        $dg = Get-CimInstance -Namespace 'root/Microsoft/Windows/DeviceGuard' -ClassName Win32_DeviceGuard -ErrorAction Stop
+        return $dg | Select-Object SecurityServicesRunning, SecurityServicesConfigured, RequiredSecurityProperties, AvailableSecurityProperties
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_DeviceGuard'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-WDACRegistry {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\CI',
+        'HKLM:\SOFTWARE\Microsoft\Windows Defender\SmartScreen'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        DeviceGuard = Get-DeviceGuardState
+        Registry    = Get-WDACRegistry
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'vbshvci.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/Security/Collect-WDAC.ps1
+++ b/Collectors/Security/Collect-WDAC.ps1
@@ -1,0 +1,61 @@
+<#!
+.SYNOPSIS
+    Collects Windows Defender Application Control (WDAC) configuration data.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DeviceGuardPolicy {
+    try {
+        $dg = Get-CimInstance -Namespace 'root/Microsoft/Windows/DeviceGuard' -ClassName Win32_DeviceGuard -ErrorAction Stop
+        return $dg | Select-Object SecurityServicesRunning, SecurityServicesConfigured, RequiredSecurityProperties, AvailableSecurityProperties, Version
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_DeviceGuard'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-WdacRegistrySnapshot {
+    $paths = @(
+        'HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy',
+        'HKLM:\SYSTEM\CurrentControlSet\Control\CI'
+    )
+
+    $result = @()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result += [PSCustomObject]@{
+                Path   = $path
+                Values = $values
+            }
+        } catch {
+            $result += [PSCustomObject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }
+        }
+    }
+
+    return $result
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        DeviceGuard = Get-DeviceGuardPolicy
+        Registry    = Get-WdacRegistrySnapshot
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'wdac.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Drivers.ps1
+++ b/Collectors/System/Collect-Drivers.ps1
@@ -1,0 +1,38 @@
+<#!
+.SYNOPSIS
+    Collects installed driver inventory with signing details.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DriverInventory {
+    try {
+        $temp = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString() + '.txt')
+        driverquery.exe /v /fo list > $temp
+        $content = Get-Content -Path $temp -ErrorAction Stop
+        Remove-Item -Path $temp -ErrorAction SilentlyContinue
+        return $content
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'driverquery.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        DriverQuery = Get-DriverInventory
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'drivers.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -1,0 +1,40 @@
+<#!
+.SYNOPSIS
+    Collects recent Application and System event log entries.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-RecentEvents {
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogName
+    )
+
+    try {
+        return Get-WinEvent -LogName $LogName -MaxEvents 100 -ErrorAction Stop | Select-Object TimeCreated, Id, LevelDisplayName, ProviderName, Message
+    } catch {
+        return [PSCustomObject]@{
+            LogName = $LogName
+            Error   = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        System      = Get-RecentEvents -LogName 'System'
+        Application = Get-RecentEvents -LogName 'Application'
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'events.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Hotfixes.ps1
+++ b/Collectors/System/Collect-Hotfixes.ps1
@@ -1,0 +1,34 @@
+<#!
+.SYNOPSIS
+    Collects installed hotfix metadata for recent updates.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-RecentHotfixes {
+    try {
+        return Get-HotFix -ErrorAction Stop | Sort-Object -Property InstalledOn -Descending | Select-Object -First 50 HotFixID, Description, InstalledOn, InstalledBy
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-HotFix'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Hotfixes = Get-RecentHotfixes
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'hotfixes.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Identity.ps1
+++ b/Collectors/System/Collect-Identity.ps1
@@ -1,0 +1,46 @@
+<#!
+.SYNOPSIS
+    Collects device identity posture including Azure AD registration and current user context.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-AzureAdJoinStatus {
+    try {
+        return dsregcmd.exe /status 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'dsregcmd.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-WhoAmIContext {
+    try {
+        return whoami.exe /all 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'whoami.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        DsRegCmd = Get-AzureAdJoinStatus
+        WhoAmI   = Get-WhoAmIContext
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'identity.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Performance.ps1
+++ b/Collectors/System/Collect-Performance.ps1
@@ -1,0 +1,52 @@
+<#!
+.SYNOPSIS
+    Collects lightweight performance snapshot including top CPU consumers and memory usage.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-TopCpuProcesses {
+    try {
+        return Get-Process | Sort-Object -Property CPU -Descending | Select-Object -First 10 Name, Id, CPU, @{Name='WorkingSetMB';Expression={[math]::Round($_.WorkingSet64 / 1MB,2)}}
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Process'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-MemorySummary {
+    try {
+        $os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
+        return [PSCustomObject]@{
+            TotalVisibleMemory = $os.TotalVisibleMemorySize
+            FreePhysicalMemory  = $os.FreePhysicalMemory
+            TotalVirtualMemory  = $os.TotalVirtualMemorySize
+            FreeVirtualMemory   = $os.FreeVirtualMemory
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_OperatingSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        TopCpuProcesses = Get-TopCpuProcesses
+        Memory          = Get-MemorySummary
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'performance.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Power.ps1
+++ b/Collectors/System/Collect-Power.ps1
@@ -1,0 +1,47 @@
+<#!
+.SYNOPSIS
+    Collects power configuration including sleep state availability and fast startup settings.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-PowerStates {
+    try {
+        return powercfg.exe /a 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'powercfg /a'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-FastStartupConfig {
+    try {
+        $values = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power' -ErrorAction Stop | Select-Object HiberbootEnabled, HibernateEnabled, HiberFileType
+        return $values
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Power Registry'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        SleepStates    = Get-PowerStates
+        FastStartup    = Get-FastStartupConfig
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'power.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Processes.ps1
+++ b/Collectors/System/Collect-Processes.ps1
@@ -1,0 +1,46 @@
+<#!
+.SYNOPSIS
+    Collects running process snapshot with resource usage.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-ProcessSnapshot {
+    try {
+        return Get-Process | Select-Object Name, Id, CPU, WorkingSet, StartTime, Path
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Process'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-TaskListVerbose {
+    try {
+        return tasklist.exe /v 2>$null
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'tasklist /v'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Processes = Get-ProcessSnapshot
+        Tasklist  = Get-TaskListVerbose
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'processes.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-ScheduledTasks.ps1
+++ b/Collectors/System/Collect-ScheduledTasks.ps1
@@ -1,0 +1,38 @@
+<#!
+.SYNOPSIS
+    Collects scheduled task inventory and run status.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-TaskInventory {
+    try {
+        $temp = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString() + '.txt')
+        schtasks.exe /query /fo LIST /v > $temp
+        $content = Get-Content -Path $temp -ErrorAction Stop
+        Remove-Item -Path $temp -ErrorAction SilentlyContinue
+        return $content
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'schtasks.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Tasks = Get-TaskInventory
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'scheduled-tasks.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Services.ps1
+++ b/Collectors/System/Collect-Services.ps1
@@ -1,0 +1,38 @@
+<#!
+.SYNOPSIS
+    Collects Windows service configuration and current state.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-ServiceMatrix {
+    try {
+        return Get-CimInstance -ClassName Win32_Service -ErrorAction Stop | Select-Object Name, DisplayName, StartMode, State, Status, StartName, ServiceType
+    } catch {
+        try {
+            return Get-Service | Select-Object Name, DisplayName, Status, StartType
+        } catch {
+            return [PSCustomObject]@{
+                Source = 'ServiceQuery'
+                Error  = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Services = Get-ServiceMatrix
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'services.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Software.ps1
+++ b/Collectors/System/Collect-Software.ps1
@@ -1,0 +1,42 @@
+<#!
+.SYNOPSIS
+    Collects installed software inventory from 32-bit and 64-bit registry locations.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-UninstallEntries {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    try {
+        return Get-ItemProperty -Path $Path -ErrorAction Stop | ForEach-Object {
+            $_ | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate, EstimatedSize, UninstallString
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Source = $Path
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Programs64 = Get-UninstallEntries -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+        Programs32 = Get-UninstallEntries -Path 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'software.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Storage.ps1
+++ b/Collectors/System/Collect-Storage.ps1
@@ -1,0 +1,58 @@
+<#!
+.SYNOPSIS
+    Collects disk, volume, and physical storage inventory.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-DiskInventory {
+    try {
+        return Get-Disk -ErrorAction Stop | Select-Object Number, FriendlyName, SerialNumber, HealthStatus, OperationalStatus, Size, PartitionStyle
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Disk'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-VolumeLayout {
+    try {
+        return Get-Volume -ErrorAction Stop | Select-Object DriveLetter, FileSystem, FileSystemLabel, HealthStatus, SizeRemaining, Size
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-Volume'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-PhysicalDisks {
+    try {
+        return Get-PhysicalDisk -ErrorAction Stop | Select-Object DeviceId, FriendlyName, SerialNumber, MediaType, CanPool, Size, HealthStatus, OperationalStatus
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-PhysicalDisk'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Disks        = Get-DiskInventory
+        Volumes      = Get-VolumeLayout
+        PhysicalDisks = Get-PhysicalDisks
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'storage.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-System.ps1
+++ b/Collectors/System/Collect-System.ps1
@@ -1,0 +1,59 @@
+<#!
+.SYNOPSIS
+    Collects core system inventory information including OS details and hardware metadata.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-SystemInfoText {
+    try {
+        $output = systeminfo.exe 2>$null
+        return $output
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'systeminfo.exe'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-OperatingSystemInventory {
+    try {
+        return Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop | Select-Object Caption, Version, BuildNumber, OSArchitecture, InstallDate, LastBootUpTime, RegisteredUser, SerialNumber
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_OperatingSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-ComputerSystemInventory {
+    try {
+        return Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop | Select-Object Manufacturer, Model, Domain, PartOfDomain, TotalPhysicalMemory, NumberOfLogicalProcessors, NumberOfProcessors
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_ComputerSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        SystemInfoText = Get-SystemInfoText
+        OperatingSystem = Get-OperatingSystemInventory
+        ComputerSystem  = Get-ComputerSystemInventory
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'system.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/Collectors/System/Collect-Uptime.ps1
+++ b/Collectors/System/Collect-Uptime.ps1
@@ -1,0 +1,40 @@
+<#!
+.SYNOPSIS
+    Collects device uptime details.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-Uptime {
+    try {
+        $os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
+        $lastBoot = $os.LastBootUpTime
+        $uptime = (Get-Date) - $lastBoot
+        return [PSCustomObject]@{
+            LastBootUpTime = $lastBoot
+            Uptime         = $uptime.ToString()
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Win32_OperatingSystem'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Uptime = Get-Uptime
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'uptime.json' -Data $result -Depth 4
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add a modular `Analyze-Diagnostics.ps1` orchestrator that loads heuristic plugins, aggregates their findings, and emits an HTML report
- provide shared analyzer helpers for loading collector JSON artifacts and capturing issues/normals/checks across categories
- implement category-specific heuristic modules plus an HTML composer to review security, system, network, AD, Office, storage, events, and services data

## Testing
- `pwsh -NoProfile -Command "& './Analyzers/Analyze-Diagnostics.ps1' -InputFolder '.' -OutputPath './tmp-diagnostics.html'"` *(fails: `pwsh` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d542efb290832d87df6fb77e5c9c85