### PR TITLE
Ensure critical evidence text uses critical color palette

### DIFF
--- a/AutoL1/styles/device-health-report.css
+++ b/AutoL1/styles/device-health-report.css
@@ -95,6 +95,10 @@ details.report-card[open] > summary {
   line-height: 1.6;
 }
 
+.report-card--critical .report-card__explanation {
+  color: var(--color-state-critical-text);
+}
+
 .report-card__body > .report-card__explanation:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- ensure explanatory text inside critical report cards inherits the yellow critical color for better contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d65e4cbab4832d88db25ce1b1c7647