### PR TITLE
Add ContainsKey support for ordered dictionaries

### DIFF
--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -1,4 +1,17 @@
 # Common helper functions shared across analyzer scripts
+
+# Ensure ordered dictionaries support ContainsKey like hashtables for compatibility.
+if (-not ([System.Collections.Specialized.OrderedDictionary].GetMethods() | Where-Object { $_.Name -eq 'ContainsKey' })) {
+  try {
+    Update-TypeData -TypeName System.Collections.Specialized.OrderedDictionary -MemberType ScriptMethod -MemberName ContainsKey -Value {
+      param($Key)
+      return $this.Contains($Key)
+    } -ErrorAction Stop
+  } catch {
+    # If type data registration fails, continue without interrupting import.
+  }
+}
+
 $script:SeverityOrder = @('info','warning','low','medium','high','critical')
 
 function Normalize-Severity {


### PR DESCRIPTION
## Summary
- register a ContainsKey script method for OrderedDictionary instances when importing Common module
- ensure analyzers that expect ContainsKey on dictionaries continue working even when data is stored in ordered dictionaries

## Testing
- attempted to run `pwsh -NoLogo -Command "Import-Module (Resolve-Path ./Modules/Common.psm1); $d=[ordered]@{foo=1}; Write-Host ($d.ContainsKey('foo'))"` *(fails: `pwsh` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5760d3624832d9efff28f89a96127