### PR TITLE
Restore missing security and service heuristics

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -31,19 +31,19 @@ function Invoke-EventsHeuristics {
                         }
                     } else {
                         if ($errorCount -gt 20) {
-                            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ("High error volume in {0} log" -f $logName) -Evidence ("Recent errors: {0}" -f $errorCount)
+                            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ("{0} log shows many errors ({1} in recent sample)." -f $logName, $errorCount) -Evidence ("Errors recorded: {0}" -f $errorCount)
                         }
                         if ($warnCount -gt 40) {
                             Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title ("Many warnings in {0} log" -f $logName)
                         }
                     }
                 } elseif ($entries.Error) {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title ("Unable to read {0} event log" -f $logName) -Evidence $entries.Error
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Unable to read {0} event log" -f $logName) -Evidence $entries.Error
                 }
             }
         }
     } else {
-        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Event log artifact missing'
+        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Event log artifact missing'
     }
 
     return $result

--- a/Analyzers/Heuristics/Office.ps1
+++ b/Analyzers/Heuristics/Office.ps1
@@ -44,7 +44,9 @@ function Invoke-OfficeHeuristics {
                 Add-CategoryNormal -CategoryResult $result -Title 'Macro runtime blocked by policy'
             }
         } else {
-            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'No Office policy data collected'
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Office MOTW macro blocking - no data. Confirm macro policies.'
+            Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Office macro notifications - no data. Collect policy details.'
+            Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Office Protected View - no data. Verify Protected View policies.'
         }
     }
 

--- a/Analyzers/Heuristics/Printing.ps1
+++ b/Analyzers/Heuristics/Printing.ps1
@@ -58,6 +58,8 @@ function Invoke-PrintingHeuristics {
                 Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Print Spooler not running' -Evidence ("Status: {0}; StartMode: {1}" -f $status, $startMode)
             } elseif ($startMode -and $startMode -notmatch '(?i)auto') {
                 Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Spooler start mode not automatic' -Evidence ("Current mode: {0}" -f $startMode)
+            } else {
+                Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Print Spooler running — disable if this workstation does not need printing.'
             }
         }
     }

--- a/Analyzers/Heuristics/Security.ps1
+++ b/Analyzers/Heuristics/Security.ps1
@@ -5,6 +5,66 @@
 
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
 
+function ConvertTo-List {
+    param($Value)
+
+    if ($null -eq $Value) { return @() }
+    if ($Value -is [string]) { return @($Value) }
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string])) {
+        $items = @()
+        foreach ($item in $Value) { $items += $item }
+        return $items
+    }
+    return @($Value)
+}
+
+function ConvertTo-IntArray {
+    param($Value)
+
+    $list = @()
+    foreach ($item in (ConvertTo-List $Value)) {
+        if ($null -eq $item) { continue }
+        $text = $item.ToString()
+        $parsed = 0
+        if ([int]::TryParse($text, [ref]$parsed)) {
+            $list += $parsed
+        }
+    }
+    return $list
+}
+
+function Format-BitLockerVolume {
+    param($Volume)
+
+    $parts = @()
+    if ($Volume.MountPoint) { $parts += ("Mount: {0}" -f $Volume.MountPoint) }
+    if ($Volume.VolumeType) { $parts += ("Type: {0}" -f $Volume.VolumeType) }
+    if ($Volume.ProtectionStatus -ne $null) { $parts += ("Protection: {0}" -f $Volume.ProtectionStatus) }
+    if ($Volume.EncryptionMethod) { $parts += ("Method: {0}" -f $Volume.EncryptionMethod) }
+    if ($Volume.LockStatus) { $parts += ("Lock: {0}" -f $Volume.LockStatus) }
+    if ($Volume.AutoUnlockEnabled -ne $null) { $parts += ("AutoUnlock: {0}" -f $Volume.AutoUnlockEnabled) }
+    return ($parts -join '; ')
+}
+
+function Get-RegistryValueFromEntries {
+    param(
+        $Entries,
+        [string]$PathPattern,
+        [string]$Name
+    )
+
+    foreach ($entry in (ConvertTo-List $Entries)) {
+        if (-not $entry) { continue }
+        if ($entry.Path -and $entry.Path -match $PathPattern) {
+            if ($entry.Values -and $entry.Values.PSObject.Properties[$Name]) {
+                return $entry.Values.$Name
+            }
+        }
+    }
+
+    return $null
+}
+
 function Invoke-SecurityHeuristics {
     param(
         [Parameter(Mandatory)]
@@ -15,6 +75,7 @@ function Invoke-SecurityHeuristics {
 
     $operatingSystem = $null
     $isWindows11 = $false
+    $systemPayload = $null
     $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
     if ($systemArtifact) {
         $systemPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact)
@@ -23,6 +84,32 @@ function Invoke-SecurityHeuristics {
             if ($operatingSystem.Caption -and $operatingSystem.Caption -match 'Windows\s*11') {
                 $isWindows11 = $true
             }
+        }
+    }
+
+    $securityServicesRunning = @()
+    $securityServicesConfigured = @()
+    $availableSecurityProperties = @()
+    $requiredSecurityProperties = @()
+
+    $vbshvciArtifact = Get-AnalyzerArtifact -Context $Context -Name 'vbshvci'
+    if ($vbshvciArtifact) {
+        $vbPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $vbshvciArtifact)
+        if ($vbPayload -and $vbPayload.DeviceGuard -and -not $vbPayload.DeviceGuard.Error) {
+            $dg = $vbPayload.DeviceGuard
+            $securityServicesRunning = ConvertTo-IntArray $dg.SecurityServicesRunning
+            $securityServicesConfigured = ConvertTo-IntArray $dg.SecurityServicesConfigured
+            $availableSecurityProperties = ConvertTo-IntArray $dg.AvailableSecurityProperties
+            $requiredSecurityProperties = ConvertTo-IntArray $dg.RequiredSecurityProperties
+        }
+    }
+
+    $lsaEntries = @()
+    $lsaArtifact = Get-AnalyzerArtifact -Context $Context -Name 'lsa'
+    if ($lsaArtifact) {
+        $lsaPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $lsaArtifact)
+        if ($lsaPayload -and $lsaPayload.Registry) {
+            $lsaEntries = ConvertTo-List $lsaPayload.Registry
         }
     }
 
