### PR TITLE
Fix printer name addition in diagnostic analysis

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -4551,7 +4551,13 @@ if ($printingPayload) {
         Printers = New-Object System.Collections.Generic.List[string]
       }
     }
-    $driverMap[$driverName].Printers.Add(if ($printer.PSObject.Properties['Name']) { [string]$printer.Name } else { '(unknown printer)' })
+    $printerName = if ($printer.PSObject.Properties['Name']) {
+      [string]$printer.Name
+    }
+    else {
+      '(unknown printer)'
+    }
+    $driverMap[$driverName].Printers.Add($printerName)
   }
 
   $legacyDrivers = @()


### PR DESCRIPTION
## Summary
- extract printer name before adding it to the driver map's printer list
- ensure fallback text is added without syntax errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5587dfd54832db283a141fff01d64