### PR TITLE
Fix artifact debug section string interpolation

### DIFF
--- a/Analyzers/HtmlComposer.ps1
+++ b/Analyzers/HtmlComposer.ps1
@@ -315,16 +315,16 @@ function Build-DebugSection {
     foreach ($key in ($Context.Artifacts.Keys | Sort-Object)) {
         $entries = $Context.Artifacts[$key]
         if (-not $entries) {
-            $lines += "$key: (no entries)"
+            $lines += "${key}: (no entries)"
             continue
         }
 
         if ($entries -is [System.Collections.IEnumerable] -and -not ($entries -is [string])) {
             $count = $entries.Count
             $firstPath = $entries[0].Path
-            $lines += "$key: $count file(s); first = $firstPath"
+            $lines += "${key}: $count file(s); first = $firstPath"
         } else {
-            $lines += "$key: $($entries.Path)"
+            $lines += "${key}: $($entries.Path)"
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure artifact summary lines in HtmlComposer use scoped variable interpolation
- prevent PowerShell from misinterpreting the colon separator in artifact debug output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d575057f84832db81a9bd16f8b8b70