### PR TITLE
Add Wi-Fi signal and roaming heuristics

### DIFF
--- a/Analyzers/Heuristics/Network.ps1
+++ b/Analyzers/Heuristics/Network.ps1
@@ -177,6 +177,147 @@ function Test-NetworkPseudoInterface {
     return $false
 }
 
+function Test-NetworkErrorEntry {
+    param($Value)
+
+    if (-not $Value) { return $false }
+
+    try {
+        if ($Value.PSObject -and $Value.PSObject.Properties['Error'] -and $Value.Error) { return $true }
+    } catch {
+        return $false
+    }
+
+    return $false
+}
+
+function ConvertTo-NetworkDateTime {
+    param([string]$Value)
+
+    if (-not $Value) { return $null }
+
+    try {
+        $styles = [System.Globalization.DateTimeStyles]::RoundtripKind
+        return [datetime]::Parse($Value, [System.Globalization.CultureInfo]::InvariantCulture, $styles)
+    } catch {
+        try {
+            return [datetime]::Parse($Value)
+        } catch {
+            return $null
+        }
+    }
+}
+
+function Get-NetworkWifiRoamSummary {
+    param(
+        [System.Collections.IEnumerable]$Events,
+        [int]$LookbackMinutes = 30
+    )
+
+    $lookback = [math]::Abs($LookbackMinutes)
+    $windowStart = (Get-Date).AddMinutes(-$lookback)
+
+    $observations = New-Object System.Collections.Generic.List[pscustomobject]
+    if (-not $Events) {
+        return [pscustomobject]@{
+            LookbackMinutes   = $lookback
+            SampleCount       = 0
+            RoamCount         = 0
+            UniqueBssidCount  = 0
+            Observations      = @()
+        }
+    }
+
+    foreach ($event in $Events) {
+        if (-not $event) { continue }
+
+        $time = $null
+        if ($event.PSObject.Properties['TimeCreated']) {
+            $time = ConvertTo-NetworkDateTime -Value $event.TimeCreated
+        }
+
+        if (-not $time) { continue }
+        if ($time -lt $windowStart) { continue }
+
+        $bssid = $null
+        foreach ($field in @('NewBssid','TargetBssid','Bssid')) {
+            if ($event.PSObject.Properties[$field] -and $event.$field) {
+                try {
+                    $bssid = ([string]$event.$field).ToLowerInvariant()
+                } catch {
+                    $bssid = [string]$event.$field
+                }
+                if ($bssid) { $bssid = $bssid -replace '-', ':' }
+                break
+            }
+        }
+
+        if (-not $bssid -and $event.PSObject.Properties['Properties']) {
+            $propertyValues = ConvertTo-NetworkArray $event.Properties
+            foreach ($value in $propertyValues) {
+                if (-not $value) { continue }
+                if ($value -match '(?i)(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}') {
+                    $candidate = ($value -replace '-', ':').ToLowerInvariant()
+                    if ($candidate) { $bssid = $candidate; break }
+                }
+            }
+        }
+
+        if (-not $bssid) { continue }
+
+        $ssidValue = $null
+        if ($event.PSObject.Properties['Ssid'] -and $event.Ssid) {
+            $ssidValue = [string]$event.Ssid
+        }
+
+        $observations.Add([pscustomobject]@{
+                Time    = $time
+                Bssid   = $bssid
+                EventId = if ($event.PSObject.Properties['Id']) { try { [int]$event.Id } catch { $event.Id } } else { $null }
+                Ssid    = $ssidValue
+            }) | Out-Null
+    }
+
+    if ($observations.Count -eq 0) {
+        return [pscustomobject]@{
+            LookbackMinutes   = $lookback
+            SampleCount       = 0
+            RoamCount         = 0
+            UniqueBssidCount  = 0
+            Observations      = @()
+        }
+    }
+
+    $sorted = $observations | Sort-Object -Property Time
+    $lastBssid = $null
+    $changes = 0
+    $evidence = New-Object System.Collections.Generic.List[pscustomobject]
+
+    foreach ($item in $sorted) {
+        if ($item.Bssid) {
+            if ($lastBssid -and $item.Bssid -ne $lastBssid) { $changes++ }
+            $lastBssid = $item.Bssid
+        }
+
+        $evidence.Add([pscustomobject]@{
+                TimeCreated = $item.Time.ToString('o')
+                Bssid       = $item.Bssid
+                EventId     = $item.EventId
+                Ssid        = $item.Ssid
+            }) | Out-Null
+    }
+
+    $uniqueBssids = ($evidence | Where-Object { $_.Bssid } | Select-Object -ExpandProperty Bssid -Unique)
+
+    return [pscustomobject]@{
+        LookbackMinutes   = $lookback
+        SampleCount       = $evidence.Count
+        RoamCount         = $changes
+        UniqueBssidCount  = $uniqueBssids.Count
+        Observations      = $evidence.ToArray()
+    }
+}
+
 function Get-NetworkDnsInterfaceInventory {
     param($AdapterPayload)
 
@@ -722,6 +863,205 @@ function Invoke-NetworkHeuristics {
                 Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'WinHTTP proxy configured' -Evidence $winHttpText -Subcategory 'Proxy Configuration'
             }
         }
