### PR TITLE
Add native command helper and quick start docs

### DIFF
--- a/Analyzers/Analyze-Diagnostics.ps1
+++ b/Analyzers/Analyze-Diagnostics.ps1
@@ -23,15 +23,12 @@ if (Test-Path -Path $commonModulePath) {
 }
 
 . (Join-Path -Path $PSScriptRoot -ChildPath 'AnalyzerCommon.ps1')
-. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/System.ps1')
-. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Security.ps1')
-. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Network.ps1')
-. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/AD.ps1')
-. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Office.ps1')
-. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Storage.ps1')
-. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Events.ps1')
-. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Services.ps1')
-. (Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics/Printing.ps1')
+$heuristicsPath = Join-Path -Path $PSScriptRoot -ChildPath 'Heuristics'
+if (Test-Path -Path $heuristicsPath) {
+    Get-ChildItem -Path $heuristicsPath -Filter '*.ps1' -File | Sort-Object Name | ForEach-Object {
+        . $_.FullName
+    }
+}
 . (Join-Path -Path $PSScriptRoot -ChildPath 'SummaryBuilder.ps1')
 . (Join-Path -Path $PSScriptRoot -ChildPath 'HtmlComposer.ps1')
 

--- a/Collectors/Network/Collect-DNS.ps1
+++ b/Collectors/Network/Collect-DNS.ps1
@@ -37,14 +37,7 @@ function Test-DnsResolution {
 
 function Trace-NetworkPath {
     param([string]$Target = 'outlook.office365.com')
-    try {
-        return tracert.exe $Target 2>$null
-    } catch {
-        return [PSCustomObject]@{
-            Target = $Target
-            Error  = $_.Exception.Message
-        }
-    }
+    return Invoke-CollectorNativeCommand -FilePath 'tracert.exe' -ArgumentList $Target -ErrorMetadata @{ Target = $Target }
 }
 
 function Test-Latency {
@@ -52,14 +45,7 @@ function Test-Latency {
     try {
         return Test-NetConnection -ComputerName $Target -WarningAction SilentlyContinue
     } catch {
-        try {
-            return ping.exe $Target 2>$null
-        } catch {
-            return [PSCustomObject]@{
-                Target = $Target
-                Error  = $_.Exception.Message
-            }
-        }
+        return Invoke-CollectorNativeCommand -FilePath 'ping.exe' -ArgumentList $Target -ErrorMetadata @{ Target = $Target }
     }
 }
 

--- a/Collectors/Network/Collect-Network.ps1
+++ b/Collectors/Network/Collect-Network.ps1
@@ -11,47 +11,19 @@ param(
 . (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
 
 function Get-IpConfiguration {
-    try {
-        return ipconfig.exe /all 2>$null
-    } catch {
-        return [PSCustomObject]@{
-            Source = 'ipconfig.exe'
-            Error  = $_.Exception.Message
-        }
-    }
+    return Invoke-CollectorNativeCommand -FilePath 'ipconfig.exe' -ArgumentList '/all' -SourceLabel 'ipconfig.exe'
 }
 
 function Get-RoutingTable {
-    try {
-        return route.exe print 2>$null
-    } catch {
-        return [PSCustomObject]@{
-            Source = 'route.exe'
-            Error  = $_.Exception.Message
-        }
-    }
+    return Invoke-CollectorNativeCommand -FilePath 'route.exe' -ArgumentList 'print' -SourceLabel 'route.exe'
 }
 
 function Get-NetstatSnapshot {
-    try {
-        return netstat.exe -ano 2>$null
-    } catch {
-        return [PSCustomObject]@{
-            Source = 'netstat.exe'
-            Error  = $_.Exception.Message
-        }
-    }
+    return Invoke-CollectorNativeCommand -FilePath 'netstat.exe' -ArgumentList '-ano' -SourceLabel 'netstat.exe'
 }
 
 function Get-ArpCache {
-    try {
-        return arp.exe -a 2>$null
-    } catch {
-        return [PSCustomObject]@{
-            Source = 'arp.exe'
-            Error  = $_.Exception.Message
-        }
-    }
+    return Invoke-CollectorNativeCommand -FilePath 'arp.exe' -ArgumentList '-a' -SourceLabel 'arp.exe'
 }
 
 function Invoke-Main {

--- a/Collectors/Network/Collect-Proxy.ps1
+++ b/Collectors/Network/Collect-Proxy.ps1
@@ -11,14 +11,7 @@ param(
 . (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
 
 function Get-WinHttpProxy {
-    try {
-        return netsh.exe winhttp show proxy 2>$null
-    } catch {
-        return [PSCustomObject]@{
-            Source = 'netsh winhttp'
-            Error  = $_.Exception.Message
-        }
-    }
+    return Invoke-CollectorNativeCommand -FilePath 'netsh.exe' -ArgumentList 'winhttp','show','proxy' -SourceLabel 'netsh winhttp'
 }
 
 function Get-InternetSettings {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,30 @@ AutoHelpDesk is a modular PowerShell toolkit that collects Windows device teleme
 
 This README documents how the system fits together and enumerates the available heuristics so you can understand what the analyzer looks for out of the box.
 
+## Quick start
+
+The toolkit is designed to run entirely from PowerShell—no installers required. The commands below assume you are running from the repository root.
+
+1. **Collect diagnostics**
+   ```powershell
+   pwsh -File .\Collectors\Collect-All.ps1 -OutputRoot .\artifacts
+   ```
+   This script discovers every `Collect-*.ps1` module, executes them in parallel, and writes JSON payloads to the `artifacts` folder (grouped by area).
+
+2. **Review collection status (optional)**
+   ```powershell
+   Get-Content .\artifacts\collection-summary.json | ConvertFrom-Json
+   ```
+   The summary lists each collector, whether it succeeded, and the on-disk path of its artifact.
+
+3. **Generate the HTML report**
+   ```powershell
+   pwsh -File .\Analyzers\Analyze-Diagnostics.ps1 -InputFolder .\artifacts -OutputPath .\artifacts\diagnostics-report.html
+   ```
+   The analyzer loads every JSON file under `artifacts`, runs the heuristic catalog, and emits an HTML report (plus merged CSS under `artifacts\styles`).
+
+You can re-run the analyzer against existing collections—only the `-InputFolder` is required if you are happy with the default output path.
+
 ## Repository layout
 
 | Path | Description |


### PR DESCRIPTION
## Summary
- add a shared helper for invoking native executables and update the network collectors to use it for consistent error reporting
- teach the analyzer orchestrator to load every heuristic script dynamically
- document a PowerShell quick start flow for running the collectors and analyzer

## Testing
- not run (PowerShell runtime is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d57330facc832da4d289a906ff635d