### PR TITLE
Add service crash loop heuristic

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -94,15 +94,28 @@ function Add-CategoryIssue {
 
         [object]$Evidence = $null,
 
-        [string]$Subcategory = $null
+        [string]$Subcategory = $null,
+
+        [string]$CheckId = $null
     )
 
-    $CategoryResult.Issues.Add([pscustomobject]@{
-            Severity = $Severity
-            Title    = $Title
-            Evidence = $Evidence
-            Subcategory = $Subcategory
-        }) | Out-Null
+    $issue = [ordered]@{
+        Severity = $Severity
+        Title    = $Title
+        Evidence = $Evidence
+    }
+
+    if ($PSBoundParameters.ContainsKey('Subcategory')) {
+        $issue['Subcategory'] = $Subcategory
+    } else {
+        $issue['Subcategory'] = $null
+    }
+
+    if ($PSBoundParameters.ContainsKey('CheckId') -and $CheckId) {
+        $issue['CheckId'] = $CheckId
+    }
+
+    $CategoryResult.Issues.Add([pscustomobject]$issue) | Out-Null
 }
 
 function Add-CategoryNormal {


### PR DESCRIPTION
## Summary
- extend analyzer issue helper to store optional check identifiers
- add service crash loop detection that inspects recent system/application events
- report repeated service crashes with severity tiers and module evidence while marking clean systems as healthy

## Testing
- No automated tests were run (PowerShell is unavailable in the container).


------
https://chatgpt.com/codex/tasks/task_e_68d69bee2d78832d8172bbe3a542865e