+    }
+
+    $wifiArtifact = Get-AnalyzerArtifact -Context $Context -Name 'network-wifi'
+    if ($wifiArtifact) {
+        $wifiPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $wifiArtifact)
+
+        $wifiInterfacesSection = $null
+        if ($wifiPayload -and $wifiPayload.PSObject.Properties['Interfaces']) {
+            $wifiInterfacesSection = $wifiPayload.Interfaces
+        }
+
+        $wifiRaw = $null
+        if ($wifiInterfacesSection -and $wifiInterfacesSection.PSObject.Properties['Raw']) {
+            $wifiRaw = $wifiInterfacesSection.Raw
+        }
+
+        if ($wifiRaw -and (Test-NetworkErrorEntry $wifiRaw)) {
+            $rawError = if ($wifiRaw.PSObject.Properties['Error']) { [string]$wifiRaw.Error } else { 'Failed to query Wi-Fi interfaces.' }
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to collect Wi-Fi interface details' -Evidence $rawError -Subcategory 'Wi-Fi Quality'
+        }
+
+        $wifiSamples = @()
+        if ($wifiInterfacesSection -and $wifiInterfacesSection.PSObject.Properties['Samples']) {
+            $wifiSamples = ConvertTo-NetworkArray $wifiInterfacesSection.Samples | Where-Object { $_ }
+        } elseif ($wifiPayload -and $wifiPayload.PSObject.Properties['Samples']) {
+            $wifiSamples = ConvertTo-NetworkArray $wifiPayload.Samples | Where-Object { $_ }
+        }
+
+        $signalCandidates = @($wifiSamples | Where-Object { $_ -and $_.PSObject.Properties['SignalPercent'] -and $null -ne $_.SignalPercent })
+        $connectedCandidates = @($signalCandidates | Where-Object {
+                $state = $null
+                if ($_.PSObject.Properties['State']) {
+                    $state = [string]$_.State
+                    if ($state) {
+                        try { $state = $state.ToLowerInvariant() } catch { $state = $state.ToLower() }
+                    }
+                }
+                return ($state -eq 'connected')
+            })
+
+        $consideredSamples = if ($connectedCandidates.Count -gt 0) { $connectedCandidates } else { $signalCandidates }
+
+        $normalizedSamples = New-Object System.Collections.Generic.List[pscustomobject]
+        foreach ($sample in $consideredSamples) {
+            if (-not $sample) { continue }
+
+            $percent = $null
+            if ($sample.PSObject.Properties['SignalPercent']) {
+                $percentRaw = $sample.SignalPercent
+                if ($percentRaw -is [int]) {
+                    $percent = [int]$percentRaw
+                } else {
+                    $percentText = [string]$percentRaw
+                    if ($percentText -match '(\d+)') {
+                        $percent = [int]$matches[1]
+                    }
+                }
+            }
+
+            if ($null -eq $percent) { continue }
+            $percent = [math]::Max([math]::Min([int]$percent, 100), 0)
+
+            $dbmValue = $null
+            if ($sample.PSObject.Properties['SignalDbm'] -and $sample.SignalDbm -ne $null) {
+                $dbmRaw = $sample.SignalDbm
+                if ($dbmRaw -is [int]) {
+                    $dbmValue = [int]$dbmRaw
+                } else {
+                    $dbmText = [string]$dbmRaw
+                    if ($dbmText -match '(-?\d+)') {
+                        $dbmValue = [int]$matches[1]
+                    }
+                }
+            }
+
+            $normalizedSamples.Add([pscustomobject]@{
+                    Percent = $percent
+                    Dbm     = $dbmValue
+                    Sample  = $sample
+                }) | Out-Null
+        }
+
+        if ($normalizedSamples.Count -gt 0) {
+            $normalizedArray = $normalizedSamples.ToArray()
+            $totalSamples = $normalizedArray.Count
+            $below60 = ($normalizedArray | Where-Object { $_.Percent -lt 60 }).Count
+            $below35 = ($normalizedArray | Where-Object { $_.Percent -lt 35 }).Count
+
+            $share60 = if ($totalSamples -gt 0) { $below60 / $totalSamples } else { 0 }
+            $share35 = if ($totalSamples -gt 0) { $below35 / $totalSamples } else { 0 }
+
+            $sortedSamples = $normalizedArray | Sort-Object -Property Percent
+            $worstSample = $sortedSamples | Select-Object -First 1
+
+            $sampleEvidence = New-Object System.Collections.Generic.List[pscustomobject]
+            foreach ($entry in $sortedSamples) {
+                $sampleData = $entry.Sample
+                $sampleEvidence.Add([pscustomobject]@{
+                        Interface     = if ($sampleData.PSObject.Properties['Name']) { [string]$sampleData.Name } else { $null }
+                        SSID          = if ($sampleData.PSObject.Properties['Ssid']) { [string]$sampleData.Ssid } else { $null }
+                        SignalPercent = $entry.Percent
+                        SignalDbm     = $entry.Dbm
+                        Channel       = if ($sampleData.PSObject.Properties['Channel']) { $sampleData.Channel } else { $null }
+                        Bssid         = if ($sampleData.PSObject.Properties['Bssid']) { $sampleData.Bssid } else { $null }
+                        State         = if ($sampleData.PSObject.Properties['State']) { $sampleData.State } else { $null }
+                        SampledAt     = if ($sampleData.PSObject.Properties['SampledAt']) { $sampleData.SampledAt } else { $null }
+                    }) | Out-Null
+            }
+
+            $signalEvidence = [ordered]@{
+                TotalSamples   = $totalSamples
+                Below60Percent = $below60
+                Below35Percent = $below35
+                Samples        = $sampleEvidence.ToArray()
+            }
+
+            $worstPercentText = $null
+            if ($worstSample) {
+                if ($worstSample.Dbm -ne $null) {
+                    $worstPercentText = '{0}% (~{1} dBm)' -f $worstSample.Percent, $worstSample.Dbm
+                } else {
+                    $worstPercentText = '{0}%' -f $worstSample.Percent
+                }
+            }
+
+            if ($share35 -ge 0.6) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Wi-Fi signal quality critical' -Evidence $signalEvidence -Subcategory 'Wi-Fi Quality'
+                $detail = ('{0}/{1} samples ({2:P1}) below 35% signal quality.' -f $below35, $totalSamples, $share35)
+                Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiQuality' -Status 'High risk' -Details $detail
+            } elseif ($share60 -ge 0.6) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Wi-Fi signal quality weak' -Evidence $signalEvidence -Subcategory 'Wi-Fi Quality'
+                $detail = ('{0}/{1} samples ({2:P1}) below 60% signal quality.' -f $below60, $totalSamples, $share60)
+                Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiQuality' -Status 'Medium risk' -Details $detail
+            } else {
+                $title = if ($worstSample -and $worstSample.Percent -ge 70) { 'Wi-Fi signal quality healthy (≥70%)' } else { 'Wi-Fi signal quality stable' }
+                if ($worstPercentText) { $title = '{0} (worst {1})' -f $title, $worstPercentText }
+                Add-CategoryNormal -CategoryResult $result -Title $title -Subcategory 'Wi-Fi Quality'
+                $detail = if ($worstPercentText) { 'Worst recorded signal {0}.' -f $worstPercentText } else { 'Signal levels above 60% for collected samples.' }
+                Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiQuality' -Status 'Healthy' -Details $detail
+            }
+        } else {
+            $qualityDetail = if ($wifiRaw -and (Test-NetworkErrorEntry $wifiRaw) -and $wifiRaw.PSObject.Properties['Error']) {
+                [string]$wifiRaw.Error
+            } elseif ($wifiSamples.Count -gt 0) {
+                'Wi-Fi samples lacked signal percentage values.'
+            } else {
+                'No Wi-Fi signal samples were collected (adapter may be disconnected).'
+            }
+
+            $qualityStatus = if ($wifiRaw -and (Test-NetworkErrorEntry $wifiRaw)) { 'Unavailable' } else { 'No data' }
+            Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiQuality' -Status $qualityStatus -Details $qualityDetail
+        }
+
+        $roamSource = $null
+        if ($wifiPayload -and $wifiPayload.PSObject.Properties['RoamEvents']) {
+            $roamSource = $wifiPayload.RoamEvents
+        }
+
+        if ($roamSource) {
+            if (Test-NetworkErrorEntry $roamSource) {
+                $roamError = if ($roamSource.PSObject.Properties['Error']) { [string]$roamSource.Error } else { 'Failed to query Wi-Fi roam events.' }
+                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to collect Wi-Fi roam events' -Evidence $roamError -Subcategory 'Wi-Fi Roaming'
+                Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiRoamRate' -Status 'Unavailable' -Details $roamError
+            } else {
+                $roamEvents = ConvertTo-NetworkArray $roamSource | Where-Object { $_ }
+                $roamSummary = Get-NetworkWifiRoamSummary -Events $roamEvents -LookbackMinutes 30
+
+                if ($roamSummary.SampleCount -gt 0) {
+                    $roamEvidence = [ordered]@{
+                        LookbackMinutes  = $roamSummary.LookbackMinutes
+                        RoamCount        = $roamSummary.RoamCount
+                        SampleCount      = $roamSummary.SampleCount
+                        UniqueBssidCount = $roamSummary.UniqueBssidCount
+                        Observations     = $roamSummary.Observations
+                    }
+
+                    if ($roamSummary.RoamCount -ge 12) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Frequent Wi-Fi roaming detected' -Evidence $roamEvidence -Subcategory 'Wi-Fi Roaming'
+                        $detail = ('{0} roam events within {1} minutes.' -f $roamSummary.RoamCount, $roamSummary.LookbackMinutes)
+                        Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiRoamRate' -Status 'High risk' -Details $detail
+                    } elseif ($roamSummary.RoamCount -ge 5) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Elevated Wi-Fi roaming rate' -Evidence $roamEvidence -Subcategory 'Wi-Fi Roaming'
+                        $detail = ('{0} roam events within {1} minutes.' -f $roamSummary.RoamCount, $roamSummary.LookbackMinutes)
+                        Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiRoamRate' -Status 'Medium risk' -Details $detail
+                    } else {
+                        Add-CategoryNormal -CategoryResult $result -Title 'Wi-Fi roaming rate normal' -Subcategory 'Wi-Fi Roaming'
+                        $detail = ('{0} roam events within {1} minutes.' -f $roamSummary.RoamCount, $roamSummary.LookbackMinutes)
+                        Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiRoamRate' -Status 'Healthy' -Details $detail
+                    }
+                } else {
+                    Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiRoamRate' -Status 'Healthy' -Details 'No Wi-Fi roam events observed within the last 30 minutes.'
+                }
+            }
+        } else {
+            Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiRoamRate' -Status 'No data' -Details 'Wi-Fi roam event log entries were not included in the collection.'
+        }
+    } else {
+        Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiQuality' -Status 'Not collected' -Details 'Wi-Fi diagnostics collector output not found.'
+        Add-CategoryCheck -CategoryResult $result -Name 'Network/WiFiRoamRate' -Status 'Not collected' -Details 'Wi-Fi diagnostics collector output not found.'
     }
 
     Invoke-DhcpAnalyzers -Context $Context -CategoryResult $result