@@ -89,30 +176,70 @@ function Invoke-SecurityHeuristics {
         } elseif ($payload -and $payload.Profiles -and $payload.Profiles.Error) {
             Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Firewall profile query failed' -Evidence $payload.Profiles.Error
         } else {
-            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Firewall data missing expected profile list'
+            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Firewall not captured. Collect firewall profile configuration.'
         }
     } else {
-        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Firewall artifact not collected'
+        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Firewall not captured. Collect firewall profile configuration.'
     }
 
     $bitlockerArtifact = Get-AnalyzerArtifact -Context $Context -Name 'bitlocker'
     if ($bitlockerArtifact) {
         $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $bitlockerArtifact)
         if ($payload -and $payload.Volumes) {
-            $unprotected = @()
-            foreach ($volume in $payload.Volumes) {
-                $status = $volume.ProtectionStatus
-                $mount = if ($volume.MountPoint) { $volume.MountPoint } else { $volume.VolumeType }
-                Add-CategoryCheck -CategoryResult $result -Name ("BitLocker: {0}" -f $mount) -Status ($status)
-                if ($status -and ($status -eq 0 -or $status -eq 'Off' -or $status -like '*Off*')) {
-                    $unprotected += $mount
+            $volumes = ConvertTo-List $payload.Volumes
+            $osVolumes = @()
+            $osUnprotected = @()
+            $osProtectedEvidence = @()
+            $hasRecoveryProtector = $false
+
+            foreach ($volume in $volumes) {
+                if (-not $volume) { continue }
+                $mount = if ($volume.MountPoint) { [string]$volume.MountPoint } else { '' }
+                $type = if ($volume.VolumeType) { [string]$volume.VolumeType } else { '' }
+                $isOs = $false
+                if ($type -and $type -match '(?i)(OperatingSystem|System)') { $isOs = $true }
+                if (-not $isOs -and $mount) {
+                    if ($mount.Trim().ToUpperInvariant() -eq 'C:') { $isOs = $true }
+                }
+                if ($isOs) { $osVolumes += $volume }
+
+                foreach ($protector in (ConvertTo-List $volume.KeyProtector)) {
+                    if ($null -eq $protector) { continue }
+                    $protectorText = $protector.ToString()
+                    if ($protector.PSObject -and $protector.PSObject.Properties['KeyProtectorType']) {
+                        $protectorText = [string]$protector.KeyProtectorType
+                    }
+                    if ($protectorText -match '(?i)RecoveryPassword') {
+                        $hasRecoveryProtector = $true
+                    }
                 }
             }
 
-            if ($unprotected.Count -gt 0) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ('BitLocker disabled on {0}' -f ($unprotected -join ', '))
-            } else {
-                Add-CategoryNormal -CategoryResult $result -Title 'BitLocker protection present'
+            foreach ($osVolume in $osVolumes) {
+                $status = if ($osVolume.ProtectionStatus) { $osVolume.ProtectionStatus.ToString() } else { '' }
+                $isProtected = $false
+                if ($status) {
+                    $isProtected = -not ($status -match '(?i)off|0')
+                }
+                if ($isProtected) {
+                    $osProtectedEvidence += (Format-BitLockerVolume $osVolume)
+                } else {
+                    $osUnprotected += $osVolume
+                }
+            }
+
+            if ($osUnprotected.Count -gt 0) {
+                $mountList = ($osUnprotected | ForEach-Object { $_.MountPoint } | Where-Object { $_ } | Sort-Object -Unique) -join ', '
+                if (-not $mountList) { $mountList = 'Unknown volume' }
+                $evidence = ($osUnprotected | ForEach-Object { Format-BitLockerVolume $_ }) -join "`n"
+                Add-CategoryIssue -CategoryResult $result -Severity 'critical' -Title ("BitLocker is OFF for system volume(s): {0}." -f $mountList) -Evidence $evidence
+            } elseif ($osProtectedEvidence.Count -gt 0) {
+                Add-CategoryNormal -CategoryResult $result -Title 'BitLocker protection active for system volume(s).' -Evidence ($osProtectedEvidence -join "`n")
+            }
+
+            if (-not $hasRecoveryProtector) {
+                $volumeEvidence = ($volumes | ForEach-Object { Format-BitLockerVolume $_ }) -join "`n"
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'No BitLocker recovery password protector detected. Ensure recovery keys are escrowed.' -Evidence $volumeEvidence
             }
         } elseif ($payload -and $payload.Volumes -and $payload.Volumes.Error) {
             Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'BitLocker query failed' -Evidence $payload.Volumes.Error
@@ -142,12 +269,172 @@ function Invoke-SecurityHeuristics {
         }
     }
 
+    $kernelDmaArtifact = Get-AnalyzerArtifact -Context $Context -Name 'kerneldma'
+    if ($kernelDmaArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $kernelDmaArtifact)
+        $registryValues = $null
+        if ($payload -and $payload.Registry -and $payload.Registry.Values) {
+            $registryValues = $payload.Registry.Values
+        }
+        $allowValue = $null
+        if ($registryValues -and $registryValues.PSObject.Properties['AllowDmaUnderLock']) {
+            $allowValue = ConvertTo-NullableInt $registryValues.AllowDmaUnderLock
+        }
+        $evidenceLines = @()
+        if ($payload.DeviceGuard) {
+            $dg = $payload.DeviceGuard
+            if ($dg.Status) { $evidenceLines += "DeviceGuard.Status: $($dg.Status)" }
+            if ($dg.Message) { $evidenceLines += "DeviceGuard.Message: $($dg.Message)" }
+        }
+        if ($payload.Registry -and $payload.Registry.Status) { $evidenceLines += "Registry.Status: $($payload.Registry.Status)" }
+        if ($payload.Registry -and $payload.Registry.Message) { $evidenceLines += "Registry.Message: $($payload.Registry.Message)" }
+        if ($payload.MsInfo -and $payload.MsInfo.Status) { $evidenceLines += "MsInfo.Status: $($payload.MsInfo.Status)" }
+        if ($payload.MsInfo -and $payload.MsInfo.Message) { $evidenceLines += "MsInfo.Message: $($payload.MsInfo.Message)" }
+        $dmaEvidence = ($evidenceLines | Where-Object { $_ }) -join "`n"
+
+        if ($allowValue -eq 0) {
+            Add-CategoryNormal -CategoryResult $result -Title 'Kernel DMA protection enforced' -Evidence $dmaEvidence
+        } elseif ($allowValue -eq 1) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Kernel DMA protection allows DMA while locked on this device (AllowDmaUnderLock = 1).' -Evidence $dmaEvidence
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Kernel DMA protection unknown. Confirm DMA protection capabilities.' -Evidence $dmaEvidence
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Kernel DMA protection unknown. Confirm DMA protection capabilities.'
+    }
+
+    $asrArtifact = Get-AnalyzerArtifact -Context $Context -Name 'asr'
+    if ($asrArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $asrArtifact)
+        $ruleMap = @{}
+        if ($payload -and $payload.Policy -and -not $payload.Policy.Error -and $payload.Policy.Rules) {
+            foreach ($rule in (ConvertTo-List $payload.Policy.Rules)) {
+                if (-not $rule) { continue }
+                $id = $rule.RuleId
+                if (-not $id) { $id = $rule.Id }
+                if (-not $id) { continue }
+                $normalized = $id.ToString().ToUpperInvariant()
+                $action = $null
+                if ($rule.PSObject.Properties['Action']) { $action = ConvertTo-NullableInt $rule.Action }
+                $ruleMap[$normalized] = $action
+            }
+            $requiredRules = @(
+                @{ Label = 'Block Office macros from Internet'; Ids = @('3B576869-A4EC-4529-8536-B80A7769E899') },
+                @{ Label = 'Block Win32 API calls from Office'; Ids = @('D4F940AB-401B-4EFC-AADC-AD5F3C50688A') },
+                @{ Label = 'Block executable content from email/WebDAV'; Ids = @('BE9BA2D9-53EA-4CDC-84E5-9B1EEEE46550','D3E037E1-3EB8-44C8-A917-57927947596D') },
+                @{ Label = 'Block credential stealing from LSASS'; Ids = @('9E6C4E1F-7D60-472F-B5E9-2D3BEEB1BF0E') }
+            )
+            foreach ($set in $requiredRules) {
+                $missing = @()
+                $nonBlocking = @()
+                foreach ($id in $set.Ids) {
+                    $lookup = $id.ToUpperInvariant()
+                    if (-not $ruleMap.ContainsKey($lookup)) {
+                        $missing += $lookup
+                        continue
+                    }
+                    if ($ruleMap[$lookup] -ne 1) {
+                        $nonBlocking += "{0} => {1}" -f $lookup, $ruleMap[$lookup]
+                    }
+                }
+                if ($missing.Count -eq 0 -and $nonBlocking.Count -eq 0) {
+                    $evidence = ($set.Ids | ForEach-Object { "{0} => 1" -f $_ }) -join "`n"
+                    Add-CategoryNormal -CategoryResult $result -Title ("ASR blocking enforced: {0}" -f $set.Label) -Evidence $evidence
+                } else {
+                    $detailParts = @()
+                    if ($missing.Count -gt 0) { $detailParts += ("Missing rule(s): {0}" -f ($missing -join ', ')) }
+                    if ($nonBlocking.Count -gt 0) { $detailParts += ("Non-blocking: {0}" -f ($nonBlocking -join '; ')) }
+                    $detailText = if ($detailParts.Count -gt 0) { $detailParts -join '; ' } else { 'Rule not enforced.' }
+                    $evidenceLines = @()
+                    foreach ($id in $set.Ids) {
+                        $lookup = $id.ToUpperInvariant()
+                        if ($ruleMap.ContainsKey($lookup)) {
+                            $evidenceLines += "{0} => {1}" -f $lookup, $ruleMap[$lookup]
+                        } else {
+                            $evidenceLines += "{0} => (missing)" -f $lookup
+                        }
+                    }
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("ASR rule not enforced: {0}. Configure to Block (1)." -f $set.Label) -Evidence ($evidenceLines -join "`n")
+                }
+            }
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'ASR policy data missing. Configure required Attack Surface Reduction rules.'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'ASR policy data missing. Configure required Attack Surface Reduction rules.'
+    }
+
+    $exploitArtifact = Get-AnalyzerArtifact -Context $Context -Name 'exploit-protection'
+    if ($exploitArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $exploitArtifact)
+        if ($payload -and $payload.Mitigations -and -not $payload.Mitigations.Error) {
+            $mitigations = $payload.Mitigations
+            $cfgEnabled = ConvertTo-NullableBool ($mitigations.CFG.Enable)
+            $depEnabled = ConvertTo-NullableBool ($mitigations.DEP.Enable)
+            $aslrEnabled = ConvertTo-NullableBool ($mitigations.ASLR.Enable)
+            $evidence = @()
+            if ($mitigations.CFG.Enable -ne $null) { $evidence += "CFG.Enable: $($mitigations.CFG.Enable)" }
+            if ($mitigations.DEP.Enable -ne $null) { $evidence += "DEP.Enable: $($mitigations.DEP.Enable)" }
+            if ($mitigations.ASLR.Enable -ne $null) { $evidence += "ASLR.Enable: $($mitigations.ASLR.Enable)" }
+            $evidenceText = $evidence -join "`n"
+            if (($cfgEnabled -eq $true) -and ($depEnabled -eq $true) -and ($aslrEnabled -eq $true)) {
+                Add-CategoryNormal -CategoryResult $result -Title 'Exploit protection mitigations enforced (CFG/DEP/ASLR)' -Evidence $evidenceText
+            } else {
+                $details = @()
+                if ($cfgEnabled -ne $true) { $details += 'CFG disabled' }
+                if ($depEnabled -ne $true) { $details += 'DEP disabled' }
+                if ($aslrEnabled -ne $true) { $details += 'ASLR disabled' }
+                $detailText = if ($details.Count -gt 0) { $details -join '; ' } else { 'Mitigation status unknown.' }
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ('Exploit protection mitigations not fully enabled ({0}).' -f $detailText) -Evidence $evidenceText
+            }
+        } elseif ($payload -and $payload.Mitigations -and $payload.Mitigations.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Exploit Protection not captured. Collect Get-ProcessMitigation output.' -Evidence $payload.Mitigations.Error
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Exploit Protection not captured. Collect Get-ProcessMitigation output.'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Exploit Protection not captured. Collect Get-ProcessMitigation output.'
+    }
+
     $wdacArtifact = Get-AnalyzerArtifact -Context $Context -Name 'wdac'
     if ($wdacArtifact) {
         $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $wdacArtifact)
+        $wdacEvidenceLines = @()
+        if ($payload -and $payload.DeviceGuard -and -not $payload.DeviceGuard.Error) {
+            $dgSection = $payload.DeviceGuard
+            $wdacEvidenceLines += "SecurityServicesRunning: $($dgSection.SecurityServicesRunning)"
+            $wdacEvidenceLines += "SecurityServicesConfigured: $($dgSection.SecurityServicesConfigured)"
+            if ($securityServicesRunning.Count -eq 0) { $securityServicesRunning = ConvertTo-IntArray $dgSection.SecurityServicesRunning }
+            if ($securityServicesConfigured.Count -eq 0) { $securityServicesConfigured = ConvertTo-IntArray $dgSection.SecurityServicesConfigured }
+            if ($availableSecurityProperties.Count -eq 0) { $availableSecurityProperties = ConvertTo-IntArray $dgSection.AvailableSecurityProperties }
+            if ($requiredSecurityProperties.Count -eq 0) { $requiredSecurityProperties = ConvertTo-IntArray $dgSection.RequiredSecurityProperties }
+        }
+
+        $wdacEnforced = $false
+        if ($securityServicesRunning -contains 4 -or $securityServicesConfigured -contains 4) { $wdacEnforced = $true }
+
+        if ($payload -and $payload.Registry) {
+            foreach ($entry in (ConvertTo-List $payload.Registry)) {
+                if ($entry.Path -and $entry.Path -match 'Control\\CI') {
+                    foreach ($prop in $entry.Values.PSObject.Properties) {
+                        if ($prop.Name -match '^PS') { continue }
+                        $wdacEvidenceLines += ("{0}: {1}" -f $prop.Name, $prop.Value)
+                        if ($prop.Name -match 'PolicyEnforcement' -and (ConvertTo-NullableInt $prop.Value) -ge 1) {
+                            $wdacEnforced = $true
+                        }
+                    }
+                }
+            }
+        }
+
+        if ($wdacEnforced) {
+            Add-CategoryNormal -CategoryResult $result -Title 'WDAC policy enforcement detected' -Evidence ($wdacEvidenceLines -join "`n")
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'No WDAC policy enforcement detected. Evaluate Application Control requirements.' -Evidence ($wdacEvidenceLines -join "`n")
+        }
+
         $smartAppEvidence = @()
         $smartAppState = $null
-
         if ($payload -and $payload.SmartAppControl) {
             $entry = $payload.SmartAppControl
             if ($entry.Error) {
@@ -169,58 +456,164 @@ function Invoke-SecurityHeuristics {
             }
         }
 
-        if ($null -eq $smartAppState -and $payload -and $payload.Registry) {
-            $registryEntries = @()
-            if ($payload.Registry -is [System.Collections.IEnumerable] -and -not ($payload.Registry -is [string])) {
-                $registryEntries = @($payload.Registry)
-            } else {
-                $registryEntries = @($payload.Registry)
-            }
-
-            $registryMatch = $registryEntries | Where-Object { $_.Path -and $_.Path -match 'SmartAppControl' } | Select-Object -First 1
-            if ($registryMatch -and $registryMatch.Values) {
-                foreach ($prop in $registryMatch.Values.PSObject.Properties) {
-                    if ($prop.Name -match '^PS') { continue }
-                    $smartAppEvidence += ("{0}: {1}" -f $prop.Name, $prop.Value)
-                    $candidate = $prop.Value
-                    if ($null -ne $candidate) {
-                        $parsed = 0
-                        if ([int]::TryParse($candidate.ToString(), [ref]$parsed)) {
-                            if ($prop.Name -match 'Enabled' -or $prop.Name -match 'State') {
-                                $smartAppState = $parsed
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         $evidenceText = if ($smartAppEvidence.Count -gt 0) { $smartAppEvidence -join "`n" } else { '' }
-
         if ($smartAppState -eq 1) {
             Add-CategoryNormal -CategoryResult $result -Title 'Smart App Control enforced' -Evidence $evidenceText
         } elseif ($smartAppState -eq 2) {
             $severity = if ($isWindows11) { 'low' } else { 'info' }
             Add-CategoryIssue -CategoryResult $result -Severity $severity -Title 'Smart App Control in evaluation mode' -Evidence $evidenceText
         } elseif ($isWindows11) {
-            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Smart App Control not enabled on Windows 11 device' -Evidence $evidenceText
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Smart App Control is not enabled on Windows 11 device.' -Evidence $evidenceText
         } elseif ($smartAppState -ne $null) {
             Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Smart App Control disabled' -Evidence $evidenceText
         }
     }
 
-    $lapsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'laps'
+    $lapsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'laps_localadmin'
+    if (-not $lapsArtifact) {
+        $lapsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'laps'
+    }
     if ($lapsArtifact) {
         $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $lapsArtifact)
-        if ($payload -and $payload.LocalAdministrators) {
-            $admins = $payload.LocalAdministrators | Where-Object { $_.AccountName -and -not $_.IsBuiltIn }
-            if ($admins.Count -gt 0) {
-                $names = $admins | Select-Object -First 5 -ExpandProperty AccountName
-                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ('Standing local administrators detected: {0}' -f ($names -join ', '))
-            } else {
-                Add-CategoryNormal -CategoryResult $result -Title 'No additional local administrators detected'
+        $lapsPolicies = $null
+        if ($payload -and $payload.LapsPolicies) {
+            $lapsPolicies = $payload.LapsPolicies
+        } elseif ($payload -and $payload.Policy) {
+            $lapsPolicies = $payload.Policy
+        }
+
+        $lapsEnabled = $false
+        $lapsEvidenceLines = @()
+        if ($lapsPolicies) {
+            foreach ($prop in $lapsPolicies.PSObject.Properties) {
+                if ($prop.Name -match '^PS') { continue }
+                $value = $prop.Value
+                if ($null -eq $value) { continue }
+                if ($value -is [System.Collections.IEnumerable] -and -not ($value -is [string])) {
+                    foreach ($inner in $value) {
+                        $lapsEvidenceLines += ("{0}: {1}" -f $prop.Name, $inner)
+                    }
+                } else {
+                    $lapsEvidenceLines += ("{0}: {1}" -f $prop.Name, $value)
+                }
+                if ($prop.Name -match 'Enabled' -and (ConvertTo-NullableInt $value) -eq 1) { $lapsEnabled = $true }
+                if ($prop.Name -match 'BackupDirectory' -and -not [string]::IsNullOrWhiteSpace($value.ToString())) { $lapsEnabled = $true }
             }
         }
+
+        if ($lapsEnabled) {
+            Add-CategoryNormal -CategoryResult $result -Title 'LAPS/PLAP policy detected' -Evidence ($lapsEvidenceLines -join "`n")
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'LAPS/PLAP not detected. Enforce password management policy.' -Evidence ($lapsEvidenceLines -join "`n")
+        }
+    }
+
+    $runAsPpl = ConvertTo-NullableInt (Get-RegistryValueFromEntries -Entries $lsaEntries -PathPattern 'Control\\\\Lsa$' -Name 'RunAsPPL')
+    $runAsPplBoot = ConvertTo-NullableInt (Get-RegistryValueFromEntries -Entries $lsaEntries -PathPattern 'Control\\\\Lsa$' -Name 'RunAsPPLBoot')
+    $credentialGuardRunning = ($securityServicesRunning -contains 1)
+    $lsaEvidenceLines = @()
+    if ($credentialGuardRunning) { $lsaEvidenceLines += 'SecurityServicesRunning includes 1 (Credential Guard).' }
+    if ($runAsPpl -ne $null) { $lsaEvidenceLines += "RunAsPPL: $runAsPpl" }
+    if ($runAsPplBoot -ne $null) { $lsaEvidenceLines += "RunAsPPLBoot: $runAsPplBoot" }
+    $lsaEvidence = $lsaEvidenceLines -join "`n"
+    if ($credentialGuardRunning -and $runAsPpl -eq 1) {
+        Add-CategoryNormal -CategoryResult $result -Title 'Credential Guard with LSA protection enabled' -Evidence $lsaEvidence
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Credential Guard or LSA protection is not enforced. Enable RunAsPPL and Credential Guard.' -Evidence $lsaEvidence
+    }
+
+    $deviceGuardEvidenceLines = @()
+    if ($securityServicesConfigured.Count -gt 0) { $deviceGuardEvidenceLines += "Configured: $($securityServicesConfigured -join ',')" }
+    if ($securityServicesRunning.Count -gt 0) { $deviceGuardEvidenceLines += "Running: $($securityServicesRunning -join ',')" }
+    if ($availableSecurityProperties.Count -gt 0) { $deviceGuardEvidenceLines += "Available: $($availableSecurityProperties -join ',')" }
+    if ($requiredSecurityProperties.Count -gt 0) { $deviceGuardEvidenceLines += "Required: $($requiredSecurityProperties -join ',')" }
+    $hvciEvidence = $deviceGuardEvidenceLines -join "`n"
+    $hvciRunning = ($securityServicesRunning -contains 2)
+    $hvciAvailable = ($availableSecurityProperties -contains 2) -or ($requiredSecurityProperties -contains 2)
+    if ($hvciRunning) {
+        Add-CategoryNormal -CategoryResult $result -Title 'Memory integrity (HVCI) running' -Evidence $hvciEvidence
+    } elseif ($hvciAvailable) {
+        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Memory integrity (HVCI) is available but not running. Enable virtualization-based protection.' -Evidence $hvciEvidence
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Memory integrity (HVCI) not captured. Collect Device Guard diagnostics.' -Evidence $hvciEvidence
+    }
+
+    $uacArtifact = Get-AnalyzerArtifact -Context $Context -Name 'uac'
+    if ($uacArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $uacArtifact)
+        if ($payload -and $payload.Policy -and -not $payload.Policy.Error) {
+            $policy = $payload.Policy
+            $enableLua = ConvertTo-NullableInt $policy.EnableLUA
+            $consentPrompt = ConvertTo-NullableInt $policy.ConsentPromptBehaviorAdmin
+            $secureDesktop = ConvertTo-NullableInt $policy.PromptOnSecureDesktop
+            $evidence = ($policy.PSObject.Properties | Where-Object { $_.Name -notmatch '^PS' } | ForEach-Object { "{0} = {1}" -f $_.Name, $_.Value }) -join "`n"
+            if ($enableLua -eq 1 -and ($secureDesktop -eq $null -or $secureDesktop -eq 1) -and ($consentPrompt -eq $null -or $consentPrompt -ge 2)) {
+                Add-CategoryNormal -CategoryResult $result -Title 'UAC configured with secure prompts' -Evidence $evidence
+            } else {
+                $findings = @()
+                if ($enableLua -ne 1) { $findings += 'EnableLUA=0' }
+                if ($consentPrompt -ne $null -and $consentPrompt -lt 2) { $findings += "ConsentPrompt=$consentPrompt" }
+                if ($secureDesktop -ne $null -and $secureDesktop -eq 0) { $findings += 'PromptOnSecureDesktop=0' }
+                $detail = if ($findings.Count -gt 0) { $findings -join '; ' } else { 'UAC configuration unclear.' }
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ('UAC configuration is insecure ({0}). Enforce secure UAC prompts.' -f $detail) -Evidence $evidence
+            }
+        }
+    }
+
+    $psLoggingArtifact = Get-AnalyzerArtifact -Context $Context -Name 'powershell-logging'
+    if ($psLoggingArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $psLoggingArtifact)
+        if ($payload -and $payload.Policies) {
+            $scriptBlockEnabled = $false
+            $moduleLoggingEnabled = $false
+            $transcriptionEnabled = $false
+            $evidenceLines = @()
+            foreach ($policy in (ConvertTo-List $payload.Policies)) {
+                if (-not $policy -or -not $policy.Values) { continue }
+                foreach ($prop in $policy.Values.PSObject.Properties) {
+                    if ($prop.Name -match '^PS') { continue }
+                    $evidenceLines += ("{0} ({1}): {2}" -f $prop.Name, $policy.Path, $prop.Value)
+                    switch -Regex ($prop.Name) {
+                        'EnableScriptBlockLogging' { if ((ConvertTo-NullableInt $prop.Value) -eq 1) { $scriptBlockEnabled = $true } }
+                        'EnableModuleLogging'     { if ((ConvertTo-NullableInt $prop.Value) -eq 1) { $moduleLoggingEnabled = $true } }
+                        'EnableTranscripting'     { if ((ConvertTo-NullableInt $prop.Value) -eq 1) { $transcriptionEnabled = $true } }
+                    }
+                }
+            }
+            if ($scriptBlockEnabled -and $moduleLoggingEnabled) {
+                Add-CategoryNormal -CategoryResult $result -Title 'PowerShell logging policies enforced' -Evidence ($evidenceLines -join "`n")
+            } else {
+                $detailParts = @()
+                if (-not $scriptBlockEnabled) { $detailParts += 'Script block logging disabled' }
+                if (-not $moduleLoggingEnabled) { $detailParts += 'Module logging disabled' }
+                if (-not $transcriptionEnabled) { $detailParts += 'Transcription not enabled' }
+                $detail = if ($detailParts.Count -gt 0) { $detailParts -join '; ' } else { 'Logging state unknown.' }
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ('PowerShell logging is incomplete ({0}). Enable required logging for auditing.' -f $detail) -Evidence ($evidenceLines -join "`n")
+            }
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'PowerShell logging is incomplete (Script block logging disabled; Module logging disabled; Transcription not enabled). Enable required logging for auditing.'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'PowerShell logging is incomplete (Script block logging disabled; Module logging disabled; Transcription not enabled). Enable required logging for auditing.'
+    }
+
+    $restrictSendingLsa = ConvertTo-NullableInt (Get-RegistryValueFromEntries -Entries $lsaEntries -PathPattern 'Control\\\\Lsa$' -Name 'RestrictSendingNTLMTraffic')
+    $msvEntry = Get-RegistryValueFromEntries -Entries $lsaEntries -PathPattern 'Control\\\\Lsa\\\\MSV1_0$' -Name 'RestrictSendingNTLMTraffic'
+    $restrictSendingMsv = ConvertTo-NullableInt $msvEntry
+    $restrictReceivingMsv = ConvertTo-NullableInt (Get-RegistryValueFromEntries -Entries $lsaEntries -PathPattern 'Control\\\\Lsa\\\\MSV1_0$' -Name 'RestrictReceivingNTLMTraffic')
+    $auditReceivingMsv = ConvertTo-NullableInt (Get-RegistryValueFromEntries -Entries $lsaEntries -PathPattern 'Control\\\\Lsa\\\\MSV1_0$' -Name 'AuditReceivingNTLMTraffic')
+    $ntlmEvidenceLines = @()
+    if ($restrictSendingLsa -ne $null) { $ntlmEvidenceLines += "Lsa RestrictSendingNTLMTraffic: $restrictSendingLsa" }
+    if ($restrictSendingMsv -ne $null) { $ntlmEvidenceLines += "MSV1_0 RestrictSendingNTLMTraffic: $restrictSendingMsv" }
+    if ($restrictReceivingMsv -ne $null) { $ntlmEvidenceLines += "MSV1_0 RestrictReceivingNTLMTraffic: $restrictReceivingMsv" }
+    if ($auditReceivingMsv -ne $null) { $ntlmEvidenceLines += "MSV1_0 AuditReceivingNTLMTraffic: $auditReceivingMsv" }
+    $ntlmEvidence = $ntlmEvidenceLines -join "`n"
+    $ntlmRestricted = ($restrictSendingLsa -ge 2) -or ($restrictSendingMsv -ge 2)
+    $ntlmAudited = ($auditReceivingMsv -ge 2)
+    if ($ntlmRestricted -and $ntlmAudited) {
+        Add-CategoryNormal -CategoryResult $result -Title 'NTLM hardening policies enforced' -Evidence $ntlmEvidence
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'NTLM hardening policies are not configured. Enforce RestrictSending/Audit NTLM settings.' -Evidence $ntlmEvidence
     }
 
     return $result

--- a/Analyzers/Heuristics/Services.ps1
+++ b/Analyzers/Heuristics/Services.ps1
@@ -17,7 +17,47 @@ function Invoke-ServicesHeuristics {
     if ($servicesArtifact) {
         $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $servicesArtifact)
         if ($payload -and $payload.Services -and -not $payload.Services.Error) {
-            $stoppedAuto = $payload.Services | Where-Object {
+            $services = $payload.Services
+            if ($services -is [System.Collections.IEnumerable] -and -not ($services -is [string])) {
+                $services = @($services)
+            } else {
+                $services = @($services)
+            }
+
+            $lookup = @{}
+            foreach ($service in $services) {
+                if (-not $service) { continue }
+                if ($service.PSObject.Properties['Name']) {
+                    $lookup[[string]$service.Name] = $service
+                }
+            }
+
+            if ($lookup.ContainsKey('BITS')) {
+                $bits = $lookup['BITS']
+                $status = if ($bits.PSObject.Properties['State']) { [string]$bits.State } elseif ($bits.PSObject.Properties['Status']) { [string]$bits.Status } else { 'Unknown' }
+                $startMode = if ($bits.PSObject.Properties['StartMode']) { [string]$bits.StartMode } elseif ($bits.PSObject.Properties['StartType']) { [string]$bits.StartType } else { 'Unknown' }
+                $statusNorm = if ($status) { $status.ToLowerInvariant() } else { '' }
+                $startNorm = if ($startMode) { $startMode.ToLowerInvariant() } else { '' }
+
+                if ($startNorm -like 'auto*' -and $statusNorm -notlike 'running') {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'BITS stopped — background transfers for updates/AV/Office.' -Evidence ("Status: {0}; StartType: {1}" -f $status, $startMode)
+                } elseif ($startNorm -eq 'manual' -and $statusNorm -notlike 'running') {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'BITS stopped (Manual start) — background transfers for updates/AV/Office.' -Evidence ("Status: {0}; StartType: {1}" -f $status, $startMode)
+                } elseif ($startNorm -like 'disabled*') {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'BITS disabled — background transfers for updates/AV/Office.' -Evidence ("Status: {0}; StartType: {1}" -f $status, $startMode)
+                }
+            }
+
+            if ($lookup.ContainsKey('Spooler')) {
+                $spooler = $lookup['Spooler']
+                $status = if ($spooler.PSObject.Properties['State']) { [string]$spooler.State } elseif ($spooler.PSObject.Properties['Status']) { [string]$spooler.Status } else { 'Unknown' }
+                $startMode = if ($spooler.PSObject.Properties['StartMode']) { [string]$spooler.StartMode } elseif ($spooler.PSObject.Properties['StartType']) { [string]$spooler.StartType } else { 'Unknown' }
+                if ($status -notmatch '(?i)running') {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Print Spooler service not running (Status: {0}, StartType: {1})." -f $status, $startMode) -Evidence ("Status: {0}; StartType: {1}" -f $status, $startMode)
+                }
+            }
+
+            $stoppedAuto = $services | Where-Object {
                 ($_.StartMode -eq 'Auto' -or $_.StartType -eq 'Automatic') -and ($_.State -ne 'Running' -and $_.Status -ne 'Running')
             }
             if ($stoppedAuto.Count -gt 0) {
@@ -27,10 +67,10 @@ function Invoke-ServicesHeuristics {
                 Add-CategoryNormal -CategoryResult $result -Title 'Automatic services running'
             }
         } elseif ($payload.Services.Error) {
-            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to query services' -Evidence $payload.Services.Error
+            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Unable to query services' -Evidence $payload.Services.Error
         }
     } else {
-        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Services artifact missing'
+        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Services artifact missing'
     }
 
     return $result


### PR DESCRIPTION
## Summary
- elevate missing event log and service data to high-severity issues and add explicit spooler/BITS checks
- expand security heuristics to cover BitLocker recovery, ASR, Credential Guard, HVCI, NTLM, PowerShell logging, WDAC, and related gaps
- improve office, system, and printing modules to surface policy absences and match legacy messaging

## Testing
- attempted `pwsh -NoProfile -Command "Import-Module ./Modules/Common.psm1; . ./Analyzers/Heuristics/Security.ps1"` *(fails: pwsh not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d57a72a548832db34a9626b62f9cd1