### PR TITLE
Fix printing collector and analyzer evidence formatting

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -92,7 +92,7 @@ function Add-CategoryIssue {
         [Parameter(Mandatory)]
         [string]$Title,
 
-        [string]$Evidence = ''
+        [object]$Evidence = $null
     )
 
     $CategoryResult.Issues.Add([pscustomobject]@{
@@ -110,7 +110,7 @@ function Add-CategoryNormal {
         [Parameter(Mandatory)]
         [string]$Title,
 
-        [string]$Evidence = ''
+        [object]$Evidence = $null
     )
 
     $CategoryResult.Normals.Add([pscustomobject]@{

--- a/Collectors/Services/Collect-Printing.ps1
+++ b/Collectors/Services/Collect-Printing.ps1
@@ -276,7 +276,13 @@ function Get-PrinterConnectionInfo {
         if ($normalizedAddress) { $hosts.Add($normalizedAddress) }
     }
 
-    foreach ($candidate in @($portName, if ($Port) { [string]$Port.Name } else { $null })) {
+    $candidates = New-Object System.Collections.Generic.List[string]
+    if ($portName) { $candidates.Add($portName) | Out-Null }
+    if ($Port -and $Port.PSObject.Properties['Name']) {
+        $candidates.Add([string]$Port.Name) | Out-Null
+    }
+
+    foreach ($candidate in $candidates) {
         if (-not $candidate) { continue }
         if ($candidate -like '\\\\*') {
             $normalizedCandidate = Normalize-HostName $candidate


### PR DESCRIPTION
## Summary
- prevent the printing collector from using an inline conditional expression inside an array literal that PowerShell cannot parse
- allow analyzer category helpers to store non-string evidence payloads
- render complex evidence objects in the HTML composer by converting them to JSON and preserving line breaks

## Testing
- ⚠️ `pwsh -NoLogo -Command ". ./Analyzers/AnalyzerCommon.ps1; . ./Analyzers/HtmlComposer.ps1; . ./Collectors/Services/Collect-Printing.ps1; 'loaded'"` *(fails: `pwsh` not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d56c00c748832d89ec52ce002715b4