### PR TITLE
Add network link stability heuristics

### DIFF
--- a/Collectors/Network/Collect-NetworkAdapters.ps1
+++ b/Collectors/Network/Collect-NetworkAdapters.ps1
@@ -12,7 +12,7 @@ param(
 
 function Get-AdapterConfigurations {
     try {
-        return Get-NetAdapter -ErrorAction Stop | Select-Object Name, InterfaceDescription, Status, LinkSpeed, MacAddress, DriverInformation
+        return Get-NetAdapter -ErrorAction Stop | Select-Object Name, InterfaceDescription, Status, LinkSpeed, MediaConnectionState, MacAddress, DriverInformation
     } catch {
         return [PSCustomObject]@{
             Source = 'Get-NetAdapter'
@@ -43,11 +43,94 @@ function Get-NetworkAdapterState {
     }
 }
 
+function ConvertTo-LinkEventRecord {
+    param(
+        [Parameter(Mandatory)]
+        $Event,
+
+        [Parameter(Mandatory)]
+        [string]$Source
+    )
+
+    $timeValue = $null
+    if ($Event.PSObject.Properties['TimeCreated']) {
+        $timeValue = $Event.TimeCreated
+        if ($timeValue -is [datetime]) {
+            $timeValue = $timeValue.ToString('o')
+        }
+    }
+
+    [PSCustomObject]@{
+        TimeCreated = $timeValue
+        Id          = if ($Event.PSObject.Properties['Id']) { $Event.Id } else { $null }
+        Level       = if ($Event.PSObject.Properties['LevelDisplayName']) { $Event.LevelDisplayName } else { $null }
+        Provider    = if ($Event.PSObject.Properties['ProviderName']) { $Event.ProviderName } else { $null }
+        Message     = if ($Event.PSObject.Properties['Message']) { $Event.Message } else { $null }
+        Source      = $Source
+    }
+}
+
+function Get-LinkEventsFromLog {
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogName,
+
+        [int[]]$Ids,
+
+        [datetime]$StartTime = (Get-Date).AddHours(-72)
+    )
+
+    $filter = @{ LogName = $LogName }
+    if ($Ids -and $Ids.Count -gt 0) {
+        $filter['Id'] = $Ids
+    }
+    if ($StartTime) {
+        $filter['StartTime'] = $StartTime
+    }
+
+    try {
+        $events = Get-WinEvent -FilterHashtable $filter -MaxEvents 400 -ErrorAction Stop | Select-Object TimeCreated, Id, LevelDisplayName, ProviderName, Message
+        if (-not $events) { return @() }
+
+        $list = New-Object System.Collections.Generic.List[object]
+        foreach ($event in $events) {
+            $list.Add((ConvertTo-LinkEventRecord -Event $event -Source $LogName)) | Out-Null
+        }
+
+        return $list.ToArray()
+    } catch {
+        return [PSCustomObject]@{
+            Source = "Get-WinEvent $LogName"
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-NetworkLinkEvents {
+    param([int]$LookbackHours = 72)
+
+    $windowStart = (Get-Date).AddHours(-[math]::Abs($LookbackHours))
+
+    $systemIds = @(27, 32, 4201, 10400, 10401, 10402, 8021, 8026)
+    $systemEvents = Get-LinkEventsFromLog -LogName 'System' -Ids $systemIds -StartTime $windowStart
+
+    $msftLog = 'Microsoft-Windows-MsftNetAdapter/Admin'
+    $msftEvents = Get-LinkEventsFromLog -LogName $msftLog -StartTime $windowStart
+
+    [ordered]@{
+        CollectedAt   = (Get-Date).ToString('o')
+        LookbackHours = [math]::Abs($LookbackHours)
+        System        = $systemEvents
+        MsftNetAdapter = $msftEvents
+    }
+}
+
 function Invoke-Main {
     $payload = [ordered]@{
         Adapters   = Get-AdapterConfigurations
         IPConfig   = Get-NetIPAssignments
         Properties = Get-NetworkAdapterState
+        LinkEvents = Get-NetworkLinkEvents
     }
 
     $result = New-CollectorMetadata -Payload $payload


### PR DESCRIPTION
## Summary
- capture media connection state and targeted link-related event logs in the network adapter collector
- add helper utilities for parsing link speeds, adapter capabilities, and event diagnostics
- implement link flap, duplex mismatch, and underspeed heuristics with associated checks and evidence

## Testing
- not run (pwsh not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d6ab337c48832d9a5d638674eb2aa1