### PR TITLE
Add heuristics for disabled or miscategorized Windows Firewall profiles

### DIFF
--- a/Analyzers/Heuristics/Security.ps1
+++ b/Analyzers/Heuristics/Security.ps1
@@ -271,32 +271,107 @@ function Invoke-SecurityHeuristics {
     }
 
     $firewallArtifact = Get-AnalyzerArtifact -Context $Context -Name 'firewall'
+    $firewallCheckId = 'Security/FirewallProfiles'
+    $firewallProfileEvidence = $null
     if ($firewallArtifact) {
         $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $firewallArtifact)
-        if ($payload -and $payload.Profiles) {
+        if ($payload -and $payload.Profiles -and $payload.Profiles.PSObject.Properties['Error'] -and $payload.Profiles.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Firewall profile query failed' -Evidence $payload.Profiles.Error -Subcategory 'Windows Firewall' -CheckId $firewallCheckId
+        } elseif ($payload -and $payload.Profiles) {
+            $profiles = ConvertTo-List $payload.Profiles
             $disabledProfiles = @()
-            foreach ($profile in $payload.Profiles) {
-                if ($profile.PSObject.Properties['Enabled']) {
-                    $enabled = ConvertTo-NullableBool $profile.Enabled
-                    if ($enabled -eq $false) {
-                        $disabledProfiles += $profile.Name
+            $domainProfileDisabled = $false
+            $profileRows = @()
+
+            foreach ($profile in $profiles) {
+                if (-not $profile) { continue }
+                if (-not $profile.PSObject.Properties['Enabled']) { continue }
+
+                $name = if ($profile.PSObject.Properties['Name']) { [string]$profile.Name } else { 'Unknown' }
+                $enabled = ConvertTo-NullableBool $profile.Enabled
+                $statusText = 'Unknown'
+                if ($enabled -eq $true) { $statusText = 'Enabled' }
+                elseif ($enabled -eq $false) { $statusText = 'Disabled' }
+
+                $inbound = Get-ObjectPropertyString -Object $profile -PropertyName 'DefaultInboundAction' -NullPlaceholder 'Unknown'
+                $outbound = Get-ObjectPropertyString -Object $profile -PropertyName 'DefaultOutboundAction' -NullPlaceholder 'Unknown'
+
+                $profileRows += [pscustomobject]@{
+                    Profile = $name
+                    Enabled = $statusText
+                    Inbound = $inbound
+                    Outbound = $outbound
+                }
+
+                Add-CategoryCheck -CategoryResult $result -Name ("Firewall profile: {0}" -f $name) -Status $statusText -Details ("Inbound: {0}; Outbound: {1}" -f $inbound, $outbound) -CheckId $firewallCheckId
+
+                if ($enabled -eq $false) {
+                    $disabledProfiles += $name
+                    if ($name -match '^(?i)Domain$') {
+                        $domainProfileDisabled = $true
                     }
-                    Add-CategoryCheck -CategoryResult $result -Name ("Firewall profile: {0}" -f $profile.Name) -Status ($(if ($enabled) { 'Enabled' } elseif ($enabled -eq $false) { 'Disabled' } else { 'Unknown' })) -Details ("Inbound: {0}; Outbound: {1}" -f $profile.DefaultInboundAction, $profile.DefaultOutboundAction)
                 }
             }
 
-            if ($disabledProfiles.Count -gt 0) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ('Firewall profiles disabled: {0}' -f ($disabledProfiles -join ', ')) -Subcategory 'Windows Firewall'
-            } else {
-                Add-CategoryNormal -CategoryResult $result -Title 'All firewall profiles enabled'
+            if ($profileRows.Count -gt 0) {
+                $firewallProfileEvidence = ($profileRows | Format-Table -AutoSize | Out-String).Trim()
             }
-        } elseif ($payload -and $payload.Profiles -and $payload.Profiles.Error) {
-            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Firewall profile query failed' -Evidence $payload.Profiles.Error -Subcategory 'Windows Firewall'
+
+            if ($disabledProfiles.Count -gt 0) {
+                $severity = if ($domainProfileDisabled) { 'high' } else { 'medium' }
+                Add-CategoryIssue -CategoryResult $result -Severity $severity -Title ('Firewall profiles disabled: {0}' -f ($disabledProfiles -join ', ')) -Evidence $firewallProfileEvidence -Subcategory 'Windows Firewall' -CheckId $firewallCheckId
+            } elseif ($profileRows.Count -gt 0) {
+                Add-CategoryNormal -CategoryResult $result -Title 'All firewall profiles enabled' -Evidence $firewallProfileEvidence -Subcategory 'Windows Firewall' -CheckId $firewallCheckId
+            } else {
+                $unstructuredEvidence = $null
+                if ($payload.Profiles -and $payload.Profiles.PSObject -and $payload.Profiles.PSObject.Properties['RawOutput']) {
+                    $unstructuredEvidence = $payload.Profiles.RawOutput
+                }
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Firewall profile query returned no structured data' -Evidence $unstructuredEvidence -Subcategory 'Windows Firewall' -CheckId $firewallCheckId
+            }
         } else {
-            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Firewall not captured. Collect firewall profile configuration.' -Subcategory 'Windows Firewall'
+            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Firewall not captured. Collect firewall profile configuration.' -Subcategory 'Windows Firewall' -CheckId $firewallCheckId
+        }
+
+        if ($payload -and $payload.Connections) {
+            if (-not ($payload.Connections.PSObject.Properties['Error'] -and $payload.Connections.Error)) {
+                $connections = ConvertTo-List $payload.Connections
+                $domainPublicRows = @()
+
+                foreach ($connection in $connections) {
+                    if (-not $connection) { continue }
+
+                    $category = if ($connection.PSObject.Properties['NetworkCategory']) { [string]$connection.NetworkCategory } else { '' }
+                    $domainAuth = $null
+                    if ($connection.PSObject.Properties['DomainAuthenticationSucceeded']) {
+                        $domainAuth = ConvertTo-NullableBool $connection.DomainAuthenticationSucceeded
+                    }
+
+                    if ($domainAuth -eq $true -and $category -match '^(?i)Public$') {
+                        $domainPublicRows += [pscustomobject]@{
+                            Name                 = if ($connection.PSObject.Properties['Name']) { [string]$connection.Name } else { '' }
+                            Interface            = if ($connection.PSObject.Properties['InterfaceAlias']) { [string]$connection.InterfaceAlias } else { '' }
+                            Category             = $category
+                            DomainAuthenticated = $true
+                        }
+                    }
+                }
+
+                if ($domainPublicRows.Count -gt 0) {
+                    $domainPublicEvidence = ($domainPublicRows | Format-Table -AutoSize | Out-String).Trim()
+                    $evidenceParts = @()
+                    if ($firewallProfileEvidence) {
+                        $evidenceParts += "Firewall profiles:`n$firewallProfileEvidence"
+                    }
+                    $evidenceParts += "Connections:`n$domainPublicEvidence"
+                    $evidence = ($evidenceParts -join ([Environment]::NewLine + [Environment]::NewLine))
+
+                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Domain network using Public firewall profile' -Evidence $evidence -Subcategory 'Windows Firewall' -CheckId $firewallCheckId
+                }
+            }
         }
     } else {
-        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Firewall not captured. Collect firewall profile configuration.' -Subcategory 'Windows Firewall'
+        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Firewall not captured. Collect firewall profile configuration.' -Subcategory 'Windows Firewall' -CheckId $firewallCheckId
     }
 
     $bitlockerArtifact = Get-AnalyzerArtifact -Context $Context -Name 'bitlocker'

--- a/Collectors/Security/Collect-Firewall.ps1
+++ b/Collectors/Security/Collect-Firewall.ps1
@@ -45,10 +45,24 @@ function Get-FirewallRules {
     }
 }
 
+function Get-ConnectionProfiles {
+    try {
+        return Get-NetConnectionProfile -ErrorAction Stop |
+            Select-Object Name, InterfaceAlias, NetworkCategory, DomainAuthenticationSucceeded
+    } catch {
+        Write-Verbose "Get-NetConnectionProfile failed: $($_.Exception.Message)"
+        return [PSCustomObject]@{
+            Source = 'Get-NetConnectionProfile'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
 function Invoke-Main {
     $payload = [ordered]@{
         Profiles = Get-FirewallProfiles
         Rules    = Get-FirewallRules
+        Connections = Get-ConnectionProfiles
     }
 
     $result = New-CollectorMetadata -Payload $payload


### PR DESCRIPTION
## Summary
- collect network connection profiles alongside firewall configuration data
- adjust Windows Firewall heuristic severities and evidence to highlight disabled profiles
- detect domain-authenticated networks that are still using the Public firewall profile

## Testing
- ⚠️ `pwsh -NoProfile -Command ". '$PWD/Analyzers/Heuristics/Security.ps1'"` *(fails: pwsh not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ab542498832db8618a14da477dc0