### PR TITLE
Surface DHCP analyzer results in network summary

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -113,13 +113,21 @@ function Add-CategoryNormal {
         [Parameter(Mandatory)]
         [string]$Title,
 
-        [object]$Evidence = $null
+        [object]$Evidence = $null,
+
+        [string]$Subcategory = $null
     )
 
-    $CategoryResult.Normals.Add([pscustomobject]@{
-            Title    = $Title
-            Evidence = $Evidence
-        }) | Out-Null
+    $entry = [ordered]@{
+        Title    = $Title
+        Evidence = $Evidence
+    }
+
+    if ($PSBoundParameters.ContainsKey('Subcategory') -and $Subcategory) {
+        $entry['Subcategory'] = $Subcategory
+    }
+
+    $CategoryResult.Normals.Add([pscustomobject]$entry) | Out-Null
 }
 
 function Add-CategoryCheck {


### PR DESCRIPTION
## Summary
- allow analyzer normals to capture subcategory metadata so DHCP findings surface under Network/DHCP
- run the DHCP analyzer scripts from the network heuristics, mapping their results into issues or healthy summaries
- add helpers for kebab-case conversion and automatic analyzer discovery to aggregate DHCP checks

## Testing
- not run (PowerShell runtime not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d69078d30c832d9f9d3d76784122af