--- a/Collectors/Network/Collect-WiFi.ps1
+++ b/Collectors/Network/Collect-WiFi.ps1
@@ -1,0 +1,250 @@
+<#!
+.SYNOPSIS
+    Collects Wi-Fi interface statistics and recent roaming events.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-WifiInterfaceOutput {
+    return Invoke-CollectorNativeCommand -FilePath 'netsh.exe' -ArgumentList 'wlan','show','interfaces' -SourceLabel 'netsh wlan'
+}
+
+function Normalize-MacLikeValue {
+    param([string]$Value)
+
+    if (-not $Value) { return $null }
+
+    $trimmed = $Value.Trim()
+    if (-not $trimmed) { return $null }
+
+    $normalized = $trimmed.ToLowerInvariant()
+    $normalized = $normalized -replace '[^0-9a-f]', ':'
+    $normalized = $normalized -replace ':+', ':'
+    $normalized = $normalized.Trim(':')
+
+    if (-not $normalized) { return $null }
+    if ($normalized -notmatch '^(?:[0-9a-f]{2}:){5}[0-9a-f]{2}$') { return $trimmed.ToLowerInvariant() }
+
+    return $normalized
+}
+
+function ConvertTo-WifiInterfaceSamples {
+    param(
+        [Parameter(Mandatory)]
+        $Lines
+    )
+
+    if (-not $Lines) { return @() }
+
+    $lineItems = @()
+    if ($Lines -is [string]) {
+        $lineItems = @($Lines)
+    } elseif ($Lines -is [System.Collections.IEnumerable] -and -not ($Lines -is [string])) {
+        foreach ($line in $Lines) { $lineItems += [string]$line }
+    } else {
+        return @()
+    }
+
+    $samples = New-Object System.Collections.Generic.List[pscustomobject]
+    $current = $null
+    $timestamp = (Get-Date).ToString('o')
+
+    foreach ($rawLine in $lineItems) {
+        if (-not $rawLine) { continue }
+        $line = [string]$rawLine
+        if (-not $line.Contains(':')) { continue }
+
+        $parts = $line.Split(':', 2)
+        if ($parts.Count -lt 2) { continue }
+
+        $key = ($parts[0]).Trim()
+        $value = ($parts[1]).Trim()
+        if (-not $key) { continue }
+
+        $normalized = ($key -replace '\s+', ' ').Trim().ToLowerInvariant()
+
+        switch -Wildcard ($normalized) {
+            'name' {
+                if ($current) { $samples.Add([pscustomobject]$current) | Out-Null }
+                $current = [ordered]@{
+                    Name      = $value
+                    SampledAt = $timestamp
+                }
+                continue
+            }
+            'guid' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $current['InterfaceGuid'] = $value
+                continue
+            }
+            'description' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $current['Description'] = $value
+                continue
+            }
+            'state' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $current['State'] = $value
+                continue
+            }
+            'ssid' {
+                if ($normalized -eq 'ssid' -or $normalized -eq 'ssid name') {
+                    if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                    $current['Ssid'] = $value
+                }
+                continue
+            }
+            'bssid' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $current['Bssid'] = Normalize-MacLikeValue -Value $value
+                continue
+            }
+            'network type' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $current['NetworkType'] = $value
+                continue
+            }
+            'radio type' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $current['RadioType'] = $value
+                continue
+            }
+            'channel' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $parsedChannel = $null
+                if ([int]::TryParse($value, [ref]$parsedChannel)) { $current['Channel'] = $parsedChannel } else { $current['Channel'] = $value }
+                continue
+            }
+            'receive rate (mbps)' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $parsed = $null
+                if ([double]::TryParse($value, [ref]$parsed)) { $current['ReceiveRateMbps'] = $parsed } else { $current['ReceiveRateMbps'] = $value }
+                continue
+            }
+            'transmit rate (mbps)' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $parsed = $null
+                if ([double]::TryParse($value, [ref]$parsed)) { $current['TransmitRateMbps'] = $parsed } else { $current['TransmitRateMbps'] = $value }
+                continue
+            }
+            'signal' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $percent = $null
+                if ($value -match '(\d+)\s*%') {
+                    $percent = [int]$matches[1]
+                    $current['SignalPercent'] = $percent
+                }
+                if ($value -match '(-?\d+)\s*dBm') {
+                    $current['SignalDbm'] = [int]$matches[1]
+                } elseif ($percent -ne $null) {
+                    $estimate = [math]::Round(-100 + ($percent * 0.55))
+                    $current['SignalDbm'] = [int]$estimate
+                }
+                continue
+            }
+            'profile' {
+                if (-not $current) { $current = [ordered]@{ SampledAt = $timestamp } }
+                $current['Profile'] = $value
+                continue
+            }
+            default {
+                continue
+            }
+        }
+    }
+
+    if ($current) { $samples.Add([pscustomobject]$current) | Out-Null }
+    return $samples.ToArray()
+}
+
+function Get-WifiRoamEvents {
+    try {
+        $events = Get-WinEvent -LogName 'Microsoft-Windows-WLAN-AutoConfig/Operational' -MaxEvents 500 -ErrorAction Stop
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-WinEvent'
+            Log    = 'Microsoft-Windows-WLAN-AutoConfig/Operational'
+            Error  = $_.Exception.Message
+        }
+    }
+
+    $results = New-Object System.Collections.Generic.List[pscustomobject]
+
+    foreach ($event in $events) {
+        if (-not $event) { continue }
+
+        $entry = [ordered]@{
+            Id          = $event.Id
+            Level       = $event.LevelDisplayName
+            TimeCreated = if ($event.TimeCreated) { $event.TimeCreated.ToString('o') } else { $null }
+        }
+
+        $message = $null
+        try { $message = $event.Message } catch { $message = $null }
+        if ($message) { $entry['Message'] = $message.Trim() }
+
+        if ($event.Properties) {
+            $props = @()
+            foreach ($prop in $event.Properties) {
+                if ($null -eq $prop) { continue }
+                $value = $prop.Value
+                if ($null -eq $value) { $props += $null; continue }
+                $props += [string]$value
+            }
+            if ($props.Count -gt 0) { $entry['Properties'] = $props }
+        }
+
+        if ($message) {
+            $patterns = @(
+                @{ Key = 'NewBssid'; Pattern = '(?i)\bNew\s+BSSID\s*[:=]\s*([0-9A-Fa-f:\-]{12,})' },
+                @{ Key = 'TargetBssid'; Pattern = '(?i)\bTarget\s+BSSID\s*[:=]\s*([0-9A-Fa-f:\-]{12,})' },
+                @{ Key = 'OldBssid'; Pattern = '(?i)\bOld\s+BSSID\s*[:=]\s*([0-9A-Fa-f:\-]{12,})' },
+                @{ Key = 'Bssid'; Pattern = '(?i)\bBSSID\s*[:=]\s*([0-9A-Fa-f:\-]{12,})' }
+            )
+
+            foreach ($pattern in $patterns) {
+                if ($entry.Contains($pattern.Key)) { continue }
+                if ($message -match $pattern.Pattern) {
+                    $entry[$pattern.Key] = Normalize-MacLikeValue -Value $matches[1]
+                }
+            }
+
+            if (-not $entry.Contains('Ssid') -and $message -match '(?i)(?<!B)SSID\s*[:=]\s*([^\r\n]+)') {
+                $entry['Ssid'] = ($matches[1]).Trim()
+            }
+        }
+
+        $results.Add([pscustomobject]$entry) | Out-Null
+    }
+
+    return $results.ToArray()
+}
+
+function Invoke-Main {
+    $interfaceOutput = Get-WifiInterfaceOutput
+    $samples = $null
+    if ($interfaceOutput -and -not ($interfaceOutput.PSObject -and $interfaceOutput.PSObject.Properties['Error'])) {
+        $samples = ConvertTo-WifiInterfaceSamples -Lines $interfaceOutput
+    }
+
+    $roamEvents = Get-WifiRoamEvents
+
+    $payload = [ordered]@{
+        Interfaces = [ordered]@{
+            Raw     = $interfaceOutput
+            Samples = $samples
+        }
+        RoamEvents = $roamEvents
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'network-wifi.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add a collector that captures `netsh wlan show interfaces` output and WLAN AutoConfig roaming events
- extend the network heuristics to grade Wi-Fi signal quality and roaming frequency with new checks for `Network/WiFiQuality` and `Network/WiFiRoamRate`

## Testing
- `pwsh -NoLogo -Command "Set-StrictMode -Version 2.0; . '$PWD/Collectors/Network/Collect-WiFi.ps1'; 'WiFi collector loaded'"` *(fails: `pwsh` not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d69b09e3c4832db3aa8d5f0b064990