### PR TITLE
Fix pseudo interface detection in network analyzer

### DIFF
--- a/Analyzers/Heuristics/Network.ps1
+++ b/Analyzers/Heuristics/Network.ps1
@@ -569,7 +569,7 @@ function Invoke-NetworkHeuristics {
                 if (-not $addresses -or $addresses.Count -eq 0) {
                     if ($isEligible) {
                         if (-not ($missingInterfaces -contains $alias)) { $missingInterfaces += $alias }
-                    } elseif (($interfaceInfo -and $interfaceInfo.IsPseudo) -or (Test-NetworkPseudoInterface -Alias $alias -Description (if ($interfaceInfo) { $interfaceInfo.Description } else { $null }))) {
+                    } elseif (($interfaceInfo -and $interfaceInfo.IsPseudo) -or (Test-NetworkPseudoInterface -Alias $alias -Description $(if ($interfaceInfo) { $interfaceInfo.Description } else { $null }))) {
                         if (-not ($ignoredPseudo -contains $alias)) { $ignoredPseudo += $alias }
                     }
                     continue


### PR DESCRIPTION
## Summary
- ensure the DNS heuristic passes a resolved description using `$(if ...)` so Windows PowerShell treats it as an expression instead of invoking `if`

## Testing
- /tmp/pwsh/pwsh -NoLogo -NoProfile -File /tmp/find_if_analyzers.ps1

------
https://chatgpt.com/codex/tasks/task_e_68d699200bcc832d83c0ae126be869af