### PR TITLE
Modularize Active Directory diagnostics scripts

### DIFF
--- a/AutoL1/Analyzers/ActiveDirectory/Common.ps1
+++ b/AutoL1/Analyzers/ActiveDirectory/Common.ps1
@@ -1,0 +1,26 @@
+<#
+  Shared helpers for Active Directory analysis.
+#>
+
+function Normalize-AdDomain {
+  param([string]$Name)
+
+  if (-not $Name) { return $null }
+  $value = $Name.Trim()
+  if (-not $value) { return $null }
+  return $value.TrimEnd('.').ToLowerInvariant()
+}
+
+function Normalize-AdHost {
+  param([string]$Name)
+
+  if (-not $Name) { return $null }
+  $value = $Name.Trim()
+  if (-not $value) { return $null }
+  $value = $value.Trim('\\')
+  if ($value -like '*\\*') {
+    $segments = $value -split '\\'
+    if ($segments.Count -gt 0) { $value = $segments[-1] }
+  }
+  return $value.Trim().TrimEnd('.').ToLowerInvariant()
+}

--- a/AutoL1/Analyzers/ActiveDirectory/Invoke-ActiveDirectoryHeuristics.ps1
+++ b/AutoL1/Analyzers/ActiveDirectory/Invoke-ActiveDirectoryHeuristics.ps1
@@ -1,0 +1,537 @@
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+function Invoke-ActiveDirectoryHeuristics {
+  param(
+    [hashtable]$Raw,
+    [hashtable]$Summary
+  )
+
+  if (-not $Raw) { return }
+  if (-not $Summary) { return }
+
+  $adDomainText    = $Raw['ad_domain']
+  $adDiscoveryText = $Raw['ad_dc']
+  $adPortText      = $Raw['ad_ports']
+  $adSysvolText    = $Raw['ad_sysvol']
+  $adTimeText      = $Raw['ad_time']
+  $adKerberosText  = $Raw['ad_kerberos']
+  $adSecureText    = $Raw['ad_secure']
+  $adGpoText       = $Raw['ad_gpo']
+
+  $hasAdData = $adDomainText -or $adDiscoveryText -or $adPortText -or $adSysvolText -or $adTimeText -or $adKerberosText -or $adSecureText -or $adGpoText
+
+  if ($hasAdData) {
+    $adDomainJoined = $null
+    $domainName = $null
+    $domainDnsName = $null
+    $userDnsDomain = $null
+    $logonServer = $null
+    $domainCandidatesSet = [System.Collections.Generic.HashSet[string]]::new()
+    $forestCandidatesSet = [System.Collections.Generic.HashSet[string]]::new()
+    $domainEvidenceLines = @()
+
+    if ($adDomainText) {
+      $domainLines = [regex]::Split($adDomainText,'\r?\n')
+      foreach ($line in $domainLines) {
+        if ($null -eq $line) { continue }
+        $trim = $line.Trim()
+        if ($trim) { $domainEvidenceLines += $trim }
+
+        if ($trim -match '^(?i)PartOfDomain\s*:\s*(.+)$') {
+          $value = $matches[1].Value.Trim()
+          if ($value -and $value -notmatch '^(?i)unknown$') {
+            $adDomainJoined = Get-BoolFromString $value
+          }
+          continue
+        }
+
+        if ($trim -match '^(?i)DomainDnsName\s*:\s*(.+)$') {
+          $domainDnsName = $matches[1].Value.Trim()
+          continue
+        }
+
+        if ($trim -match '^(?i)Domain\s*:\s*(.+)$') {
+          $domainName = $matches[1].Value.Trim()
+          continue
+        }
+
+        if ($trim -match '^(?i)USERDNSDOMAIN\s*:\s*(.+)$') {
+          $userDnsDomain = $matches[1].Value.Trim()
+          continue
+        }
+
+        if ($trim -match '^(?i)LOGONSERVER\s*:\s*(.+)$') {
+          $logonServer = $matches[1].Value.Trim()
+          continue
+        }
+
+        if ($trim -match '^(?i)DomainCandidates\s*:\s*(.+)$') {
+          $RawValue = $matches[1].Value.Trim()
+          if ($RawValue -and $RawValue -notmatch '^\(none\)$') {
+            foreach ($piece in ($RawValue -split ',|;')) {
+              $normalized = Normalize-AdDomain $piece
+              if ($normalized) { $null = $domainCandidatesSet.Add($normalized) }
+            }
+          }
+          continue
+        }
+
+        if ($trim -match '^(?i)ForestCandidates\s*:\s*(.+)$') {
+          $RawValue = $matches[1].Value.Trim()
+          if ($RawValue -and $RawValue -notmatch '^\(none\)$') {
+            foreach ($piece in ($RawValue -split ',|;')) {
+              $normalized = Normalize-AdDomain $piece
+              if ($normalized) { $null = $forestCandidatesSet.Add($normalized) }
+            }
+          }
+          continue
+        }
+      }
+    }
+
+    $domainEvidenceText = if ($domainEvidenceLines -and $domainEvidenceLines.Count -gt 0) { ($domainEvidenceLines | Select-Object -First 40) -join "`n" } else { Get-FirstLines $adDomainText 40 }
+
+    $normalizedDomainName = Normalize-AdDomain $domainName
+    if ($normalizedDomainName) {
+      if ($normalizedDomainName -eq 'workgroup' -and $null -eq $adDomainJoined) { $adDomainJoined = $false }
+      $null = $domainCandidatesSet.Add($normalizedDomainName)
+    }
+
+    $normalizedDomainDns = Normalize-AdDomain $domainDnsName
+    if ($normalizedDomainDns) {
+      $null = $domainCandidatesSet.Add($normalizedDomainDns)
+      $null = $forestCandidatesSet.Add($normalizedDomainDns)
+    }
+
+    $normalizedUserDns = Normalize-AdDomain $userDnsDomain
+    if ($normalizedUserDns) {
+      $null = $domainCandidatesSet.Add($normalizedUserDns)
+      $null = $forestCandidatesSet.Add($normalizedUserDns)
+    }
+
+    foreach ($candidate in $domainCandidatesSet) { $null = $forestCandidatesSet.Add($candidate) }
+
+    $domainCandidates = @($domainCandidatesSet) | Sort-Object -Unique
+    $forestCandidates = @($forestCandidatesSet) | Sort-Object -Unique
+
+    if (-not $domainDnsName) {
+      if ($userDnsDomain) {
+        $domainDnsName = $userDnsDomain
+      } elseif ($domainCandidates -and $domainCandidates.Count -gt 0) {
+        $domainDnsName = $domainCandidates[0]
+      }
+    }
+
+    if (-not $forestCandidates -or $forestCandidates.Count -eq 0) {
+      $forestCandidates = $domainCandidates
+    }
+
+    if ($null -eq $adDomainJoined) {
+      $nonWorkgroupCandidates = $domainCandidates | Where-Object { $_ -and $_ -ne 'workgroup' }
+      if ($nonWorkgroupCandidates -and $nonWorkgroupCandidates.Count -gt 0) {
+        $adDomainJoined = $true
+      } elseif (($adDiscoveryText -and $adDiscoveryText -match 'DiscoveredDC') -or ($adPortText -and $adPortText -match 'PortResult')) {
+        $adDomainJoined = $true
+      } else {
+        $adDomainJoined = $false
+      }
+    }
+
+    if ($domainDnsName) { $Summary.Domain = $domainDnsName }
+    if ($adDomainJoined -ne $null) { $Summary.DomainJoined = $adDomainJoined }
+    if ($logonServer) { $Summary.LogonServer = $logonServer }
+
+    if (-not $adDomainJoined) {
+      Add-Normal "AD/Status" "GOOD AD not applicable (device not domain-joined)." $domainEvidenceText
+    } else {
+        $adConnectivityRootCause = $false
+        $adTimeSkewHigh = $false
+        $adTimeEvidence = ''
+
+      $dcMap = @{}
+      $srvStatus = @{}
+      $nltestResults = New-Object System.Collections.Generic.List[pscustomobject]
+      if ($adDiscoveryText) {
+        $discoveryLines = [regex]::Split($adDiscoveryText,'\r?\n')
+        foreach ($line in $discoveryLines) {
+          if ($null -eq $line) { continue }
+          $trim = $line.Trim()
+          if (-not $trim) { continue }
+
+          if ($trim -match '^NLTEST\.DSGETDC\.Result\s*:\s*(?<result>[^|]+)\s*\|\s*Domain=(?<domain>[^|]+)\s*\|\s*ExitCode=(?<code>[^|]+)') {
+            $nltestResults.Add([pscustomobject]@{ Command = 'dsgetdc'; Domain = $matches['domain'].Value.Trim(); Result = $matches['result'].Value.Trim(); ExitCode = $matches['code'].Value.Trim() })
+            continue
+          }
+
+          if ($trim -match '^NLTEST\.DCLIST\.Result\s*:\s*(?<result>[^|]+)\s*\|\s*Domain=(?<domain>[^|]+)\s*\|\s*ExitCode=(?<code>[^|]+)') {
+            $nltestResults.Add([pscustomobject]@{ Command = 'dclist'; Domain = $matches['domain'].Value.Trim(); Result = $matches['result'].Value.Trim(); ExitCode = $matches['code'].Value.Trim() })
+            continue
+          }
+
+          if ($trim -match '^SRVLookup\s*:\s*(?<srv>[^|]+)\s*\|\s*Status=(?<status>[^|]+)(?:\s*\|\s*Count=(?<count>[^|]+))?(?:\s*\|\s*Error=(?<error>.+))?$') {
+            $srvName = $matches['srv'].Value.Trim()
+            $srvStatus[$srvName] = [pscustomobject]@{
+              Status = $matches['status'].Value.Trim()
+              Count  = if ($matches['count'].Success) { $matches['count'].Value.Trim() } else { '' }
+              Error  = if ($matches['error'].Success) { $matches['error'].Value.Trim() } else { '' }
+            }
+            continue
+          }
+
+          if ($trim -match '^DiscoveredDC\s*:\s*(?<dc>[^|]+)(?:\|\s*(?<rest>.*))?$') {
+            $dcNameRaw = $matches['dc'].Value.Trim()
+            $dcNormalized = Normalize-AdHost $dcNameRaw
+            if ($dcNormalized) {
+              if (-not $dcMap.ContainsKey($dcNormalized)) {
+                $dcMap[$dcNormalized] = [pscustomobject]@{
+                  Name      = $dcNormalized
+                  Display   = $dcNameRaw
+                  Sources   = [System.Collections.Generic.HashSet[string]]::new()
+                  Addresses = [System.Collections.Generic.HashSet[string]]::new()
+                }
+              }
+              $source = 'Unknown'
+              if ($matches['rest'].Success -and $matches['rest'].Value -match 'Source=([^|]+)') {
+                $source = $matches[1].Value.Trim()
+              }
+              $null = $dcMap[$dcNormalized].Sources.Add($source)
+            }
+            continue
+          }
+
+          if ($trim -match '^DiscoveredDCAddress\s*:\s*(?<addr>[^|]+)\s*\|\s*Domain=(?<domain>[^|]+)\s*\|\s*DC=(?<dc>.+)$') {
+            $addr = $matches['addr'].Value.Trim()
+            $dcNameRaw = $matches['dc'].Value.Trim()
+            $dcNormalized = Normalize-AdHost $dcNameRaw
+            if ($dcNormalized -and $dcMap.ContainsKey($dcNormalized)) {
+              $null = $dcMap[$dcNormalized].Addresses.Add($addr)
+            }
+            continue
+          }
+        }
+      }
+
+      $dcPortMap = @{}
+      $portsAnyAttempt = $false
+      $portsAnySuccess = $false
+      if ($adPortText) {
+        $portLines = [regex]::Split($adPortText,'\r?\n')
+        foreach ($line in $portLines) {
+          if ($null -eq $line) { continue }
+          $trim = $line.Trim()
+          if (-not $trim) { continue }
+
+          if ($trim -match '^(?i)PortResult\s*:\s*(?<dc>[^|]+)\|\s*(?<rest>.+)$') {
+            $portsAnyAttempt = $true
+            $dcNameRaw = $matches['dc'].Value.Trim()
+            $dcNormalized = Normalize-AdHost $dcNameRaw
+            $rest = $matches['rest'].Value
+            $fields = ($rest -split '\|') | ForEach-Object { $_.Trim() }
+            $portNumber = $null
+            $successValue = $null
+            $errorValue = $null
+            $remoteAddress = $null
+
+            foreach ($field in $fields) {
+              if ($field -match '^(?i)Port=(\d+)') { $portNumber = [int]$matches[1].Value; continue }
+              if ($field -match '^(?i)Success=(.+)$') {
+                $successRaw = $matches[1].Value.Trim()
+                if ($successRaw -match '^(?i)True$') { $successValue = $true }
+                elseif ($successRaw -match '^(?i)False$') { $successValue = $false }
+                elseif ($successRaw -match '^(?i)Error$') { $successValue = $null }
+                continue
+              }
+              if ($field -match '^(?i)Error=(.+)$') { $errorValue = $matches[1].Value.Trim(); continue }
+              if ($field -match '^(?i)RemoteAddress=(.+)$') { $remoteAddress = $matches[1].Value.Trim(); continue }
+            }
+
+            if ($dcNormalized) {
+              if (-not $dcPortMap.ContainsKey($dcNormalized)) {
+                $dcPortMap[$dcNormalized] = [pscustomobject]@{
+                  Name            = $dcNormalized
+                  Display         = $dcNameRaw
+                  Ports           = @{}
+                  RemoteAddresses = [System.Collections.Generic.HashSet[string]]::new()
+                }
+              }
+
+              if ($portNumber) {
+                $dcPortMap[$dcNormalized].Ports[$portNumber] = [pscustomobject]@{ Success = $successValue; Error = $errorValue }
+                if ($successValue -eq $true) { $portsAnySuccess = $true }
+              }
+
+              if ($remoteAddress) { $null = $dcPortMap[$dcNormalized].RemoteAddresses.Add($remoteAddress) }
+            }
+          }
+        }
+      }
+
+      $sysvolExists = $false
+      $netlogonExists = $false
+      $sysvolErrors = @()
+      if ($adSysvolText) {
+        $sysvolLines = [regex]::Split($adSysvolText,'\r?\n')
+        foreach ($line in $sysvolLines) {
+          if ($null -eq $line) { continue }
+          $trim = $line.Trim()
+          if (-not $trim) { continue }
+
+          if ($trim -match '^ShareExists\s*:\s*(?<share>[^|]+)\s*\|\s*Path=(?<path>[^|]+)\s*\|\s*Exists=(?<exists>[^|]+)$') {
+            $share = $matches['share'].Value.Trim().ToUpperInvariant()
+            $existsValue = $matches['exists'].Value.Trim()
+            if ($share -eq 'SYSVOL') {
+              if ($existsValue -match '^(?i)true$') { $sysvolExists = $true }
+              elseif ($existsValue -notmatch '^(?i)false$') { $sysvolErrors += $trim }
+            } elseif ($share -eq 'NETLOGON') {
+              if ($existsValue -match '^(?i)true$') { $netlogonExists = $true }
+              elseif ($existsValue -notmatch '^(?i)false$') { $sysvolErrors += $trim }
+            }
+            continue
+          }
+
+          if ($trim -match '^ShareError\s*:\s*(?<share>[^|]+)\s*\|\s*Error=(?<err>.+)$') {
+            $sysvolErrors += $trim
+            continue
+          }
+        }
+      }
+
+      $sysvolAccessible = ($sysvolExists -or $netlogonExists)
+
+      $timeStatusExit = $null
+      $timePeersExit = $null
+      $timeSource = $null
+      $timeOffsetSeconds = $null
+      $timeErrors = @()
+      if ($adTimeText) {
+        if ($adTimeText -match 'StatusExitCode\s*:\s*([^
+  ]+)') { $timeStatusExit = $matches[1].Value.Trim() }
+        if ($adTimeText -match 'PeersExitCode\s*:\s*([^
+  ]+)') { $timePeersExit = $matches[1].Value.Trim() }
+        if ($adTimeText -match 'PhaseOffsetSeconds\s*:\s*([^
+  ]+)') {
+          $offsetRaw = $matches[1].Value.Trim()
+          $offsetParsed = 0.0
+          if ([double]::TryParse($offsetRaw, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$offsetParsed)) {
+            $timeOffsetSeconds = $offsetParsed
+          }
+        }
+        if ($adTimeText -match 'TimeSource\s*:\s*([^
+  ]+)') { $timeSource = $matches[1].Value.Trim() }
+        if ($adTimeText -match '(?i)The service has not been started|Access is denied|Unable to open the service|0x800705b4') { $timeErrors += $matches[0].Value.Trim() }
+      }
+
+      $secureChannelResult = $null
+      if ($adSecureText -match 'SecureChannelResult\s*:\s*(\w+)') {
+        $resultValue = $matches[1].Value.Trim()
+        if ($resultValue -match '^(?i)true$') { $secureChannelResult = $true }
+        elseif ($resultValue -match '^(?i)false$') { $secureChannelResult = $false }
+        elseif ($resultValue -match '^(?i)error$') { $secureChannelResult = $null }
+      }
+
+      $secureChannelNltestExit = $null
+      if ($adSecureText -match 'SecureChannelNltestExitCode\s*:\s*([^
+  ]+)') { $secureChannelNltestExit = $matches[1].Value.Trim() }
+
+      $secureChannelNltestFailure = $false
+      if ($adSecureText -match '(?i)TRUST_FAILURE|NO_LOGON_SERVERS|STATUS_TRUST_FAILURE|STATUS_ACCESS_DENIED') { $secureChannelNltestFailure = $true }
+
+      $kerberosTgtPresent = $false
+      if ($adKerberosText -and ($adKerberosText -match 'krbtgt/')) { $kerberosTgtPresent = $true }
+      $kerberosEventCount = 0
+      if ($adKerberosText -match 'KerberosEventCount\s*:\s*(\d+)') { $kerberosEventCount = [int]$matches[1].Value }
+      $kerberosFailureCount = 0
+      $kerberosSkewCount = 0
+      if ($adKerberosText) {
+        $kerbLines = [regex]::Split($adKerberosText,'\r?\n')
+        foreach ($line in $kerbLines) {
+          if ($null -eq $line) { continue }
+          $trim = $line.Trim()
+          if (-not $trim) { continue }
+          if ($trim -match '^KerberosEvent\s*:\s*Id=(?<id>\d+);\s*Time=(?<time>[^;]+);\s*Provider=(?<provider>[^;]+);\s*Message=(?<msg>.+)$') {
+            $msg = $matches['msg'].Value
+            $failureDetected = $false
+            if ($msg -match '(?i)KRB_AP_ERR_SKEW') { $kerberosSkewCount++ }
+            if ($msg -match '(?i)Failure') {
+              if ($msg -match '(?i)Failure Code\s*:\s*(0x[0-9A-Fa-f]+)') {
+                if ($matches[1].Value -ne '0x0') { $failureDetected = $true }
+              } elseif ($msg -match '(?i)Status\s*:\s*(0x[0-9A-Fa-f]+)') {
+                if ($matches[1].Value -ne '0x0') { $failureDetected = $true }
+              } else {
+                $failureDetected = $true }
+            }
+            if ($failureDetected) { $kerberosFailureCount++ }
+          }
+        }
+      }
+
+      $gpoEventCount = 0
+      if ($adGpoText -match 'GPOEventCount\s*:\s*(\d+)') { $gpoEventCount = [int]$matches[1].Value }
+      $gpFailureDetected = $false
+      $gpSuccessDetected = $false
+      if ($adGpoText) {
+        if ($adGpoText -match '(?i)The processing of Group Policy failed') { $gpFailureDetected = $true }
+        if ($adGpoText -match '(?i)Group Policy was applied successfully') { $gpSuccessDetected = $true }
+      }
+
+      $discoveredDcEntries = $dcMap.Keys | ForEach-Object { $dcMap[$_] }
+      $srvSuccess = $false
+      foreach ($entry in $srvStatus.Values) {
+        if ($entry.Status -eq 'Success') { $srvSuccess = $true; break }
+      }
+      $srvAttempted = $srvStatus.Count -gt 0
+      $srvAllFail = $srvAttempted -and (-not $srvSuccess)
+
+      $nltestAnySuccess = $false
+      foreach ($res in $nltestResults) {
+        if ($res.Result -match 'Success') { $nltestAnySuccess = $true; break }
+      }
+      $nltestAttempted = $nltestResults.Count -gt 0
+      $nltestAllFail = $nltestAttempted -and (-not $nltestAnySuccess)
+
+      $adDiscoverySummaryLines = @()
+      foreach ($dcEntry in $discoveredDcEntries | Sort-Object Name) {
+        $sourceText = ''
+        if ($dcEntry.Sources -and $dcEntry.Sources.Count -gt 0) { $sourceText = (@($dcEntry.Sources) -join ', ') }
+        $addrText = ''
+        if ($dcEntry.Addresses -and $dcEntry.Addresses.Count -gt 0) { $addrText = (@($dcEntry.Addresses) -join ', ') }
+        $line = $dcEntry.Display
+        if ($sourceText) { $line += " (Sources: $sourceText)" }
+        if ($addrText) { $line += " (Addr: $addrText)" }
+        $adDiscoverySummaryLines += $line
+      }
+      $adDiscoveryEvidence = ($adDiscoverySummaryLines + '' + (Get-FirstLines $adDiscoveryText 40)) -join "`n"
+
+      $portEvidenceLines = @()
+      foreach ($dcEntry in $dcPortMap.Values | Sort-Object Name) {
+        $portSummaries = @()
+        foreach ($p in @(88,389,445,135)) {
+          if ($dcEntry.Ports.ContainsKey($p)) {
+            $success = $dcEntry.Ports[$p].Success
+            if ($success -eq $true) { $portSummaries += "$p:OK" }
+            elseif ($success -eq $false) { $portSummaries += "$p:Fail" }
+            else { $portSummaries += "$p:Error" }
+          } else {
+            $portSummaries += "$p:NoData"
+          }
+        }
+        $addrText = ''
+        if ($dcEntry.RemoteAddresses -and $dcEntry.RemoteAddresses.Count -gt 0) { $addrText = " Addr=" + (@($dcEntry.RemoteAddresses) -join ',') }
+        $portEvidenceLines += ("{0} -> {1}{2}" -f $dcEntry.Display, ($portSummaries -join ' '), $addrText)
+      }
+      $adPortEvidence = ($portEvidenceLines + '' + (Get-FirstLines $adPortText 40)) -join "`n"
+
+      $sysvolEvidenceLines = @()
+      $sysvolEvidenceLines += ("SYSVOL Exists: " + ([string]$sysvolExists))
+      $sysvolEvidenceLines += ("NETLOGON Exists: " + ([string]$netlogonExists))
+      if ($sysvolErrors -and $sysvolErrors.Count -gt 0) { $sysvolEvidenceLines += $sysvolErrors }
+      $sysvolEvidenceLines += Get-FirstLines $adSysvolText 30
+      $adSysvolEvidence = $sysvolEvidenceLines -join "`n"
+
+      $timeEvidenceLines = @()
+      if ($timeOffsetSeconds -ne $null) { $timeEvidenceLines += ("PhaseOffsetSeconds: {0}" -f $timeOffsetSeconds) }
+      if ($timeSource) { $timeEvidenceLines += ("TimeSource: {0}" -f $timeSource) }
+      if ($timeStatusExit) { $timeEvidenceLines += ("StatusExitCode: {0}" -f $timeStatusExit) }
+      if ($timeErrors -and $timeErrors.Count -gt 0) { $timeEvidenceLines += $timeErrors }
+      $timeEvidenceLines += Get-FirstLines $adTimeText 40
+      $adTimeEvidence = $timeEvidenceLines -join "`n"
+
+      $secureEvidenceLines = @()
+      if ($null -ne $secureChannelResult) { $secureEvidenceLines += ("SecureChannelResult: {0}" -f $secureChannelResult) }
+      if ($secureChannelNltestExit) { $secureEvidenceLines += ("NLTEST ExitCode: {0}" -f $secureChannelNltestExit) }
+      $secureEvidenceLines += Get-FirstLines $adSecureText 40
+      $adSecureEvidence = $secureEvidenceLines -join "`n"
+
+      $kerberosEvidenceLines = @()
+      $kerberosEvidenceLines += ("TGT Present: " + ([string]$kerberosTgtPresent))
+      $kerberosEvidenceLines += ("Kerberos Failure Events: {0}" -f $kerberosFailureCount)
+      if ($kerberosSkewCount -gt 0) { $kerberosEvidenceLines += ("KRB_AP_ERR_SKEW events: {0}" -f $kerberosSkewCount) }
+      $kerberosEvidenceLines += Get-FirstLines $adKerberosText 40
+      $kerberosEvidence = $kerberosEvidenceLines -join "`n"
+
+      $gpoEvidenceLines = @()
+      $gpoEvidenceLines += ("GPOEventCount: {0}" -f $gpoEventCount)
+      if ($gpFailureDetected) { $gpoEvidenceLines += "gpresult reported failures." }
+      $gpoEvidenceLines += Get-FirstLines $adGpoText 60
+      $adGpoEvidence = $gpoEvidenceLines -join "`n"
+
+      $noDcDiscovered = ($dcMap.Count -eq 0)
+      if ($noDcDiscovered -and $srvAllFail -and $nltestAllFail) {
+        Add-Issue 'high' 'AD/Discovery' 'No DC discovered.' $adDiscoveryEvidence
+        $adConnectivityRootCause = $true
+      }
+
+      if ($srvAllFail) {
+        Add-Issue 'high' 'AD/DNS' 'AD SRV records not resolvable.' $adDiscoveryEvidence
+        $adConnectivityRootCause = $true
+        } elseif ($srvSuccess) {
+          Add-Normal 'AD/DNS' 'GOOD AD/DNS (SRV resolves).' $adDiscoveryEvidence
+        }
+
+        if ($portsAnyAttempt -and -not $portsAnySuccess) {
+          Add-Issue 'high' 'AD/Reachability' 'Cannot reach any DC on required ports.' $adPortEvidence
+          $adConnectivityRootCause = $true
+        } elseif ($portsAnySuccess -and $sysvolAccessible) {
+          Add-Normal 'AD/Reachability' 'GOOD AD/Reachability (≥1 DC reachable + SYSVOL).' $adPortEvidence
+        }
+
+        if ($portsAnySuccess -and -not $sysvolAccessible) {
+          Add-Issue 'medium' 'AD/SYSVOL' 'Domain shares unreachable (DFS/DNS/auth).' $adSysvolEvidence
+        }
+
+      $timeUnsynced = $false
+      if ($timeStatusExit -and $timeStatusExit -notin @('0','0x0')) { $timeUnsynced = $true }
+      if ($timeErrors -and $timeErrors.Count -gt 0) { $timeUnsynced = $true }
+      if ($timeSource -and $timeSource -match '(?i)local cmos clock|free-running|local machine clock') { $timeUnsynced = $true }
+
+      if ($timeOffsetSeconds -ne $null -and [math]::Abs($timeOffsetSeconds) -gt 300) {
+        Add-Issue 'high' 'AD/Time' ("Kerberos time skew: offset {0}s (source {1})." -f [math]::Round($timeOffsetSeconds,2), (if ($timeSource) { $timeSource } else { 'Unknown' })) $adTimeEvidence
+        $adTimeSkewHigh = $true
+      } elseif ($timeUnsynced) {
+        Add-Issue 'high' 'AD/Time' 'Kerberos time skew: time service unsynchronized.' $adTimeEvidence
+        $adTimeSkewHigh = $true
+        } elseif ($timeOffsetSeconds -ne $null -and [math]::Abs($timeOffsetSeconds) -le 300 -and -not $timeUnsynced) {
+          Add-Normal 'AD/Time' 'GOOD Time (skew ≤5m).' $adTimeEvidence
+        }
+
+      $secureChannelBroken = $false
+      if ($secureChannelResult -eq $false) { $secureChannelBroken = $true }
+      if ($secureChannelNltestExit -and $secureChannelNltestExit -notin @('0','0x0')) { $secureChannelBroken = $true }
+      if ($secureChannelNltestFailure) { $secureChannelBroken = $true }
+
+      if ($secureChannelBroken) {
+        Add-Issue 'high' 'AD/SecureChannel' 'Broken machine secure channel.' $adSecureEvidence
+        $adConnectivityRootCause = $true
+      } elseif ($secureChannelResult -eq $true -and -not $secureChannelNltestFailure) {
+        Add-Normal 'AD/SecureChannel' 'GOOD SecureChannel (verified).' $adSecureEvidence
+      }
+
+        if ($kerberosFailureCount -gt 0) {
+          $kerberosSeverity = if ($kerberosFailureCount -ge 10) { 'high' } else { 'medium' }
+          if ($adConnectivityRootCause -or ($portsAnyAttempt -and -not $portsAnySuccess)) { $kerberosSeverity = 'medium' }
+          $kerberosMessage = "Kerberos failures ({0} recent 4768/4771/4776 events)." -f $kerberosFailureCount
+          if ($kerberosSkewCount -gt 0) {
+            $kerberosMessage += ' Includes KRB_AP_ERR_SKEW.'
+          }
+          if ($adTimeSkewHigh -and $kerberosSeverity -eq 'high') { $kerberosSeverity = 'medium' }
+          if ($adTimeSkewHigh -and ($kerberosMessage -notmatch 'Related to time skew')) { $kerberosMessage += ' Related to time skew.' }
+          Add-Issue $kerberosSeverity 'AD/Kerberos' $kerberosMessage $kerberosEvidence
+        } elseif (-not $kerberosTgtPresent) {
+          $severity = 'medium'
+          Add-Issue $severity 'AD/Kerberos' 'No TGT cached; device may be offline from the domain.' $kerberosEvidence
+        }
+
+      if ($gpoEventCount -gt 0 -or $gpFailureDetected) {
+          $gpoSeverity = if ($gpoEventCount -ge 5 -and -not $sysvolAccessible) { 'high' } else { 'medium' }
+          if ($adConnectivityRootCause -and $gpoSeverity -eq 'high') { $gpoSeverity = 'medium' }
+          if ($adTimeSkewHigh -and $gpoSeverity -eq 'high') { $gpoSeverity = 'medium' }
+          $gpoMessage = "Group Policy errors detected ({0} recent 1058/1030 events)." -f $gpoEventCount
+          if ($adTimeSkewHigh) { $gpoMessage += ' Related to time skew.' }
+          Add-Issue $gpoSeverity 'AD/GPO' $gpoMessage $adGpoEvidence
+        } elseif ($gpSuccessDetected) {
+        Add-Normal 'AD/GPO' 'GOOD GPO (processed successfully).' $adGpoEvidence
+      }
+    }
+  }
+
+}

