### PR TITLE
Improve Kernel DMA diagnostics and analysis

### DIFF
--- a/Analyzers/System/KernelDMA.ps1
+++ b/Analyzers/System/KernelDMA.ps1
@@ -1,0 +1,158 @@
+<#!
+.SYNOPSIS
+    Analyzes Kernel DMA protection collector output and classifies policy health.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$InputFolder
+)
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
+
+function New-KernelDmaFinding {
+    param(
+        [string]$Check,
+        [string]$Severity,
+        [string]$Message,
+        [object]$Evidence = $null
+    )
+
+    return [pscustomobject]@{
+        Area     = 'System/Kernel DMA'
+        Check    = $Check
+        Severity = $Severity
+        Message  = $Message
+        Evidence = $Evidence
+    }
+}
+
+function Get-KernelDmaPayload {
+    param([string]$InputFolder)
+
+    $file = Get-ChildItem -Path $InputFolder -Filter 'kerneldma.json' -File -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $file) { return $null }
+
+    try {
+        $data = Get-Content -Path $file.FullName -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        return [pscustomobject]@{
+            Error = "Failed to parse $($file.FullName): $($_.Exception.Message)"
+            File  = $file.FullName
+        }
+    }
+
+    return [pscustomobject]@{
+        File    = $file.FullName
+        Payload = $data.Payload
+    }
+}
+
+$payloadResult = Get-KernelDmaPayload -InputFolder $InputFolder
+if (-not $payloadResult) { return @() }
+if ($payloadResult.PSObject.Properties['Error']) {
+    return @(New-KernelDmaFinding -Check 'Kernel DMA protection' -Severity 'warning' -Message $payloadResult.Error -Evidence ([ordered]@{ File = $payloadResult.File }))
+}
+
+$payload = $payloadResult.Payload
+if (-not $payload) {
+    return @(New-KernelDmaFinding -Check 'Kernel DMA protection' -Severity 'warning' -Message 'Kernel DMA payload missing from collector output.' -Evidence ([ordered]@{ File = $payloadResult.File }))
+}
+
+$deviceGuard = $payload.DeviceGuard
+$registry    = $payload.Registry
+$msInfo      = $payload.MsInfo
+
+$findings = @()
+
+if ($deviceGuard) {
+    $dgEvidence = [ordered]@{
+        Status  = $deviceGuard.Status
+        Message = $deviceGuard.Message
+    }
+    $dgEntry = $null
+    if ($deviceGuard.Entries) {
+        $dgEntry = $deviceGuard.Entries | Select-Object -First 1
+    }
+    if ($dgEntry) {
+        if ($dgEntry.PSObject.Properties['VirtualizationBasedSecurityStatus']) {
+            $dgEvidence.VirtualizationBasedSecurityStatus = $dgEntry.VirtualizationBasedSecurityStatus
+        }
+        if ($dgEntry.PSObject.Properties['SecurityServicesRunning']) {
+            $dgEvidence.SecurityServicesRunning = ($dgEntry.SecurityServicesRunning -join ',')
+        }
+        if ($dgEntry.PSObject.Properties['AvailableSecurityProperties']) {
+            $dgEvidence.AvailableSecurityProperties = ($dgEntry.AvailableSecurityProperties -join ',')
+        }
+        if ($dgEntry.PSObject.Properties['RequiredSecurityProperties']) {
+            $dgEvidence.RequiredSecurityProperties = ($dgEntry.RequiredSecurityProperties -join ',')
+        }
+    }
+
+    switch ($deviceGuard.Status) {
+        'Error' {
+            $findings += New-KernelDmaFinding -Check 'Device Guard state' -Severity 'warning' -Message "Unable to query Win32_DeviceGuard: $($deviceGuard.Message)" -Evidence $dgEvidence
+        }
+        'Info' {
+            $message = if ($deviceGuard.Message) { $deviceGuard.Message } else { 'Device Guard data not available.' }
+            $findings += New-KernelDmaFinding -Check 'Device Guard state' -Severity 'info' -Message $message -Evidence $dgEvidence
+        }
+        default {
+            $findings += New-KernelDmaFinding -Check 'Device Guard state' -Severity 'good' -Message 'Device Guard information collected successfully.' -Evidence $dgEvidence
+        }
+    }
+}
+
+$allowValue = $null
+if ($registry -and $registry.Values -and $registry.Values.PSObject.Properties['AllowDmaUnderLock']) {
+    $allowValue = $registry.Values.AllowDmaUnderLock
+}
+$allowInt = ConvertTo-NullableInt $allowValue
+
+$registryEvidence = [ordered]@{
+    Path   = if ($registry) { $registry.Path } else { $null }
+    Status = if ($registry) { $registry.Status } else { 'Missing' }
+    AllowDmaUnderLock = $allowValue
+}
+if ($registry -and $registry.Values) {
+    foreach ($property in $registry.Values.PSObject.Properties) {
+        if ($property.Name -eq 'AllowDmaUnderLock') { continue }
+        $registryEvidence[$property.Name] = $property.Value
+    }
+}
+
+if ($registry) {
+    switch ($registry.Status) {
+        'Error' {
+            $findings += New-KernelDmaFinding -Check 'Kernel DMA registry policy' -Severity 'warning' -Message "Unable to read KernelDMAProtection policy: $($registry.Message)" -Evidence $registryEvidence
+        }
+        'Info' {
+            $message = if ($registry.Message) { $registry.Message } else { 'Kernel DMA registry policy not present.' }
+            $findings += New-KernelDmaFinding -Check 'Kernel DMA registry policy' -Severity 'info' -Message $message -Evidence $registryEvidence
+        }
+        default {
+            if ($allowInt -eq 0) {
+                $findings += New-KernelDmaFinding -Check 'Kernel DMA registry policy' -Severity 'good' -Message 'AllowDmaUnderLock = 0 (DMA blocked while locked).' -Evidence $registryEvidence
+            } elseif ($allowInt -eq 1) {
+                $findings += New-KernelDmaFinding -Check 'Kernel DMA registry policy' -Severity 'high' -Message 'AllowDmaUnderLock = 1 (DMA allowed when locked).' -Evidence $registryEvidence
+            } else {
+                $findings += New-KernelDmaFinding -Check 'Kernel DMA registry policy' -Severity 'info' -Message 'Kernel DMA registry policy captured but AllowDmaUnderLock value not present.' -Evidence $registryEvidence
+            }
+        }
+    }
+} else {
+    $findings += New-KernelDmaFinding -Check 'Kernel DMA registry policy' -Severity 'warning' -Message 'Kernel DMA registry policy missing from collector payload.' -Evidence $registryEvidence
+}
+
+if ($msInfo -and $msInfo.Status -and $msInfo.Status -ne 'Skipped') {
+    $msInfoEvidence = [ordered]@{
+        Status = $msInfo.Status
+        Message = $msInfo.Message
+        Lines   = if ($msInfo.Lines) { ($msInfo.Lines | Select-Object -First 10) } else { @() }
+    }
+    $severity = if ($msInfo.Status -eq 'Success') { 'info' } elseif ($msInfo.Status -eq 'Timeout') { 'warning' } else { 'info' }
+    $findings += New-KernelDmaFinding -Check 'msinfo32 fallback' -Severity $severity -Message "msinfo32 fallback status: $($msInfo.Status)" -Evidence $msInfoEvidence
+}
+
+return $findings

