### PR TITLE
Add Defender platform baseline heuristic

### DIFF
--- a/Analyzers/Heuristics/SecurityConfig.psd1
+++ b/Analyzers/Heuristics/SecurityConfig.psd1
@@ -1,0 +1,5 @@
+@{
+    DefenderPlatform = @{
+        MinimumProductVersion = '4.18.24040.8'
+    }
+}

--- a/Collectors/Security/Collect-Defender.ps1
+++ b/Collectors/Security/Collect-Defender.ps1
@@ -13,7 +13,7 @@ param(
 function Get-DefenderStatus {
     try {
         $status = Get-MpComputerStatus -ErrorAction Stop
-        return $status | Select-Object AMServiceEnabled, AntispywareEnabled, AntivirusEnabled, IoavProtectionEnabled, RealTimeProtectionEnabled, TamperProtectionEnabled, IsTamperProtected, NISEnabled, QuickScanEndTime, FullScanEndTime, ProductStatus, AntivirusSignatureVersion, AntispywareSignatureVersion
+        return $status | Select-Object AMServiceEnabled, AntispywareEnabled, AntivirusEnabled, IoavProtectionEnabled, RealTimeProtectionEnabled, TamperProtectionEnabled, IsTamperProtected, NISEnabled, QuickScanEndTime, FullScanEndTime, ProductStatus, AntivirusSignatureVersion, AntispywareSignatureVersion, AMProductVersion, AntimalwareEngineVersion, NISPlatformVersion
     } catch {
         return [PSCustomObject]@{
             Source = 'Get-MpComputerStatus'


### PR DESCRIPTION
## Summary
- extend the Defender collector to capture platform and engine version fields needed for age evaluation
- add a configuration-driven Defender platform age heuristic that surfaces high severity when the product version lags the baseline and records OS build context
- introduce a security heuristics configuration file to store the minimum supported Defender platform version

## Testing
- powershell -NoProfile -Command ". '$PWD/Analyzers/Heuristics/Security.ps1'" *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ab433fe8832db78bddd4207251d9