--- a/AutoL1/Collectors/ActiveDirectory/Collect-ADDCDiscovery.ps1
+++ b/AutoL1/Collectors/ActiveDirectory/Collect-ADDCDiscovery.ps1
@@ -1,0 +1,137 @@
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+function Invoke-ADDomainControllerDiscovery {
+  param(
+    [pscustomobject]$Context
+  )
+
+  $ctx = if ($PSBoundParameters.ContainsKey('Context') -and $Context) { $Context } else { Get-ADCollectorContext }
+
+  Write-Output ("Timestamp : {0:o}" -f (Get-Date))
+  $partText = if ($null -eq $ctx.PartOfDomain) { 'Unknown' } else { [string]$ctx.PartOfDomain }
+  Write-Output ("PartOfDomain : {0}" -f $partText)
+  if ($ctx.DomainCandidates -and $ctx.DomainCandidates.Count -gt 0) {
+    Write-Output ("DomainCandidates : {0}" -f ($ctx.DomainCandidates -join ', '))
+  } else {
+    Write-Output "DomainCandidates : (none)"
+  }
+  if ($ctx.ForestCandidates -and $ctx.ForestCandidates.Count -gt 0) {
+    Write-Output ("ForestCandidates : {0}" -f ($ctx.ForestCandidates -join ', '))
+  } else {
+    Write-Output "ForestCandidates : (none)"
+  }
+  if ($ctx.PartOfDomain -ne $true) {
+    Write-Output "Status : Skipped (NotDomainJoined)"
+    return
+  }
+
+  $domainList = $ctx.DomainCandidates
+  if (-not $domainList -or $domainList.Count -eq 0) {
+    Write-Output "Status : No domain candidates for discovery."
+    return
+  }
+
+  foreach ($domain in $domainList) {
+    Write-Output ("## nltest /dsgetdc:{0}" -f $domain)
+    $dsOutput = nltest /dsgetdc:$domain 2>&1
+    $dsExit = $LASTEXITCODE
+    Write-Output ("NLTEST.DSGETDC.Result : {0} | Domain={1} | ExitCode={2}" -f (if ($dsExit -eq 0) { 'Success' } else { 'Failure' }), $domain, $dsExit)
+    if ($dsOutput) { $dsOutput | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+    $lastDcName = $null
+    foreach ($line in $dsOutput) {
+      if ($line -match '^\s*DC:\s*\\(?<dc>[^\s]+)') {
+        $lastDcName = Normalize-HostName $matches['dc']
+        $dcFqdn = ConvertTo-Fqdn $lastDcName $ctx.DomainDnsName
+        $record = if ($dcFqdn) { $dcFqdn } else { $lastDcName }
+        if ($record) { Write-Output ("DiscoveredDC : {0} | Source=nltest /dsgetdc | Domain={1}" -f $record, $domain) }
+      } elseif ($line -match '^\s*Address:\s*\\(?<addr>[^\s]+)') {
+        $addr = $matches['addr'].Trim('\\').Trim()
+        if ($addr -and $lastDcName) {
+          $dcForAddr = ConvertTo-Fqdn $lastDcName $ctx.DomainDnsName
+          $addressTarget = if ($dcForAddr) { $dcForAddr } else { $lastDcName }
+          Write-Output ("DiscoveredDCAddress : {0} | Domain={1} | DC={2}" -f $addr, $domain, $addressTarget)
+        }
+      } elseif ($line -match '^\s*Forest Name:\s*(?<forest>\S.*)$') {
+        $forestName = Normalize-DomainName $matches['forest']
+        if ($forestName) { Write-Output ("DiscoveredForest : {0} | Source=nltest /dsgetdc | Domain={1}" -f $forestName, $domain) }
+      } elseif ($line -match '^\s*Site Name:\s*(?<site>\S.*)$') {
+        Write-Output ("SiteName : {0} | Domain={1}" -f $matches['site'].Trim(), $domain)
+      }
+    }
+    Write-Output ""
+
+    Write-Output ("## nltest /dclist:{0}" -f $domain)
+    $dcList = nltest /dclist:$domain 2>&1
+    $dcListExit = $LASTEXITCODE
+    Write-Output ("NLTEST.DCLIST.Result : {0} | Domain={1} | ExitCode={2}" -f (if ($dcListExit -eq 0) { 'Success' } else { 'Failure' }), $domain, $dcListExit)
+    if ($dcList) { $dcList | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+    foreach ($line in $dcList) {
+      if ($line -match '^\s*(?<name>[A-Za-z0-9\-\.]+)(?:\s*\(.*\))?$') {
+        $candidate = $matches['name']
+        if ($candidate -and $candidate -notmatch '^(Get|The|List|of|Domain|domain|from|completed|successfully)$') {
+          $fqdnCandidate = ConvertTo-Fqdn $candidate $ctx.DomainDnsName
+          $recorded = if ($fqdnCandidate) { $fqdnCandidate } else { Normalize-HostName $candidate }
+          if ($recorded) { Write-Output ("DiscoveredDC : {0} | Source=nltest /dclist | Domain={1}" -f $recorded, $domain) }
+        }
+      }
+    }
+    Write-Output ""
+  }
+
+  $forestNames = if ($ctx.ForestCandidates -and $ctx.ForestCandidates.Count -gt 0) { $ctx.ForestCandidates } else { $ctx.DomainCandidates }
+  if (-not $forestNames) { $forestNames = @() }
+  $resolveCmd = Get-Command Resolve-DnsName -ErrorAction SilentlyContinue
+  foreach ($forest in $forestNames) {
+    foreach ($srvName in @("_ldap._tcp.dc._msdcs.$forest", "_kerberos._tcp.$forest")) {
+      if (-not $resolveCmd) {
+        Write-Output ("SRVLookup : {0} | Status=CmdUnavailable" -f $srvName)
+        Write-Output ""
+        continue
+      }
+      try {
+        $srvResults = Resolve-DnsName -Name $srvName -Type SRV -ErrorAction Stop
+        if (-not $srvResults) {
+          Write-Output ("SRVLookup : {0} | Status=NoRecords" -f $srvName)
+        } else {
+          $count = $srvResults.Count
+          Write-Output ("SRVLookup : {0} | Status=Success | Count={1}" -f $srvName, $count)
+          foreach ($record in $srvResults) {
+            $target = if ($record.NameTarget) { $record.NameTarget.TrimEnd('.') } else { $null }
+            $addresses = @()
+            if ($target) {
+              try {
+                $addresses = [System.Net.Dns]::GetHostAddresses($target) | ForEach-Object { $_.IPAddressToString }
+              } catch {
+                $addresses = @()
+              }
+            }
+            $addressText = if ($addresses -and $addresses.Count -gt 0) { $addresses -join ', ' } else { '' }
+            Write-Output ("SRVRecord : {0} | Target={1} | Port={2} | Priority={3} | Weight={4} | Addresses={5}" -f $srvName, $target, $record.Port, $record.Priority, $record.Weight, $addressText)
+            if ($target) {
+              Write-Output ("DiscoveredDC : {0} | Source={1} | Domain={2}" -f $target, $srvName, $forest)
+            }
+          }
+        }
+      } catch {
+        Write-Output ("SRVLookup : {0} | Status=Error | Error={1}" -f $srvName, $_)
+      }
+      Write-Output ""
+    }
+  }
+
+  try {
+    Write-Output "## nltest /dsgetsite"
+    $siteResult = nltest /dsgetsite 2>&1
+    if ($siteResult) { $siteResult | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+  } catch {
+    Write-Output ("nltest /dsgetsite failed: {0}" -f $_)
+  }
+  Write-Output ""
+  try {
+    Write-Output "## nltest /domain_trusts"
+    $trustResult = nltest /domain_trusts 2>&1
+    if ($trustResult) { $trustResult | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+  } catch {
+    Write-Output ("nltest /domain_trusts failed: {0}" -f $_)
+  }
+}

--- a/AutoL1/Collectors/ActiveDirectory/Collect-ADDCPorts.ps1
+++ b/AutoL1/Collectors/ActiveDirectory/Collect-ADDCPorts.ps1
@@ -1,0 +1,81 @@
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+function Invoke-ADDomainControllerPortTests {
+  param(
+    [pscustomobject]$Context
+  )
+
+  $ctx = if ($PSBoundParameters.ContainsKey('Context') -and $Context) { $Context } else { Get-ADCollectorContext }
+
+  Write-Output ("Timestamp : {0:o}" -f (Get-Date))
+  $partText = if ($null -eq $ctx.PartOfDomain) { 'Unknown' } else { [string]$ctx.PartOfDomain }
+  Write-Output ("PartOfDomain : {0}" -f $partText)
+  if ($ctx.PartOfDomain -ne $true) {
+    Write-Output "Status : Skipped (NotDomainJoined)"
+    return
+  }
+
+  if ($ctx.DomainCandidates -and $ctx.DomainCandidates.Count -gt 0) {
+    Write-Output ("DomainCandidates : {0}" -f ($ctx.DomainCandidates -join ', '))
+  } else {
+    Write-Output "DomainCandidates : (none)"
+  }
+
+  $dcSet = [System.Collections.Generic.HashSet[string]]::new()
+  $domainList = $ctx.DomainCandidates
+  foreach ($domain in $domainList) {
+    $dsOutput = nltest /dsgetdc:$domain 2>&1
+    foreach ($line in $dsOutput) {
+      if ($line -match '^\s*DC:\s*\\(?<dc>[^\s]+)') {
+        $dcName = ConvertTo-Fqdn $matches['dc'] $ctx.DomainDnsName
+        if ($dcName) { $null = $dcSet.Add($dcName) }
+      }
+    }
+    $dcList = nltest /dclist:$domain 2>&1
+    foreach ($line in $dcList) {
+      if ($line -match '^\s*(?<name>[A-Za-z0-9\-\.]+)(?:\s*\(.*\))?$') {
+        $candidate = $matches['name']
+        if ($candidate -and $candidate -notmatch '^(Get|The|List|of|Domain|domain|from|completed|successfully)$') {
+          $fqdnCandidate = ConvertTo-Fqdn $candidate $ctx.DomainDnsName
+          if ($fqdnCandidate) { $null = $dcSet.Add($fqdnCandidate) }
+        }
+      }
+    }
+  }
+
+  $dcListFinal = @($dcSet) | Sort-Object
+  if (-not $dcListFinal -or $dcListFinal.Count -eq 0) {
+    Write-Output "CandidateDCs : (none)"
+    return
+  }
+
+  Write-Output ("CandidateDCs : {0}" -f ($dcListFinal -join ', '))
+  $testCmd = Get-Command Test-NetConnection -ErrorAction SilentlyContinue
+  if (-not $testCmd) {
+    Write-Output "Status : Test-NetConnection unavailable"
+    return
+  }
+
+  $ports = @(88, 389, 445, 135)
+  foreach ($dc in $dcListFinal) {
+    Write-Output ("PortTestTarget : {0}" -f $dc)
+    foreach ($port in $ports) {
+      try {
+        $result = Test-NetConnection -ComputerName $dc -Port $port -WarningAction SilentlyContinue -ErrorAction Stop
+        $tcp = if ($result.TcpTestSucceeded) { $result.TcpTestSucceeded } else { $false }
+        $addr = $null
+        if ($result.RemoteAddress) {
+          if ($result.RemoteAddress -is [System.Net.IPAddress]) {
+            $addr = $result.RemoteAddress.IPAddressToString
+          } else {
+            $addr = [string]$result.RemoteAddress
+          }
+        }
+        Write-Output ("PortResult : {0}| Port={1} | Success={2} | RemoteAddress={3}" -f $dc, $port, $tcp, (if ($addr) { $addr } else { '' }))
+      } catch {
+        Write-Output ("PortResult : {0}| Port={1} | Success=Error | Error={2}" -f $dc, $port, $_)
+      }
+    }
+    Write-Output ""
+  }
+}

--- a/AutoL1/Collectors/ActiveDirectory/Collect-ADDomainStatus.ps1
+++ b/AutoL1/Collectors/ActiveDirectory/Collect-ADDomainStatus.ps1
@@ -1,0 +1,44 @@
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+function Invoke-ADDomainStatusCollection {
+  param(
+    [pscustomobject]$Context
+  )
+
+  $ctx = if ($PSBoundParameters.ContainsKey('Context') -and $Context) { $Context } else { Get-ADCollectorContext }
+
+  Write-Output ("Timestamp : {0:o}" -f (Get-Date))
+  Write-Output ("ComputerName : {0}" -f $ctx.ComputerName)
+  $partText = if ($null -eq $ctx.PartOfDomain) { 'Unknown' } else { [string]$ctx.PartOfDomain }
+  Write-Output ("PartOfDomain : {0}" -f $partText)
+  if ($ctx.Domain) { Write-Output ("Domain : {0}" -f $ctx.Domain) }
+  if ($ctx.DomainDnsName) { Write-Output ("DomainDnsName : {0}" -f $ctx.DomainDnsName) }
+  if ($ctx.DomainCandidates -and $ctx.DomainCandidates.Count -gt 0) {
+    Write-Output ("DomainCandidates : {0}" -f ($ctx.DomainCandidates -join ', '))
+  } else {
+    Write-Output "DomainCandidates : (none)"
+  }
+  if ($ctx.ForestCandidates -and $ctx.ForestCandidates.Count -gt 0) {
+    Write-Output ("ForestCandidates : {0}" -f ($ctx.ForestCandidates -join ', '))
+  } else {
+    Write-Output "ForestCandidates : (none)"
+  }
+  if ($ctx.UserDnsDomain) { Write-Output ("USERDNSDOMAIN : {0}" -f $ctx.UserDnsDomain) }
+  if ($ctx.UserDomain) { Write-Output ("USERDOMAIN : {0}" -f $ctx.UserDomain) }
+  if ($ctx.LogonServer) { Write-Output ("LOGONSERVER : {0}" -f $ctx.LogonServer) }
+  if ($ctx.Errors -and $ctx.Errors.Count -gt 0) {
+    foreach ($err in $ctx.Errors) { Write-Output $err }
+  }
+  if ($ctx.PartOfDomain) {
+    try {
+      $root = [ADSI]'LDAP://RootDSE'
+      if ($root) {
+        if ($root.defaultNamingContext) { Write-Output ("DefaultNamingContext : {0}" -f $root.defaultNamingContext) }
+        if ($root.rootDomainNamingContext) { Write-Output ("RootDomainNamingContext : {0}" -f $root.rootDomainNamingContext) }
+        if ($root.configurationNamingContext) { Write-Output ("ConfigurationNamingContext : {0}" -f $root.configurationNamingContext) }
+      }
+    } catch {
+      Write-Output ("RootDSEError : {0}" -f $_)
+    }
+  }
+}

--- a/AutoL1/Collectors/ActiveDirectory/Collect-ADGpo.ps1
+++ b/AutoL1/Collectors/ActiveDirectory/Collect-ADGpo.ps1
@@ -1,0 +1,57 @@
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+function Invoke-ADGpoCollection {
+  param(
+    [pscustomobject]$Context
+  )
+
+  $ctx = if ($PSBoundParameters.ContainsKey('Context') -and $Context) { $Context } else { Get-ADCollectorContext }
+
+  Write-Output ("Timestamp : {0:o}" -f (Get-Date))
+  $partText = if ($null -eq $ctx.PartOfDomain) { 'Unknown' } else { [string]$ctx.PartOfDomain }
+  Write-Output ("PartOfDomain : {0}" -f $partText)
+  if ($ctx.PartOfDomain -ne $true) {
+    Write-Output "Status : Skipped (NotDomainJoined)"
+    return
+  }
+
+  Write-Output "## gpresult /r /scope computer"
+  try {
+    $gpComputer = gpresult /r /scope computer 2>&1
+    $gpComputerExit = $LASTEXITCODE
+  } catch {
+    $gpComputer = @("gpresult /r /scope computer failed: {0}" -f $_)
+    $gpComputerExit = -1
+  }
+  if ($gpComputer) { $gpComputer | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+  Write-Output ("GPResultComputerExitCode : {0}" -f $gpComputerExit)
+  Write-Output ""
+
+  Write-Output "## gpresult /r /scope user"
+  try {
+    $gpUser = gpresult /r /scope user 2>&1
+    $gpUserExit = $LASTEXITCODE
+  } catch {
+    $gpUser = @("gpresult /r /scope user failed: {0}" -f $_)
+    $gpUserExit = -1
+  }
+  if ($gpUser) { $gpUser | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+  Write-Output ("GPResultUserExitCode : {0}" -f $gpUserExit)
+  Write-Output ""
+
+  $startTime = (Get-Date).AddHours(-72)
+  try {
+    $gpoEvents = Get-WinEvent -FilterHashtable @{ LogName='System'; Id=@(1058,1030); StartTime=$startTime } -ErrorAction Stop
+    $count = if ($gpoEvents) { $gpoEvents.Count } else { 0 }
+    Write-Output ("GPOEventCount : {0}" -f $count)
+    if ($gpoEvents) {
+      $sorted = $gpoEvents | Sort-Object TimeCreated -Descending | Select-Object -First 25
+      foreach ($ev in $sorted) {
+        $msg = ($ev.Message -replace "[\r\n]+", ' ').Trim()
+        Write-Output ("GPOEvent : Id={0}; Time={1:o}; Provider={2}; Message={3}" -f $ev.Id, $ev.TimeCreated, $ev.ProviderName, $msg)
+      }
+    }
+  } catch {
+    Write-Output ("GPOEventError : {0}" -f $_)
+  }
+}

--- a/AutoL1/Collectors/ActiveDirectory/Collect-ADKerberos.ps1
+++ b/AutoL1/Collectors/ActiveDirectory/Collect-ADKerberos.ps1
@@ -1,0 +1,36 @@
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+function Invoke-ADKerberosCollection {
+  param(
+    [pscustomobject]$Context
+  )
+
+  $ctx = if ($PSBoundParameters.ContainsKey('Context') -and $Context) { $Context } else { Get-ADCollectorContext }
+
+  Write-Output ("Timestamp : {0:o}" -f (Get-Date))
+  $partText = if ($null -eq $ctx.PartOfDomain) { 'Unknown' } else { [string]$ctx.PartOfDomain }
+  Write-Output ("PartOfDomain : {0}" -f $partText)
+  Write-Output "## klist"
+  try {
+    $klistOutput = klist 2>&1
+    if ($klistOutput) { $klistOutput | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+  } catch {
+    Write-Output ("klist failed: {0}" -f $_)
+  }
+  Write-Output ""
+  $startTime = (Get-Date).AddHours(-72)
+  try {
+    $events = Get-WinEvent -FilterHashtable @{ LogName='Security'; Id=@(4768,4771,4776); StartTime=$startTime } -ErrorAction Stop
+    $count = if ($events) { $events.Count } else { 0 }
+    Write-Output ("KerberosEventCount : {0}" -f $count)
+    if ($events) {
+      $sorted = $events | Sort-Object TimeCreated -Descending | Select-Object -First 25
+      foreach ($ev in $sorted) {
+        $msg = ($ev.Message -replace "[\r\n]+", ' ').Trim()
+        Write-Output ("KerberosEvent : Id={0}; Time={1:o}; Provider={2}; Message={3}" -f $ev.Id, $ev.TimeCreated, $ev.ProviderName, $msg)
+      }
+    }
+  } catch {
+    Write-Output ("KerberosEventError : {0}" -f $_)
+  }
+}

--- a/AutoL1/Collectors/ActiveDirectory/Collect-ADSecureChannel.ps1
+++ b/AutoL1/Collectors/ActiveDirectory/Collect-ADSecureChannel.ps1
@@ -1,0 +1,52 @@
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+function Invoke-ADSecureChannelCollection {
+  param(
+    [pscustomobject]$Context
+  )
+
+  $ctx = if ($PSBoundParameters.ContainsKey('Context') -and $Context) { $Context } else { Get-ADCollectorContext }
+
+  Write-Output ("Timestamp : {0:o}" -f (Get-Date))
+  $partText = if ($null -eq $ctx.PartOfDomain) { 'Unknown' } else { [string]$ctx.PartOfDomain }
+  Write-Output ("PartOfDomain : {0}" -f $partText)
+  if ($ctx.PartOfDomain -ne $true) {
+    Write-Output "Status : Skipped (NotDomainJoined)"
+    return
+  }
+
+  try {
+    $scResult = Test-ComputerSecureChannel -ErrorAction Stop
+    Write-Output ("SecureChannelResult : {0}" -f $scResult)
+  } catch {
+    Write-Output "SecureChannelResult : Error"
+    Write-Output ("SecureChannelError : {0}" -f $_)
+  }
+
+  $queryTarget = $null
+  if ($ctx.DomainDnsName) {
+    $queryTarget = $ctx.DomainDnsName
+  } elseif ($ctx.Domain) {
+    $queryTarget = $ctx.Domain
+  } elseif ($ctx.DomainCandidates -and $ctx.DomainCandidates.Count -gt 0) {
+    $queryTarget = $ctx.DomainCandidates[0]
+  }
+
+  Write-Output ("SecureChannelQueryTarget : {0}" -f (if ($queryTarget) { $queryTarget } else { '(unknown)' }))
+  if ($queryTarget) {
+    try {
+      $nlOutput = nltest /sc_query:$queryTarget 2>&1
+      $nlExit = $LASTEXITCODE
+    } catch {
+      $nlOutput = @("nltest /sc_query failed: {0}" -f $_)
+      $nlExit = -1
+    }
+  } else {
+    $nlOutput = @("nltest /sc_query skipped: domain unknown")
+    $nlExit = -1
+  }
+
+  Write-Output ("SecureChannelNltestExitCode : {0}" -f $nlExit)
+  Write-Output "## nltest /sc_query"
+  if ($nlOutput) { $nlOutput | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+}

--- a/AutoL1/Collectors/ActiveDirectory/Collect-ADSysvol.ps1
+++ b/AutoL1/Collectors/ActiveDirectory/Collect-ADSysvol.ps1
@@ -1,0 +1,60 @@
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+function Invoke-ADSysvolCollection {
+  param(
+    [pscustomobject]$Context
+  )
+
+  $ctx = if ($PSBoundParameters.ContainsKey('Context') -and $Context) { $Context } else { Get-ADCollectorContext }
+
+  Write-Output ("Timestamp : {0:o}" -f (Get-Date))
+  $partText = if ($null -eq $ctx.PartOfDomain) { 'Unknown' } else { [string]$ctx.PartOfDomain }
+  Write-Output ("PartOfDomain : {0}" -f $partText)
+  if ($ctx.PartOfDomain -ne $true) {
+    Write-Output "Status : Skipped (NotDomainJoined)"
+    return
+  }
+
+  $domainFqdn = $null
+  if ($ctx.DomainDnsName) { $domainFqdn = $ctx.DomainDnsName }
+  elseif ($ctx.UserDnsDomain) { $domainFqdn = $ctx.UserDnsDomain }
+  elseif ($ctx.Domain) { $domainFqdn = $ctx.Domain }
+
+  if (-not $domainFqdn) {
+    Write-Output "DomainFqdn : (unknown)"
+    return
+  }
+
+  Write-Output ("DomainFqdn : {0}" -f $domainFqdn)
+  $paths = @(
+    @{ Label = 'SYSVOL'; Path = "\\$domainFqdn\SYSVOL" },
+    @{ Label = 'NETLOGON'; Path = "\\$domainFqdn\NETLOGON" }
+  )
+
+  foreach ($entry in $paths) {
+    $label = $entry.Label
+    $path = $entry.Path
+    Write-Output ("SharePath : {0} | Path={1}" -f $label, $path)
+    try {
+      $exists = Test-Path -Path $path -PathType Container -ErrorAction Stop
+      Write-Output ("ShareExists : {0} | Path={1} | Exists={2}" -f $label, $path, $exists)
+      if ($exists) {
+        try {
+          $items = Get-ChildItem -Path $path -ErrorAction Stop | Select-Object -First 10
+          if ($items) {
+            $names = $items | ForEach-Object { $_.Name }
+            Write-Output ("ShareSample : {0} | Items={1}" -f $label, ($names -join ', '))
+          } else {
+            Write-Output ("ShareSample : {0} | Items=(empty)" -f $label)
+          }
+        } catch {
+          Write-Output ("ShareSampleError : {0} | Error={1}" -f $label, $_)
+        }
+      }
+    } catch {
+      Write-Output ("ShareExists : {0} | Path={1} | Exists=Error" -f $label, $path)
+      Write-Output ("ShareError : {0} | Error={1}" -f $label, $_)
+    }
+    Write-Output ""
+  }
+}

--- a/AutoL1/Collectors/ActiveDirectory/Collect-ADTime.ps1
+++ b/AutoL1/Collectors/ActiveDirectory/Collect-ADTime.ps1
@@ -1,0 +1,44 @@
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+function Invoke-ADTimeCollection {
+  param(
+    [pscustomobject]$Context
+  )
+
+  $ctx = if ($PSBoundParameters.ContainsKey('Context') -and $Context) { $Context } else { Get-ADCollectorContext }
+
+  Write-Output ("Timestamp : {0:o}" -f (Get-Date))
+  $partText = if ($null -eq $ctx.PartOfDomain) { 'Unknown' } else { [string]$ctx.PartOfDomain }
+  Write-Output ("PartOfDomain : {0}" -f $partText)
+
+  try {
+    $status = w32tm /query /status 2>&1
+    $statusExit = $LASTEXITCODE
+  } catch {
+    $status = @("w32tm /query /status failed: {0}" -f $_)
+    $statusExit = -1
+  }
+  Write-Output "## w32tm /query /status"
+  if ($status) { $status | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+  Write-Output ("StatusExitCode : {0}" -f $statusExit)
+  if ($status) {
+    $statusText = ($status -join "`n")
+    $offsetMatch = [regex]::Match($statusText,'(?im)^(?:Phase Offset|Offset)\s*:\s*([+-]?[0-9\.]+)s')
+    if ($offsetMatch.Success) { Write-Output ("PhaseOffsetSeconds : {0}" -f $offsetMatch.Groups[1].Value.Trim()) }
+    $sourceMatch = [regex]::Match($statusText,'(?im)^\s*Source\s*:\s*(.+)$')
+    if ($sourceMatch.Success) { Write-Output ("TimeSource : {0}" -f $sourceMatch.Groups[1].Value.Trim()) }
+    $lastSyncMatch = [regex]::Match($statusText,'(?im)^\s*Last Successful Sync Time\s*:\s*(.+)$')
+    if ($lastSyncMatch.Success) { Write-Output ("LastSuccessfulSync : {0}" -f $lastSyncMatch.Groups[1].Value.Trim()) }
+  }
+  Write-Output ""
+  try {
+    $peers = w32tm /query /peers 2>&1
+    $peersExit = $LASTEXITCODE
+  } catch {
+    $peers = @("w32tm /query /peers failed: {0}" -f $_)
+    $peersExit = -1
+  }
+  Write-Output "## w32tm /query /peers"
+  if ($peers) { $peers | ForEach-Object { Write-Output $_ } } else { Write-Output "(no output)" }
+  Write-Output ("PeersExitCode : {0}" -f $peersExit)
+}

--- a/AutoL1/Collectors/ActiveDirectory/Common.ps1
+++ b/AutoL1/Collectors/ActiveDirectory/Common.ps1
@@ -1,0 +1,113 @@
+<#
+  Common helpers for Active Directory collectors.
+#>
+
+function Normalize-DomainName {
+  param([string]$Name)
+
+  if (-not $Name) { return $null }
+  $trimmed = $Name.Trim()
+  if (-not $trimmed) { return $null }
+  return $trimmed.TrimEnd('.').ToLowerInvariant()
+}
+
+function Normalize-HostName {
+  param([string]$Name)
+
+  if (-not $Name) { return $null }
+  $result = $Name.Trim()
+  if (-not $result) { return $null }
+  $result = $result.Trim('\\')
+  if (-not $result) { return $null }
+  if ($result -like '*\\*') {
+    $segments = $result -split '\\'
+    $result = $segments[-1]
+  }
+  return $result.Trim().ToLowerInvariant()
+}
+
+function ConvertTo-Fqdn {
+  param(
+    [string]$Host,
+    [string]$Domain
+  )
+
+  $normalizedHost = Normalize-HostName $Host
+  if (-not $normalizedHost) { return $null }
+  if ($normalizedHost.Contains('.')) { return $normalizedHost }
+
+  $normalizedDomain = Normalize-DomainName $Domain
+  if ($normalizedDomain) {
+    return ("{0}.{1}" -f $normalizedHost, $normalizedDomain)
+  }
+
+  return $normalizedHost
+}
+
+function Get-ADCollectorContext {
+  $ctx = [ordered]@{
+    ComputerName     = $env:COMPUTERNAME
+    Timestamp        = Get-Date
+    PartOfDomain     = $null
+    Domain           = $null
+    DomainDnsName    = $null
+    DomainCandidates = @()
+    ForestCandidates = @()
+    UserDnsDomain    = if ($env:USERDNSDOMAIN) { $env:USERDNSDOMAIN } else { $null }
+    UserDomain       = if ($env:USERDOMAIN) { $env:USERDOMAIN } else { $null }
+    LogonServer      = if ($env:LOGONSERVER) { $env:LOGONSERVER } else { $null }
+    Errors           = @()
+  }
+
+  try {
+    $cs = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
+    if ($null -ne $cs.PartOfDomain) { $ctx.PartOfDomain = [bool]$cs.PartOfDomain }
+    if ($cs.Domain) { $ctx.Domain = $cs.Domain.Trim() }
+    if ($cs.Domain) { $ctx.DomainCandidates += $cs.Domain.Trim() }
+  } catch {
+    $ctx.Errors += ("ComputerSystemError : {0}" -f $_)
+  }
+
+  if ($ctx.UserDnsDomain) { $ctx.DomainCandidates += $ctx.UserDnsDomain }
+
+  $domainSet = [System.Collections.Generic.HashSet[string]]::new()
+  foreach ($candidate in $ctx.DomainCandidates) {
+    $normalized = Normalize-DomainName $candidate
+    if ($normalized) { $null = $domainSet.Add($normalized) }
+  }
+  $ctx.DomainCandidates = @($domainSet) | Sort-Object -Unique
+
+  if ($ctx.PartOfDomain) {
+    try {
+      $domainObj = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain()
+      if ($domainObj) {
+        if ($domainObj.Name) { $ctx.DomainDnsName = $domainObj.Name.Trim() }
+        if ($domainObj.Forest -and $domainObj.Forest.Name) {
+          $ctx.ForestCandidates += $domainObj.Forest.Name.Trim()
+        }
+      }
+    } catch {
+      $ctx.Errors += ("GetComputerDomainError : {0}" -f $_)
+    }
+
+    try {
+      $forestObj = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+      if ($forestObj -and $forestObj.Name) { $ctx.ForestCandidates += $forestObj.Name.Trim() }
+    } catch {
+      $ctx.Errors += ("GetCurrentForestError : {0}" -f $_)
+    }
+  }
+
+  $forestSet = [System.Collections.Generic.HashSet[string]]::new()
+  foreach ($candidate in $ctx.ForestCandidates + $ctx.DomainCandidates) {
+    $normalizedForest = Normalize-DomainName $candidate
+    if ($normalizedForest) { $null = $forestSet.Add($normalizedForest) }
+  }
+  $ctx.ForestCandidates = @($forestSet) | Sort-Object -Unique
+
+  if (-not $ctx.DomainDnsName -and $ctx.DomainCandidates.Count -gt 0) {
+    $ctx.DomainDnsName = $ctx.DomainCandidates[0]
+  }
+
+  return [pscustomobject]$ctx
+}


### PR DESCRIPTION
## Summary
- load Active Directory collector helpers from a dedicated folder and call modular functions for each domain health capture step
- add standalone PowerShell scripts under Collectors/ActiveDirectory to gather domain status, discovery, port tests, SYSVOL, time, Kerberos, secure channel, and GPO evidence
- expose the Active Directory heuristics logic through a new Analyzers/ActiveDirectory module and invoke it from the main analyzer script

## Testing
- not run (Windows-specific PowerShell cmdlets unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d41ad2505c832d8c6e45eb5062b52d