### PR TITLE
Add Defender platform baseline checks

### DIFF
--- a/Collectors/Security/Collect-Defender.ps1
+++ b/Collectors/Security/Collect-Defender.ps1
@@ -13,10 +13,22 @@ param(
 function Get-DefenderStatus {
     try {
         $status = Get-MpComputerStatus -ErrorAction Stop
-        return $status | Select-Object AMServiceEnabled, AntispywareEnabled, AntivirusEnabled, IoavProtectionEnabled, RealTimeProtectionEnabled, TamperProtectionEnabled, IsTamperProtected, NISEnabled, QuickScanEndTime, FullScanEndTime, ProductStatus, AntivirusSignatureVersion, AntispywareSignatureVersion
+        return $status | Select-Object AMServiceEnabled, AntispywareEnabled, AntivirusEnabled, IoavProtectionEnabled, RealTimeProtectionEnabled, TamperProtectionEnabled, IsTamperProtected, NISEnabled, QuickScanEndTime, FullScanEndTime, ProductStatus, AMEngineVersion, AntimalwareEngineVersion, AMProductVersion, NISPlatformVersion, AntivirusSignatureVersion, AntispywareSignatureVersion
     } catch {
         return [PSCustomObject]@{
             Source = 'Get-MpComputerStatus'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-OperatingSystemBuild {
+    try {
+        $os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
+        return $os | Select-Object Caption, Version, BuildNumber
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-CimInstance Win32_OperatingSystem'
             Error  = $_.Exception.Message
         }
     }
@@ -54,6 +66,7 @@ function Invoke-Main {
         Status       = Get-DefenderStatus
         Threats      = Get-DefenderThreatStatistics
         Preferences  = Get-DefenderPreferences
+        OperatingSystem = Get-OperatingSystemBuild
     }
 
     $result = New-CollectorMetadata -Payload $payload


### PR DESCRIPTION
## Summary
- collect Defender platform and engine version details along with OS build context in the Defender collector
- add a security heuristic that reads Defender platform baseline requirements from configuration and reports below-baseline versions
- teach the AutoL1 analyzer to honor the baseline configuration, emit the Security/DefenderPlatformAge check, and surface GOOD evidence when the platform meets requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d69b7dc9b4832dbc7283fc8d087753