### PR TITLE
Add pending reboot collector and heuristic

### DIFF
--- a/Analyzers/Heuristics/System.ps1
+++ b/Analyzers/Heuristics/System.ps1
@@ -217,6 +217,86 @@ function Invoke-SystemHeuristics {
         }
     }
 
+    $pendingRebootArtifact = Get-AnalyzerArtifact -Context $Context -Name 'pending-reboot'
+    if ($pendingRebootArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $pendingRebootArtifact)
+        if ($payload -and $payload.Registry) {
+            $entries = @($payload.Registry)
+
+            $presentEntries = @($entries | Where-Object { $_ -and $_.PSObject.Properties['Present'] -and $_.Present })
+            $evidenceLines = New-Object System.Collections.Generic.List[string]
+
+            foreach ($entry in $entries) {
+                $descriptor = if ($entry.ValueName) { "{0}::{1}" -f $entry.Path, $entry.ValueName } else { [string]$entry.Path }
+                $status = if ($entry.Present) { 'present' } else { 'absent' }
+                $timestamp = if ($entry.LastWriteTime) { [string]$entry.LastWriteTime } else { 'timestamp unavailable' }
+
+                $additional = $null
+                if ($entry.PSObject.Properties['Values'] -and $entry.Values) {
+                    if ($entry.Values -is [System.Collections.IEnumerable] -and -not ($entry.Values -is [string])) {
+                        $additional = "values={0}" -f ((@($entry.Values) | Select-Object -First 3) -join ', ')
+                    } else {
+                        $additional = "value={0}" -f $entry.Values
+                    }
+                } elseif ($entry.PSObject.Properties['ValueReadError'] -and $entry.ValueReadError) {
+                    $additional = "value read error: {0}" -f $entry.ValueReadError
+                } elseif ($entry.PSObject.Properties['Error'] -and $entry.Error) {
+                    $additional = "error: {0}" -f $entry.Error
+                }
+
+                $lineParts = @("{0} → {1}" -f $descriptor, $status)
+                $lineParts += "LastWriteTime={0}" -f $timestamp
+                if ($additional) { $lineParts += $additional }
+                $evidenceLines.Add(($lineParts -join ' | ')) | Out-Null
+            }
+
+            $oldestRecord = $null
+            foreach ($entry in $presentEntries) {
+                if (-not ($entry.PSObject.Properties['LastWriteTime']) -or -not $entry.LastWriteTime) { continue }
+                try {
+                    $parsed = [datetime]::Parse($entry.LastWriteTime)
+                } catch {
+                    continue
+                }
+
+                if (-not $oldestRecord -or $parsed -lt $oldestRecord.Timestamp) {
+                    $oldestRecord = [pscustomobject]@{ Entry = $entry; Timestamp = $parsed }
+                }
+            }
+
+            if ($presentEntries.Count -gt 0) {
+                $now = Get-Date
+                $severity = 'medium'
+                $title = 'Pending reboot required'
+                if ($oldestRecord) {
+                    $age = $now - $oldestRecord.Timestamp
+                    if ($age.TotalDays -ge 7) {
+                        $severity = 'high'
+                        $title = 'Pending reboot overdue'
+                    }
+
+                    $descriptor = if ($oldestRecord.Entry.ValueName) { "{0}::{1}" -f $oldestRecord.Entry.Path, $oldestRecord.Entry.ValueName } else { [string]$oldestRecord.Entry.Path }
+                    $ageLine = "Oldest pending marker: {0} (recorded {1:yyyy-MM-ddTHH:mm:ssK}, ~{2:N1} days ago)" -f $descriptor, $oldestRecord.Timestamp, $age.TotalDays
+                    $evidenceLines.Add($ageLine) | Out-Null
+                }
+
+                $evidence = $evidenceLines -join "`n"
+                Add-CategoryIssue -CategoryResult $result -Severity $severity -Title $title -Evidence $evidence -Subcategory 'Pending Reboot' -CheckId 'System/PendingReboot'
+            } else {
+                $evidence = $evidenceLines -join "`n"
+                if (-not [string]::IsNullOrWhiteSpace($evidence)) {
+                    Add-CategoryNormal -CategoryResult $result -Title 'No reboot pending' -Evidence $evidence -CheckId 'System/PendingReboot'
+                } else {
+                    Add-CategoryNormal -CategoryResult $result -Title 'No reboot pending' -CheckId 'System/PendingReboot'
+                }
+            }
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Pending reboot data unavailable' -Subcategory 'Pending Reboot' -CheckId 'System/PendingReboot'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Pending reboot artifact missing' -Subcategory 'Pending Reboot' -CheckId 'System/PendingReboot'
+    }
+
     $startupArtifact = Get-AnalyzerArtifact -Context $Context -Name 'startup'
     if ($startupArtifact) {
         $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $startupArtifact)

