### PR TITLE
Restore legacy What Looks Good category grouping

### DIFF
--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -5872,7 +5872,7 @@ function Get-NormalCategory {
   )
 
   if ([string]::IsNullOrWhiteSpace($Area)) {
-    return 'Hardware'
+    return 'General'
   }
 
   $prefix = ($Area -split '/')[0]
@@ -5883,14 +5883,16 @@ function Get-NormalCategory {
   $trimmed = $prefix.Trim()
 
   switch -Regex ($trimmed) {
-    '^(?i)services$'        { return 'Services' }
-    '^(?i)(outlook|office)$' { return 'Office' }
-    '^(?i)(network|dns)$'    { return 'Network' }
-    '^(?i)security$'         { return 'Security' }
-    '^(?i)system$'           { return 'System' }
-    '^(?i)scheduled tasks$'  { return 'System' }
-    '^(?i)storage$'          { return 'Hardware' }
-    default { return 'Hardware' }
+    '^(?i)services'           { return 'Services' }
+    '^(?i)(outlook|office)'   { return 'Office' }
+    '^(?i)(network|dns)'      { return 'Network' }
+    '^(?i)system'             { return 'System' }
+    '^(?i)(storage|hardware)' { return 'Hardware' }
+    '^(?i)security'           { return 'Security' }
+    '^(?i)active\s*directory' { return 'Active Directory' }
+    '^(?i)printing'           { return 'Printing' }
+    '^(?i)events'             { return 'Events' }
+    default                   { return 'General' }
   }
 }
 
@@ -5899,7 +5901,7 @@ $goodTitle = "What Looks Good ({0})" -f $normals.Count
 if ($normals.Count -eq 0){
   $goodContent = '<div class="report-card"><i>No specific positives recorded.</i></div>'
 } else {
-  $categoryOrder = @('Services','Office','Network','System','Hardware','Security')
+  $categoryOrder = @('Services','Office','Network','System','Hardware','Security','Active Directory','Printing','Events','General')
   $categorized = [ordered]@{}
 
   foreach ($category in $categoryOrder) {


### PR DESCRIPTION
## Summary
- update What Looks Good category detection to mirror the legacy analyzer groupings
- extend the displayed good-result tab order to include Active Directory, Printing, Events, and General buckets

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d57a693e6c832da1596bd6170f77cf