--- a/Collectors/System/KernelDMAStatus.ps1
+++ b/Collectors/System/KernelDMAStatus.ps1
@@ -1,0 +1,218 @@
+<#!
+.SYNOPSIS
+    Helper functions for gathering Kernel DMA protection state using fast data sources.
+.DESCRIPTION
+    Provides reusable functions to query Device Guard (Win32_DeviceGuard),
+    registry policy, and an optional msinfo32 fallback with a timeout.
+#>
+
+function ConvertTo-PlainValue {
+    param(
+        [object]$Value
+    )
+
+    if ($null -eq $Value) { return $null }
+
+    if ($Value -is [string]) {
+        $text = $Value.Trim()
+        return ($text -replace '\s+', ' ')
+    }
+
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string])) {
+        $list = @()
+        foreach ($item in $Value) {
+            if ($null -eq $item) { continue }
+            $list += [string]$item
+        }
+        return $list
+    }
+
+    return $Value
+}
+
+function Get-KernelDmaDeviceGuardState {
+    try {
+        $instances = Get-CimInstance -Namespace 'root/Microsoft/Windows/DeviceGuard' -ClassName Win32_DeviceGuard -ErrorAction Stop
+    } catch {
+        return [pscustomobject]@{
+            Status  = 'Error'
+            Message = $_.Exception.Message
+            Entries = @()
+            HasData = $false
+        }
+    }
+
+    if (-not $instances) {
+        return [pscustomobject]@{
+            Status  = 'Info'
+            Message = 'Not supported / no data'
+            Entries = @()
+            HasData = $false
+        }
+    }
+
+    $converted = @()
+    $hasData = $false
+    foreach ($instance in $instances) {
+        $entry = [ordered]@{}
+        foreach ($property in $instance.PSObject.Properties) {
+            if ($property.Name -like 'Cim*' -or $property.Name -like 'PS*') { continue }
+            $plain = ConvertTo-PlainValue $property.Value
+            if ($plain -is [System.Collections.IEnumerable] -and -not ($plain -is [string])) {
+                $plain = @($plain)
+            }
+            $entry[$property.Name] = $plain
+            if ($null -ne $plain) {
+                if ($plain -is [System.Collections.IEnumerable] -and -not ($plain -is [string])) {
+                    if ($plain.Count -gt 0) { $hasData = $true }
+                } else {
+                    $hasData = $true
+                }
+            }
+        }
+        $converted += [pscustomobject]$entry
+    }
+
+    if (-not $hasData) {
+        return [pscustomobject]@{
+            Status  = 'Info'
+            Message = 'Not supported / no data'
+            Entries = @()
+            HasData = $false
+        }
+    }
+
+    return [pscustomobject]@{
+        Status  = 'Success'
+        Message = $null
+        Entries = $converted
+        HasData = $true
+    }
+}
+
+function Get-KernelDmaRegistryPolicy {
+    $path = 'HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\KernelDMAProtection'
+    if (-not (Test-Path -Path $path)) {
+        return [pscustomobject]@{
+            Status  = 'Info'
+            Message = 'Registry key not found'
+            Path    = $path
+            Values  = @{}
+            HasData = $false
+        }
+    }
+
+    try {
+        $values = Get-ItemProperty -Path $path -ErrorAction Stop
+    } catch {
+        return [pscustomobject]@{
+            Status  = 'Error'
+            Message = $_.Exception.Message
+            Path    = $path
+            Values  = @{}
+            HasData = $false
+        }
+    }
+
+    $result = [ordered]@{}
+    foreach ($property in $values.PSObject.Properties) {
+        if ($property.Name -like 'PS*' -or $property.Name -like 'Cim*') { continue }
+        $result[$property.Name] = ConvertTo-PlainValue $property.Value
+    }
+
+    $hasData = ($result.Count -gt 0)
+
+    return [pscustomobject]@{
+        Status  = 'Success'
+        Message = $null
+        Path    = $path
+        Values  = [pscustomobject]$result
+        HasData = $hasData
+    }
+}
+
+function Get-KernelDmaMsInfoFallback {
+    param(
+        [int]$TimeoutSeconds = 4
+    )
+
+    $tempPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath (([System.Guid]::NewGuid().ToString()) + '.txt')
+    $arguments = @('/report', $tempPath, '/categories', 'Hardware Resources\\DMA')
+
+    try {
+        $process = Start-Process -FilePath 'msinfo32.exe' -ArgumentList $arguments -PassThru -WindowStyle Hidden -ErrorAction Stop
+    } catch {
+        return [pscustomobject]@{
+            Status  = 'Error'
+            Message = $_.Exception.Message
+            Lines   = @()
+        }
+    }
+
+    $timeoutMilliseconds = [math]::Max(1000, $TimeoutSeconds * 1000)
+    $completed = $false
+    try {
+        $completed = $process.WaitForExit($timeoutMilliseconds)
+    } catch {
+        $completed = $false
+    }
+
+    if (-not $completed) {
+        try { $process.Kill() | Out-Null } catch {}
+        return [pscustomobject]@{
+            Status  = 'Timeout'
+            Message = "msinfo32.exe exceeded ${TimeoutSeconds}s timeout"
+            Lines   = @()
+        }
+    }
+
+    if (-not (Test-Path -Path $tempPath)) {
+        return [pscustomobject]@{
+            Status  = 'Error'
+            Message = "msinfo32.exe did not produce output"
+            Lines   = @()
+        }
+    }
+
+    try {
+        $content = Get-Content -Path $tempPath -ErrorAction Stop
+    } catch {
+        $content = @()
+    }
+
+    Remove-Item -Path $tempPath -ErrorAction SilentlyContinue
+
+    return [pscustomobject]@{
+        Status  = 'Success'
+        Message = $null
+        Lines   = @($content)
+    }
+}
+
+function Get-KernelDmaStatusData {
+    param(
+        [int]$MsInfoTimeoutSeconds = 4
+    )
+
+    $deviceGuard = Get-KernelDmaDeviceGuardState
+    $registry    = Get-KernelDmaRegistryPolicy
+
+    $fastPathAvailable = $deviceGuard.HasData -or $registry.HasData -or ($deviceGuard.Status -eq 'Info' -and $deviceGuard.Message)
+
+    $msInfo = $null
+    if (-not $fastPathAvailable) {
+        $msInfo = Get-KernelDmaMsInfoFallback -TimeoutSeconds $MsInfoTimeoutSeconds
+    } else {
+        $msInfo = [pscustomobject]@{
+            Status  = 'Skipped'
+            Message = 'Fast path data collected'
+            Lines   = @()
+        }
+    }
+
+    return [pscustomobject]@{
+        DeviceGuard = $deviceGuard
+        Registry    = $registry
+        MsInfo      = $msInfo
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared Kernel DMA status helper that queries Device Guard, registry policy, and a timed msinfo32 fallback
- switch the security collector and AutoL1 data capture to the fast-path helper and emit structured key/value evidence
- add a system analyzer and AutoL1 heuristic logic that evaluate AllowDmaUnderLock and surface warnings when DMA remains enabled while locked

## Testing
- not run (PowerShell collectors require a Windows environment)


------
https://chatgpt.com/codex/tasks/task_e_68d556006cf8832d8eb3b786669a6c51