### PR TITLE
Add comment-based help for core scripts and helpers

### DIFF
--- a/Analyzers/Analyze-Diagnostics.ps1
+++ b/Analyzers/Analyze-Diagnostics.ps1
@@ -1,6 +1,10 @@
 <#!
 .SYNOPSIS
     Analyzer orchestrator that loads JSON artifacts, runs heuristic modules, and generates an HTML report.
+.PARAMETER InputFolder
+    Specifies the folder containing collector artifacts to be analyzed.
+.PARAMETER OutputPath
+    Optional path for the generated HTML report. When omitted, the report is written next to the input folder.
 #>
 [CmdletBinding()]
 param(

--- a/Analyzers/System/KernelDMA.ps1
+++ b/Analyzers/System/KernelDMA.ps1
@@ -1,6 +1,8 @@
 <#!
 .SYNOPSIS
     Analyzes Kernel DMA protection collector output and classifies policy health.
+.PARAMETER InputFolder
+    Specifies the folder containing collector artifacts for Kernel DMA analysis.
 #>
 [CmdletBinding()]
 param(

--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -1,11 +1,15 @@
 <#
-Analyze-Diagnostics.ps1  (fixed)
-- Robust file detection (by name or content)
-- Bracket indexing for hashtables ($raw['key'])
-- Issues are [pscustomobject]
-- CSS via literal here-string; summary via expanding here-string
-USAGE:
-  .\Analyze-Diagnostics.ps1 -InputFolder "C:\Path\To\DiagReports\20250924_181518"
+.SYNOPSIS
+  Analyzes collected AutoHelpDesk diagnostics and produces an HTML device health report.
+.DESCRIPTION
+  Loads collector output from the specified folder, normalizes artifacts, evaluates a wide array of heuristic modules,
+  and renders HTML along with structured issue and check collections for downstream automation.
+.PARAMETER InputFolder
+  Specifies the folder containing collector artifacts (JSON, text, and CSV files) to analyze.
+.EXAMPLE
+  PS C:\> .\Analyze-Diagnostics.ps1 -InputFolder "C:\Path\To\DiagReports\20250924_181518"
+
+  Generates an HTML diagnostic report for the specified collection folder.
 #>
 
 [CmdletBinding()]

--- a/AutoL1/Collect-SystemDiagnostics.ps1
+++ b/AutoL1/Collect-SystemDiagnostics.ps1
@@ -1,7 +1,23 @@
 <#
-Collect-SystemDiagnostics.ps1
-Collect a broad snapshot of a Windows machine and build a simple HTML report.
-Run as Administrator.
+.SYNOPSIS
+  Collects a broad diagnostic snapshot of a Windows device and optionally builds an HTML report.
+.DESCRIPTION
+  Creates a timestamped output folder, captures a curated set of networking, Outlook, and system diagnostics, and writes
+  the raw command output to text files. When HTML generation is enabled, the script stitches results into a technician-
+  friendly summary.
+.PARAMETER OutRoot
+  Specifies the root folder where timestamped diagnostic collections are stored. Defaults to the desktop DiagReports
+  folder for the current user.
+.PARAMETER NoHtml
+  Skips HTML report generation when supplied, leaving only the raw text outputs.
+.EXAMPLE
+  PS C:\> .\Collect-SystemDiagnostics.ps1
+
+  Captures diagnostics into a new timestamped folder under the default DiagReports directory and builds an HTML summary.
+.EXAMPLE
+  PS C:\> .\Collect-SystemDiagnostics.ps1 -OutRoot 'C:\Temp\Diag' -NoHtml
+
+  Writes the diagnostic text files to C:\Temp\Diag without producing an HTML report.
 #>
 
 [CmdletBinding()]
@@ -11,6 +27,15 @@ param(
 )
 
 # Ensure Admin
+<#
+.SYNOPSIS
+  Ensures the script is running with administrator privileges and stops execution when it is not.
+.DESCRIPTION
+  Checks the current security principal for membership in the local Administrators group and terminates the script with
+  an error message when elevation is missing.
+.OUTPUTS
+  None. Throws a terminating error when the session is not elevated.
+#>
 function Assert-Admin {
   $id = [Security.Principal.WindowsIdentity]::GetCurrent()
   $p = New-Object Security.Principal.WindowsPrincipal($id)
@@ -30,6 +55,19 @@ Write-Host "Starting diagnostics collection..."
 Write-Host "Output folder: $reportDir"
 
 # Simple helper to run a command and write output
+<#
+.SYNOPSIS
+  Executes a diagnostic action and saves the output to a timestamped text file.
+.DESCRIPTION
+  Creates or appends to a text file beneath the current report directory, capturing command output and wrapping it in a
+  dated header for easy review. Errors are surfaced to both the log file and the console.
+.PARAMETER Name
+  Friendly name used for the output file and header text.
+.PARAMETER Action
+  Script block that, when invoked, produces the diagnostic output to capture.
+.OUTPUTS
+  System.String. Returns the full path to the file containing the captured output.
+#>
 function Save-Output {
   param(
     [Parameter(Mandatory)] [string]$Name,
@@ -52,6 +90,14 @@ $kernelDmaHelperPath = Join-Path (Split-Path $PSScriptRoot -Parent) 'Collectors\
 if (Test-Path $kernelDmaHelperPath) {
   . $kernelDmaHelperPath
 } elseif (-not (Get-Command Get-KernelDmaStatusData -ErrorAction SilentlyContinue)) {
+  <#
+  .SYNOPSIS
+    Provides a fallback Kernel DMA status object when the dedicated helper cannot be loaded.
+  .PARAMETER MsInfoTimeoutSeconds
+    Specifies the timeout used when collecting MSINFO data. Present for interface compatibility only.
+  .OUTPUTS
+    PSCustomObject. Returns placeholder Device Guard, registry, and MSINFO details indicating the helper was unavailable.
+  #>
   function Get-KernelDmaStatusData {
     param([int]$MsInfoTimeoutSeconds = 4)
 

--- a/AutoL1/Device-Report.ps1
+++ b/AutoL1/Device-Report.ps1
@@ -1,16 +1,22 @@
-<# 
-Device-Report.ps1
-Parent script: 
-  1) Runs Collect-SystemDiagnostics.ps1 to gather outputs
-  2) Locates the newest collection folder
-  3) Runs Analyze-Diagnostics.ps1 against it
-  4) Opens the resulting HTML report
-USAGE:
-  PowerShell (Admin):
-    Set-ExecutionPolicy -Scope Process Bypass -Force
-    .\Device-Report.ps1
-    # or specify an existing folder to analyze:
-    .\Device-Report.ps1 -InputFolder "C:\Users\Me\Desktop\DiagReports\20250924_181518"
+<#
+.SYNOPSIS
+  Coordinates collection and analysis to produce an AutoHelpDesk device health report.
+.DESCRIPTION
+  Ensures the session is elevated, runs Collect-SystemDiagnostics.ps1 when no existing folder is provided, chooses the
+  most recent collection directory, invokes Analyze-Diagnostics.ps1, and opens the resulting HTML report for review.
+.PARAMETER OutRoot
+  Specifies the root folder where new diagnostic collections should be created. Defaults to the desktop DiagReports
+  directory for the current user.
+.PARAMETER InputFolder
+  Provides the path to an existing diagnostics folder to analyze without running collection.
+.EXAMPLE
+  PS C:\> .\Device-Report.ps1
+
+  Collects diagnostics into the default location, analyzes the results, and opens the generated HTML report.
+.EXAMPLE
+  PS C:\> .\Device-Report.ps1 -InputFolder 'C:\Reports\Diag\20250101_103000'
+
+  Skips new collection and analyzes the specified folder.
 #>
 
 [CmdletBinding()]
@@ -19,6 +25,15 @@ param(
   [string]$InputFolder # optional: analyze an existing folder without collecting
 )
 
+<#
+.SYNOPSIS
+  Ensures the script is running with administrator privileges and stops execution when it is not.
+.DESCRIPTION
+  Checks the current security principal for membership in the local Administrators group and terminates the script with
+  an error message when elevation is missing.
+.OUTPUTS
+  None. Throws a terminating error when the session is not elevated.
+#>
 function Assert-Admin {
   $id = [Security.Principal.WindowsIdentity]::GetCurrent()
   $p = New-Object Security.Principal.WindowsPrincipal($id)

--- a/AutoL1/Test-AutorunsDetection.ps1
+++ b/AutoL1/Test-AutorunsDetection.ps1
@@ -1,3 +1,16 @@
+<#
+.SYNOPSIS
+  Tests Autoruns export detection logic against a diagnostics folder.
+.DESCRIPTION
+  Scans the provided input folder for text-based exports, locates the Autoruns output either by filename or signature,
+  and writes the detected file path to the console for validation.
+.PARAMETER InputFolder
+  Specifies the diagnostics folder that should contain an Autoruns export.
+.EXAMPLE
+  PS C:\> .\Test-AutorunsDetection.ps1 -InputFolder 'C:\Temp\Diag\20240101_120000'
+
+  Attempts to detect the Autoruns export inside the specified diagnostics collection.
+#>
 [CmdletBinding()]
 param(
   [Parameter(Mandatory)]
@@ -19,6 +32,14 @@ $allTextFiles = Get-ChildItem -Path $InputFolder -Recurse -File -ErrorAction Sil
   Where-Object { $textExtensions -contains $_.Extension.ToLowerInvariant() }
 
 # Helper: find an Autoruns file by name hints or content inspection.
+<#
+.SYNOPSIS
+  Locates the Autoruns export file from a candidate set based on filename patterns or file contents.
+.PARAMETER Files
+  Candidate files to inspect for Autoruns output.
+.OUTPUTS
+  System.IO.FileInfo. Returns the matching file when found; otherwise, returns $null.
+#>
 function Find-AutorunsFile {
   param(
     [System.IO.FileInfo[]]$Files

--- a/Collectors/System/Collect-ADHealth.ps1
+++ b/Collectors/System/Collect-ADHealth.ps1
@@ -1,6 +1,8 @@
 <#!
 .SYNOPSIS
     Collects detailed Active Directory health information, including discovery, reachability, time, Kerberos, and GPO data.
+.PARAMETER OutputDirectory
+    Specifies the folder where the AD health JSON artifact will be written.
 #>
 [CmdletBinding()]
 param(

--- a/Get-ADQuickHealth.ps1
+++ b/Get-ADQuickHealth.ps1
@@ -4,8 +4,14 @@
 .DESCRIPTION
   - Lists FSMO roles, DCs, GC status, replication summary, time source, and basic DFSR SYSVOL health.
   - Requires: RSAT AD PowerShell, repadmin, dcdiag present on the machine running it.
+.PARAMETER SaveReport
+  Saves the collected output to a timestamped text report beneath the local Reports directory when specified.
 .OUTPUTS
-  Writes to screen and saves a timestamped TXT under .\Reports\
+  System.String. Writes results to the console and optionally saves a timestamped TXT under .\Reports\.
+.EXAMPLE
+  PS C:\> .\Get-ADQuickHealth.ps1 -SaveReport
+
+  Runs the health snapshot and saves the output to the Reports folder alongside the script.
 #>
 [CmdletBinding()]
 param(
@@ -17,6 +23,17 @@ $reportDir = Join-Path -Path $PSScriptRoot -ChildPath "Reports"
 if ($SaveReport -and -not (Test-Path $reportDir)) { New-Item -ItemType Directory -Path $reportDir | Out-Null }
 $sb = New-Object System.Text.StringBuilder
 
+<#
+.SYNOPSIS
+  Adds a formatted line to the in-memory report buffer and returns the same text for display.
+.DESCRIPTION
+  Appends the supplied text to the script-scoped StringBuilder so it can be emitted to the console and, if requested,
+  written to a report file without duplicating logic.
+.PARAMETER txt
+  The text to append to the report buffer.
+.OUTPUTS
+  System.String. Returns the same string that was added to the buffer.
+#>
 function Add-Line($txt){[void]$sb.AppendLine($txt); $txt}
 
 Add-Line "=== AD QUICK HEALTH $(Get-Date) ==="

--- a/Get-DHCPStatus.ps1
+++ b/Get-DHCPStatus.ps1
@@ -1,8 +1,19 @@
 <#
 .SYNOPSIS
-  DHCP snapshot: authorization, scopes, failover partnerships, DNS update settings.
-.REQUIRES
-  DhcpServer module.
+  Captures an at-a-glance snapshot of DHCP server configuration and health.
+.DESCRIPTION
+  Reviews the current DHCP authorization state, IPv4 scopes, failover partnerships, and dynamic DNS update configuration.
+  Requires the DhcpServer PowerShell module on the executing host.
+.PARAMETER ComputerName
+  Specifies the DHCP server to query. Defaults to the local computer.
+.PARAMETER SaveReport
+  Saves the collected output to a timestamped text report beneath the local Reports directory when specified.
+.OUTPUTS
+  System.String. Writes results to the console and optionally saves a timestamped TXT under .\Reports\.
+.EXAMPLE
+  PS C:\> .\Get-DHCPStatus.ps1 -ComputerName DHCP01 -SaveReport
+
+  Collects configuration details from DHCP01 and saves them to the Reports folder alongside the script.
 #>
 [CmdletBinding()]
 param(
@@ -14,6 +25,14 @@ $stamp = (Get-Date).ToString('yyyyMMdd_HHmmss')
 $reportDir = Join-Path -Path $PSScriptRoot -ChildPath "Reports"
 if ($SaveReport -and -not (Test-Path $reportDir)) { New-Item -ItemType Directory -Path $reportDir | Out-Null }
 $sb = New-Object System.Text.StringBuilder
+<#
+.SYNOPSIS
+  Adds a formatted line to the in-memory report buffer and returns the same text for display.
+.PARAMETER t
+  The text to append to the report buffer.
+.OUTPUTS
+  System.String. Returns the same string that was added to the buffer.
+#>
 function Add-Line($t){[void]$sb.AppendLine($t); $t}
 
 Add-Line "=== DHCP STATUS on $ComputerName $(Get-Date) ==="

--- a/Get-DNSStatus.ps1
+++ b/Get-DNSStatus.ps1
@@ -1,8 +1,19 @@
 <#
 .SYNOPSIS
-  DNS server configuration snapshot (zones, dynamic updates, forwarders, scavenging).
-.REQUIRES
-  DnsServer module.
+  Captures an at-a-glance snapshot of DNS server configuration and health.
+.DESCRIPTION
+  Reviews forwarders, scavenging posture, and zone metadata (including replication and dynamic update mode). Requires the
+  DnsServer module on the executing host.
+.PARAMETER ComputerName
+  Specifies the DNS server to query. Defaults to the local computer.
+.PARAMETER SaveReport
+  Saves the collected output to a timestamped text report beneath the local Reports directory when specified.
+.OUTPUTS
+  System.String. Writes results to the console and optionally saves a timestamped TXT under .\Reports\.
+.EXAMPLE
+  PS C:\> .\Get-DNSStatus.ps1 -ComputerName DNS01 -SaveReport
+
+  Collects configuration details from DNS01 and saves them to the Reports folder alongside the script.
 #>
 [CmdletBinding()]
 param(
@@ -14,6 +25,14 @@ $stamp = (Get-Date).ToString('yyyyMMdd_HHmmss')
 $reportDir = Join-Path -Path $PSScriptRoot -ChildPath "Reports"
 if ($SaveReport -and -not (Test-Path $reportDir)) { New-Item -ItemType Directory -Path $reportDir | Out-Null }
 $sb = New-Object System.Text.StringBuilder
+<#
+.SYNOPSIS
+  Adds a formatted line to the in-memory report buffer and returns the same text for display.
+.PARAMETER t
+  The text to append to the report buffer.
+.OUTPUTS
+  System.String. Returns the same string that was added to the buffer.
+#>
 function Add-Line($t){[void]$sb.AppendLine($t); $t}
 
 Add-Line "=== DNS STATUS on $ComputerName $(Get-Date) ==="

--- a/Get-InfrastructureMap.ps1
+++ b/Get-InfrastructureMap.ps1
@@ -1,9 +1,17 @@
 <#
 .SYNOPSIS
-  Generates a Markdown summary and Graphviz .dot of AD/DNS/DHCP/Sites. Optional Hyper-V inventory if present.
-.OUTPUT
-  .\Reports\Infrastructure_Report.md
-  .\Reports\Infrastructure_Map.dot
+  Generates a Markdown summary and Graphviz .dot of AD/DNS/DHCP/Sites with optional Hyper-V inventory.
+.DESCRIPTION
+  Collects directory services, DNS, DHCP, and AD Sites metadata to produce a Markdown report and a Graphviz DOT map inside
+  the Reports folder. When requested, Hyper-V host and VM information is also appended.
+.PARAMETER IncludeHyperV
+  Adds Hyper-V inventory details to the Markdown report when the Hyper-V module is available.
+.OUTPUTS
+  System.String. Writes the generated report and DOT file paths to the console.
+.EXAMPLE
+  PS C:\> .\Get-InfrastructureMap.ps1 -IncludeHyperV
+
+  Creates infrastructure report and map files including Hyper-V host and VM inventory.
 #>
 [CmdletBinding()]
 param(

--- a/New-DHCPFailoverPair.ps1
+++ b/New-DHCPFailoverPair.ps1
@@ -1,8 +1,27 @@
 <#
 .SYNOPSIS
-  Creates DHCP failover between two DHCP servers for all or selected scopes.
+  Creates a DHCP failover partnership between two DHCP servers for all or selected scopes.
+.DESCRIPTION
+  Authorizes both servers in Active Directory (when necessary) and configures DHCP failover using either load-balanced or
+  hot-standby modes. All scopes from the primary are included unless specific scope IDs are supplied.
+.PARAMETER Primary
+  Specifies the hostname of the primary DHCP server.
+.PARAMETER Partner
+  Specifies the hostname of the partner DHCP server.
+.PARAMETER Mode
+  Sets the failover mode. Valid values are LoadBalance and HotStandby.
+.PARAMETER BalancePercent
+  When using load balancing, determines the percentage of the address pool serviced by the primary server.
+.PARAMETER MaxClientLeadTimeMinutes
+  Controls the maximum client lead time communicated between partners in minutes.
+.PARAMETER SharedSecret
+  Provides the shared secret used to secure the replication partnership.
+.PARAMETER ScopeIds
+  Limits the configuration to the provided IPv4 scope IDs. When omitted, all scopes on the primary server are included.
 .EXAMPLE
   .\New-DHCPFailoverPair.ps1 -Primary DHCPA -Partner DHCPB -Mode LoadBalance -BalancePercent 50 -SharedSecret 'S3cret!'
+
+  Creates a load-balanced failover partnership using a 50/50 split between DHCPA and DHCPB.
 #>
 [CmdletBinding()]
 param(

--- a/Set-DNSZone-ADIntegratedSecure.ps1
+++ b/Set-DNSZone-ADIntegratedSecure.ps1
@@ -1,8 +1,19 @@
 <#
 .SYNOPSIS
   Converts a standard primary zone to AD-integrated (if needed) and sets DynamicUpdates to Secure.
+.DESCRIPTION
+  Validates that the specified zone exists, converts it to an Active Directory-integrated zone when required, and forces
+  secure-only dynamic updates. Should be executed on a domain controller hosting DNS.
+.PARAMETER ZoneName
+  Specifies the DNS zone to convert and secure.
+.PARAMETER ReplicationScope
+  Indicates the desired replication scope for the zone. Accepts Forest or Domain, defaulting to Domain.
 .NOTES
   Run on a DC with DNS role. For public/DMZ zones, do NOT convert.
+.EXAMPLE
+  PS C:\> .\Set-DNSZone-ADIntegratedSecure.ps1 -ZoneName "contoso.com" -ReplicationScope Forest
+
+  Converts contoso.com to a forest-wide AD-integrated zone and sets dynamic updates to Secure Only.
 #>
 [CmdletBinding()]
 param(

--- a/Set-PDC-TimeSource.ps1
+++ b/Set-PDC-TimeSource.ps1
@@ -1,6 +1,16 @@
 <#
 .SYNOPSIS
-  Sets PDC Emulator to sync with external NTP servers and restarts time service.
+  Sets the domain PDC Emulator to sync with external NTP servers and restarts the time service.
+.DESCRIPTION
+  Confirms the script is running on the PDC Emulator, updates the manual peer list to the provided NTP servers, marks the
+  clock as reliable, restarts the Windows Time service, and forces a resynchronization.
+.PARAMETER NtpServers
+  Specifies the NTP servers to configure. Each entry should include optional flags (for example, ",0x9"). Defaults to a
+  pair of publicly available time sources.
+.EXAMPLE
+  PS C:\> .\Set-PDC-TimeSource.ps1 -NtpServers 'time.nist.gov,0x8','pool.ntp.org,0x8'
+
+  Configures the local PDC Emulator to sync with the provided time servers and restarts the Windows Time service.
 #>
 [CmdletBinding()]
 param(

--- a/Setup-MSPPowerPackPrereqs.ps1
+++ b/Setup-MSPPowerPackPrereqs.ps1
@@ -1,12 +1,18 @@
 <#
 .SYNOPSIS
   Installs the Windows components needed for the MSP PowerPack scripts.
-  Works on Windows Server (Install-WindowsFeature) and Windows 10/11 (Add-WindowsCapability).
 .DESCRIPTION
-  Installs RSAT for AD, DNS, DHCP, DFS tools, and optional Hyper-V PowerShell.
-  Verifies modules/tools: ActiveDirectory, DnsServer, DhcpServer, Hyper-V, repadmin, dcdiag, dfsrdiag, w32tm.
+  Detects the operating system role, installs the required RSAT features or capabilities, optionally enables Hyper-V
+  management tools, and verifies that key modules and diagnostic utilities are available. Supports both Windows Server
+  and Windows client editions.
+.PARAMETER SkipHyperVTools
+  Skips installation and verification of Hyper-V management components when specified.
 .NOTES
   Run in an elevated PowerShell window (Run as administrator).
+.EXAMPLE
+  PS C:\> .\Setup-MSPPowerPackPrereqs.ps1 -SkipHyperVTools
+
+  Installs the required RSAT tools but omits Hyper-V PowerShell features on the local machine.
 #>
 
 [CmdletBinding()]
@@ -14,6 +20,12 @@ param(
   [switch]$SkipHyperVTools
 )
 
+<#
+.SYNOPSIS
+  Determines whether the current PowerShell session is running with administrator privileges.
+.OUTPUTS
+  System.Boolean. Returns $true when the current user context belongs to the local Administrators group.
+#>
 function Test-IsAdmin {
   $id = [Security.Principal.WindowsIdentity]::GetCurrent()
   $p = New-Object Security.Principal.WindowsPrincipal($id)

--- a/Test-UptimeParse.ps1
+++ b/Test-UptimeParse.ps1
@@ -1,8 +1,19 @@
-<#  Save as Test-UptimeParse.ps1 (or run directly in a PS session)
+<#
+.SYNOPSIS
+  Parses Windows boot time strings into DateTime objects and calculates uptime in days.
+.DESCRIPTION
+  Accepts boot time strings from tools such as systeminfo, attempts to interpret WMI and culture-specific formats, and
+  reports the parsed boot time alongside the estimated uptime.
+.PARAMETER BootString
+  Provides the boot time string to parse. When omitted, the script queries systeminfo for the most recent value.
+.EXAMPLE
+  PS C:\> .\Test-UptimeParse.ps1
 
-    .\Test-UptimeParse.ps1
-    .\Test-UptimeParse.ps1 -BootString '20240101120000.000000-300'
-    .\Test-UptimeParse.ps1 -BootString '13.05.2024 08:12:44'  # example localized format
+  Retrieves the boot string from systeminfo, parses it, and prints the approximate uptime.
+.EXAMPLE
+  PS C:\> .\Test-UptimeParse.ps1 -BootString '20240101120000.000000-300'
+
+  Parses the supplied WMI-formatted timestamp and reports the uptime.
 #>
 
 param(


### PR DESCRIPTION
## Summary
- add full comment-based help to operational cmdlets covering parameters, outputs, and usage examples
- document AutoL1 orchestration scripts and helper functions with inline comment-based help blocks
- annotate analyzer and collector entry points with parameter documentation to align with PowerShell help standards

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d5616a7cd4832db42670fe9d31c360