### PR TITLE
Fix printer name addition in diagnostic analysis

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -4551,7 +4551,13 @@ if ($printingPayload) {
         Printers = New-Object System.Collections.Generic.List[string]
       }
     }
-    $driverMap[$driverName].Printers.Add(if ($printer.PSObject.Properties['Name']) { [string]$printer.Name } else { '(unknown printer)' })
+    $printerName = if ($printer.PSObject.Properties['Name']) {
+      [string]$printer.Name
+    }
+    else {
+      '(unknown printer)'
+    }
+    $driverMap[$driverName].Printers.Add($printerName)
   }
 
   $legacyDrivers = @()
@@ -4655,7 +4661,11 @@ if ($printingPayload) {
       if ($successValue -eq $true) { $anySuccess = $true }
       $statusText = if ($successValue -eq $true) { 'OK' } elseif ($successValue -eq $false) { 'Fail' } else { 'Unknown' }
       $testName = if ($test.PSObject.Properties['Name']) { [string]$test.Name } else { 'Test' }
-      if ($test.PSObject.Properties['Port'] -and $test.Port) { $testSummaries += "$testName:$statusText(port=$($test.Port))" } else { $testSummaries += "$testName:$statusText" }
+      if ($test.PSObject.Properties['Port'] -and $test.Port) {
+        $testSummaries += "${testName}:${statusText}(port=$($test.Port))"
+      } else {
+        $testSummaries += "${testName}:${statusText}"
+      }
     }
     $networkEvidenceLines += ("{0} ({1}) => {2}" -f (if ($hostName) { $hostName } else { 'Unknown host' }), $kind, ($testSummaries -join ', '))
     if (-not $anySuccess) {


### PR DESCRIPTION
## Summary
- extract printer name before adding it to the driver map's printer list
- ensure fallback text is added without syntax errors
- wrap network test name/status strings in braces to avoid scope parsing errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5587dfd54832db283a141fff01d64