--- a/Collectors/System/Collect-PendingReboot.ps1
+++ b/Collectors/System/Collect-PendingReboot.ps1
@@ -1,0 +1,96 @@
+<#!
+.SYNOPSIS
+    Collects registry indicators that signal a pending reboot requirement.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\CollectorCommon.ps1')
+
+function Get-PendingRebootRegistryStatus {
+    $checks = @(
+        @{ Path = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending' },
+        @{ Path = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' },
+        @{ Path = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager'; ValueName = 'PendingFileRenameOperations' }
+    )
+
+    $results = @()
+
+    foreach ($check in $checks) {
+        $entry = [ordered]@{
+            Path = $check.Path
+        }
+
+        if ($check.ContainsKey('ValueName') -and $check.ValueName) {
+            $entry['ValueName'] = $check.ValueName
+        }
+
+        try {
+            if ($entry.ValueName) {
+                $item = Get-ItemProperty -Path $entry.Path -Name $entry.ValueName -ErrorAction Stop
+                $value = $item.PSObject.Properties[$entry.ValueName].Value
+                $lastWrite = (Get-Item -LiteralPath $entry.Path -ErrorAction Stop).LastWriteTime
+
+                $normalizedValue = $null
+                if ($null -ne $value) {
+                    if ($value -is [System.Collections.IEnumerable] -and -not ($value -is [string])) {
+                        $normalizedValue = @($value | ForEach-Object { $_ })
+                    } else {
+                        $normalizedValue = @([string]$value)
+                    }
+                }
+
+                $hasEntries = $false
+                if ($normalizedValue) {
+                    $nonEmpty = $normalizedValue | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }
+                    if ($nonEmpty.Count -gt 0) {
+                        $hasEntries = $true
+                    }
+                }
+
+                $entry['Present'] = $hasEntries
+                $entry['LastWriteTime'] = if ($lastWrite) { $lastWrite.ToString('o') } else { $null }
+                if ($normalizedValue) {
+                    $entry['Values'] = $normalizedValue
+                }
+            } else {
+                $item = Get-Item -LiteralPath $entry.Path -ErrorAction Stop
+                $entry['Present'] = $true
+                if ($item.PSObject.Properties['LastWriteTime']) {
+                    $entry['LastWriteTime'] = $item.LastWriteTime.ToString('o')
+                }
+
+                try {
+                    $values = Get-ItemProperty -Path $entry.Path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+                    if ($values) {
+                        $entry['Values'] = $values
+                    }
+                } catch {
+                    $entry['ValueReadError'] = $_.Exception.Message
+                }
+            }
+        } catch {
+            $entry['Present'] = $false
+            $entry['Error'] = $_.Exception.Message
+        }
+
+        $results += [pscustomobject]$entry
+    }
+
+    return $results
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-PendingRebootRegistryStatus
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'pending-reboot.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add a collector that captures Windows pending reboot registry indicators
- surface a system heuristic that flags pending reboots and escalates severity when aged

## Testing
- not run (Windows-specific PowerShell collectors)


------
https://chatgpt.com/codex/tasks/task_e_68d6ad317b44832d8de7608f99c5c333