### PR TITLE
Add Defender tamper/cloud protection heuristics

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -94,15 +94,23 @@ function Add-CategoryIssue {
 
         [object]$Evidence = $null,
 
-        [string]$Subcategory = $null
+        [string]$Subcategory = $null,
+
+        [string]$CheckId = $null
     )
 
-    $CategoryResult.Issues.Add([pscustomobject]@{
-            Severity = $Severity
-            Title    = $Title
-            Evidence = $Evidence
-            Subcategory = $Subcategory
-        }) | Out-Null
+    $entry = [ordered]@{
+        Severity    = $Severity
+        Title       = $Title
+        Evidence    = $Evidence
+        Subcategory = $Subcategory
+    }
+
+    if ($PSBoundParameters.ContainsKey('CheckId') -and -not [string]::IsNullOrWhiteSpace($CheckId)) {
+        $entry['CheckId'] = $CheckId
+    }
+
+    $CategoryResult.Issues.Add([pscustomobject]$entry) | Out-Null
 }
 
 function Add-CategoryNormal {
@@ -115,7 +123,9 @@ function Add-CategoryNormal {
 
         [object]$Evidence = $null,
 
-        [string]$Subcategory = $null
+        [string]$Subcategory = $null,
+
+        [string]$CheckId = $null
     )
 
     $entry = [ordered]@{
@@ -125,6 +135,10 @@ function Add-CategoryNormal {
 
     if ($PSBoundParameters.ContainsKey('Subcategory') -and $Subcategory) {
         $entry['Subcategory'] = $Subcategory
+    }
+
+    if ($PSBoundParameters.ContainsKey('CheckId') -and -not [string]::IsNullOrWhiteSpace($CheckId)) {
+        $entry['CheckId'] = $CheckId
     }
 
     $CategoryResult.Normals.Add([pscustomobject]$entry) | Out-Null

--- a/Collectors/Security/Collect-Defender.ps1
+++ b/Collectors/Security/Collect-Defender.ps1
@@ -40,7 +40,7 @@ function Get-DefenderThreatStatistics {
 function Get-DefenderPreferences {
     try {
         $prefs = Get-MpPreference -ErrorAction Stop
-        return $prefs | Select-Object DisableRealtimeMonitoring, DisableIOAVProtection, DisablePrivacyMode, DisableIntrusionPreventionSystem, DisableScriptScanning, ScanScheduleDay, ScanScheduleTime, SignatureScheduleDay, SignatureScheduleTime, MAPSReporting, SubmitSamplesConsent, EnableNetworkProtection, UILockdownMode
+        return $prefs | Select-Object DisableTamperProtection, DisableRealtimeMonitoring, DisableIOAVProtection, DisablePrivacyMode, DisableIntrusionPreventionSystem, DisableScriptScanning, ScanScheduleDay, ScanScheduleTime, SignatureScheduleDay, SignatureScheduleTime, MAPSReporting, SubmitSamplesConsent, CloudBlockLevel, EnableNetworkProtection, UILockdownMode
     } catch {
         return [PSCustomObject]@{
             Source = 'Get-MpPreference'


### PR DESCRIPTION
## Summary
- collect Defender preference fields for tamper protection and cloud-delivered protection analysis
- allow analyzer issues and normals to carry CheckId metadata for downstream checks
- add Defender preference heuristics that flag tamper protection/cloud protection gaps and record healthy baselines

## Testing
- PowerShell not available in container (`pwsh` and `powershell` commands missing)

------
https://chatgpt.com/codex/tasks/task_e_68d69b73f8c8832d8101248d4351b2ab