### PR TITLE
Adopt approved verbs for Common module helpers

### DIFF
--- a/Analyzers/HtmlComposer.ps1
+++ b/Analyzers/HtmlComposer.ps1
@@ -133,7 +133,7 @@ function Convert-ToIssueCard {
         $Issue
     )
 
-    $severity = Normalize-Severity $Issue.Severity
+    $severity = ConvertTo-NormalizedSeverity $Issue.Severity
     $detail = Format-AnalyzerEvidence -Value $Issue.Evidence
     $hasNewLines = $detail -match "\r|\n"
 

--- a/AutoL1/Analyze-Diagnostics.ps1
+++ b/AutoL1/Analyze-Diagnostics.ps1
@@ -1316,7 +1316,7 @@ function Get-IssueExplanation {
     return "Broken Autodiscover SCP records keep domain-joined PCs from finding the right Exchange endpoints. Outlook may connect to the wrong place or fail to sign in on the internal network." 
   }
 
-  $severityWord = Normalize-Severity $Severity
+  $severityWord = ConvertTo-NormalizedSeverity $Severity
   if (-not $severityWord) { $severityWord = 'issue' }
   return "This $severityWord points to something outside the normal health baseline. Reviewing the evidence and correcting it will help keep the device stable and secure."
 }
@@ -1338,7 +1338,7 @@ function Add-Issue(
     }
 
     # normalize
-    $sevKey = Normalize-Severity $Severity
+    $sevKey = ConvertTo-NormalizedSeverity $Severity
     switch -regex ($sevKey){
         '^(crit(ical)?)$' { $sevKey = 'critical' }
         '^(hi(gh)?)$'     { $sevKey = 'high' }
@@ -5461,7 +5461,7 @@ if ($raw['disks']) {
 
     if ($disk.IsBoot -eq $true -or $disk.IsSystem -eq $true) {
       if ($severity) {
-        $severity = Promote-Severity $severity 1
+        $severity = ConvertTo-EscalatedSeverity $severity 1
       } else {
         $severity = 'high'
       }
@@ -5562,7 +5562,7 @@ if ($raw['volumes']) {
     }
 
     if ($driveLetter -and $driveLetter.Length -gt 0 -and $driveLetter.ToUpperInvariant() -eq 'C') {
-      $severity = if ($severity) { Promote-Severity $severity 1 } else { 'medium' }
+      $severity = if ($severity) { ConvertTo-EscalatedSeverity $severity 1 } else { 'medium' }
     }
 
     if (-not $severity) { $severity = 'medium' }
@@ -5989,7 +5989,7 @@ if ($issues.Count -eq 0){
 
   foreach ($entry in $sortedIssues) {
     $cardHtml = New-IssueCardHtml -Entry $entry
-    $severityKey = Normalize-Severity $entry.Severity
+    $severityKey = ConvertTo-NormalizedSeverity $entry.Severity
     if ($severityKey -and $groupedIssues.ContainsKey($severityKey)) {
       $groupedIssues[$severityKey].Add($cardHtml)
     } else {

--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -14,7 +14,7 @@ if (-not ([System.Collections.Specialized.OrderedDictionary].GetMethods() | Wher
 
 $script:SeverityOrder = @('info','warning','low','medium','high','critical')
 
-function Normalize-Severity {
+function ConvertTo-NormalizedSeverity {
   param($Severity)
 
   if ($null -eq $Severity) { return '' }
@@ -42,7 +42,7 @@ function Get-SeverityIndex {
 
   if (-not $Severity) { return -1 }
 
-  $normalized = Normalize-Severity $Severity
+  $normalized = ConvertTo-NormalizedSeverity $Severity
   if (-not $normalized) { return -1 }
 
   return $script:SeverityOrder.IndexOf($normalized)
@@ -61,7 +61,7 @@ function Get-MaxSeverity {
   return $Second
 }
 
-function Promote-Severity {
+function ConvertTo-EscalatedSeverity {
   param(
     [string]$Severity,
     [int]$Steps = 1

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ You can re-run the analyzer against existing collections—only the `-InputFolde
 | `/Reports` | Static HTML/CSS prototypes and assets for presenting analyzer output. |
 | `/Modules` | Cross-cutting PowerShell modules that can be imported by collectors, analyzers, or orchestration scripts. |
 
+## Troubleshooting PowerShell warnings
+
+PowerShell enforces a list of "approved" verbs so that commands follow discoverable naming conventions (for example, `Get-*`, `Set-*`, `New-*`). The built-in AutoHelpDesk modules now export helper functions using approved verbs, so importing them no longer emits name-check warnings. If you add your own helper functions and see warnings such as:
+
+> `WARNING: The names of some imported commands from the module 'Common' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.`
+
+identify the offending commands by importing with `-Verbose`:
+
+```powershell
+Import-Module .\Modules\Common\Common.psm1 -Verbose
+```
+
+Then rename those functions so their verb appears in the output of `Get-Verb` (or choose an approved prefix such as `ConvertTo-` or `Get-`). Suppressing the warning with `Import-Module -DisableNameChecking` is possible, but using approved verbs keeps commands discoverable and avoids future warnings.
+
 ### Artifact format
 
 All collector scripts use `CollectorCommon.ps1` helpers to enforce a consistent JSON envelope:


### PR DESCRIPTION
## Summary
- rename Common module helper functions to use approved PowerShell verbs and update all call sites
- refresh the troubleshooting note to reflect the removal of name-check warnings when importing the module

## Testing
- not run (pwsh not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d68efbfe04832daf944bd78baf4506