### PR TITLE
Add bugcheck and power reset heuristics

### DIFF
--- a/Analyzers/Heuristics/System.ps1
+++ b/Analyzers/Heuristics/System.ps1
@@ -75,6 +75,53 @@ function Test-IsMicrosoftStartupEntry {
     return $false
 }
 
+function ConvertFrom-EventIsoString {
+    param(
+        [string]$Timestamp
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Timestamp)) { return $null }
+
+    $styles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+
+    try {
+        return [System.DateTime]::Parse($Timestamp, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind)
+    } catch {
+        try {
+            return [System.DateTime]::Parse($Timestamp, $null, $styles)
+        } catch {
+            return $null
+        }
+    }
+}
+
+function Format-EventParameterEvidence {
+    param(
+        [object]$Parameters
+    )
+
+    if (-not $Parameters) { return 'Unavailable' }
+
+    if ($Parameters -is [System.Collections.IEnumerable] -and -not ($Parameters -is [string])) {
+        $values = @()
+        foreach ($item in $Parameters) {
+            if ($null -ne $item -and -not [string]::IsNullOrWhiteSpace([string]$item)) {
+                $values += [string]$item
+            }
+        }
+
+        if ($values.Count -gt 0) {
+            return ($values -join ', ')
+        }
+
+        return 'None'
+    }
+
+    $valueText = [string]$Parameters
+    if ([string]::IsNullOrWhiteSpace($valueText)) { return 'None' }
+    return $valueText
+}
+
 function Invoke-SystemHeuristics {
     param(
         [Parameter(Mandatory)]
@@ -185,6 +232,131 @@ function Invoke-SystemHeuristics {
         } elseif ($payload -and $payload.FastStartup -and $payload.FastStartup.Error) {
             Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to read Fast Startup configuration' -Evidence $payload.FastStartup.Error -Subcategory 'Power Configuration'
         }
+    }
+
+    $criticalEventsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system-critical-events'
+    if ($criticalEventsArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $criticalEventsArtifact)
+        if ($payload -and $payload.PSObject.Properties['Events']) {
+            $rawEvents = $payload.Events
+            if ($null -eq $rawEvents) {
+                $rawEvents = @()
+            } elseif ($rawEvents -isnot [System.Collections.IEnumerable] -or $rawEvents -is [string]) {
+                $rawEvents = @($rawEvents)
+            } else {
+                $rawEvents = @($rawEvents)
+            }
+
+            if ($rawEvents.Count -eq 1 -and $rawEvents[0].PSObject.Properties['Error']) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to query targeted system events' -Evidence $rawEvents[0].Error -Subcategory 'System stability'
+            } else {
+                $normalizedEvents = New-Object System.Collections.Generic.List[object]
+                foreach ($event in $rawEvents) {
+                    if (-not $event) { continue }
+                    if (-not $event.PSObject.Properties['Id']) { continue }
+
+                    $parsedTime = $null
+                    if ($event.PSObject.Properties['TimeCreated']) {
+                        $parsedTime = ConvertFrom-EventIsoString -Timestamp ([string]$event.TimeCreated)
+                    }
+
+                    $normalizedEvents.Add([pscustomobject]@{
+                            Id          = [int]$event.Id
+                            TimeCreated = $parsedTime
+                            RawTime     = $event.TimeCreated
+                            Properties  = if ($event.PSObject.Properties['Properties']) { $event.Properties } else { $null }
+                            Message     = if ($event.PSObject.Properties['Message']) { $event.Message } else { $null }
+                        }) | Out-Null
+                }
+
+                $windowStart = (Get-Date).AddDays(-7)
+
+                $bugcheckEvents = @($normalizedEvents | Where-Object { $_.Id -eq 1001 -and $_.TimeCreated -and $_.TimeCreated -ge $windowStart })
+                $kernelPowerEvents = @($normalizedEvents | Where-Object { $_.Id -eq 41 -and $_.TimeCreated -and $_.TimeCreated -ge $windowStart })
+                $unexpectedShutdownEvents = @($normalizedEvents | Where-Object { $_.Id -eq 6008 -and $_.TimeCreated -and $_.TimeCreated -ge $windowStart })
+                $tdrEvents = @($normalizedEvents | Where-Object { $_.Id -eq 4101 -and $_.TimeCreated -and $_.TimeCreated -ge $windowStart })
+
+                $bugcheckCount = $bugcheckEvents.Count
+                Add-CategoryCheck -CategoryResult $result -Name 'BugCheck 1001 events (7 days)' -Status ([string]$bugcheckCount) -CheckId 'System/BugChecks'
+
+                if ($bugcheckCount -gt 0) {
+                    $latestBugcheck = $bugcheckEvents | Sort-Object TimeCreated -Descending | Select-Object -First 1
+                    $bugcheckEvidence = New-Object System.Collections.Generic.List[string]
+                    [void]$bugcheckEvidence.Add("Count (7 days): {0}" -f $bugcheckCount)
+                    if ($latestBugcheck.TimeCreated) { [void]$bugcheckEvidence.Add("Most recent: {0}" -f $latestBugcheck.TimeCreated.ToString('u')) }
+                    $paramEvidence = Format-EventParameterEvidence -Parameters $latestBugcheck.Properties
+                    [void]$bugcheckEvidence.Add("Last parameters: {0}" -f $paramEvidence)
+
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Recent bugcheck detected' -Evidence ($bugcheckEvidence -join '; ') -Subcategory 'System stability' -CheckId 'System/BugChecks'
+                } else {
+                    Add-CategoryNormal -CategoryResult $result -Title 'No recent bugchecks detected' -Evidence 'Count (7 days): 0' -Subcategory 'System stability' -CheckId 'System/BugChecks'
+                }
+
+                $kernelPowerCount = $kernelPowerEvents.Count
+                $unexpectedCount = $unexpectedShutdownEvents.Count
+                $totalPowerResets = $kernelPowerCount + $unexpectedCount
+
+                Add-CategoryCheck -CategoryResult $result -Name 'Kernel-Power 41 events (7 days)' -Status ([string]$kernelPowerCount) -CheckId 'System/PowerResets'
+                Add-CategoryCheck -CategoryResult $result -Name 'Unexpected shutdown 6008 events (7 days)' -Status ([string]$unexpectedCount) -CheckId 'System/PowerResets'
+
+                if ($totalPowerResets -gt 0) {
+                    $latestPowerEvent = @($kernelPowerEvents + $unexpectedShutdownEvents) | Sort-Object TimeCreated -Descending | Select-Object -First 1
+                    $powerEvidence = New-Object System.Collections.Generic.List[string]
+                    [void]$powerEvidence.Add("Kernel-Power 41 count (7 days): {0}" -f $kernelPowerCount)
+                    [void]$powerEvidence.Add("Unexpected shutdown 6008 count (7 days): {0}" -f $unexpectedCount)
+                    if ($latestPowerEvent -and $latestPowerEvent.TimeCreated) { [void]$powerEvidence.Add("Most recent: {0}" -f $latestPowerEvent.TimeCreated.ToString('u')) }
+                    if ($latestPowerEvent) {
+                        $powerParams = Format-EventParameterEvidence -Parameters $latestPowerEvent.Properties
+                        [void]$powerEvidence.Add("Last parameters: {0}" -f $powerParams)
+                    }
+
+                    if ($kernelPowerCount -ge 5 -or $totalPowerResets -ge 6) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Frequent power reset events detected' -Evidence ($powerEvidence -join '; ') -Subcategory 'Power' -CheckId 'System/PowerResets'
+                    } elseif ($kernelPowerCount -ge 2 -or $unexpectedCount -ge 2 -or $totalPowerResets -ge 3) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Repeated power reset events detected' -Evidence ($powerEvidence -join '; ') -Subcategory 'Power' -CheckId 'System/PowerResets'
+                    } else {
+                        Add-CategoryNormal -CategoryResult $result -Title 'Power reset events observed' -Evidence ($powerEvidence -join '; ') -Subcategory 'Power' -CheckId 'System/PowerResets'
+                    }
+                } else {
+                    Add-CategoryNormal -CategoryResult $result -Title 'No recent power reset events detected' -Evidence 'Count (7 days): 0' -Subcategory 'Power' -CheckId 'System/PowerResets'
+                }
+
+                $tdrCount = $tdrEvents.Count
+                Add-CategoryCheck -CategoryResult $result -Name 'Display driver TDR 4101 events (7 days)' -Status ([string]$tdrCount) -CheckId 'System/GpuTdr'
+
+                if ($tdrCount -ge 2) {
+                    $latestTdr = $tdrEvents | Sort-Object TimeCreated -Descending | Select-Object -First 1
+                    $tdrEvidence = New-Object System.Collections.Generic.List[string]
+                    [void]$tdrEvidence.Add("Count (7 days): {0}" -f $tdrCount)
+                    if ($latestTdr -and $latestTdr.TimeCreated) { [void]$tdrEvidence.Add("Most recent: {0}" -f $latestTdr.TimeCreated.ToString('u')) }
+                    if ($latestTdr) {
+                        $tdrParams = Format-EventParameterEvidence -Parameters $latestTdr.Properties
+                        [void]$tdrEvidence.Add("Last parameters: {0}" -f $tdrParams)
+                    }
+
+                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Display driver timeouts detected' -Evidence ($tdrEvidence -join '; ') -Subcategory 'Graphics' -CheckId 'System/GpuTdr'
+                } elseif ($tdrCount -eq 1) {
+                    $latestTdr = $tdrEvents | Sort-Object TimeCreated -Descending | Select-Object -First 1
+                    $tdrEvidence = New-Object System.Collections.Generic.List[string]
+                    [void]$tdrEvidence.Add("Count (7 days): 1")
+                    if ($latestTdr -and $latestTdr.TimeCreated) { [void]$tdrEvidence.Add("Most recent: {0}" -f $latestTdr.TimeCreated.ToString('u')) }
+                    if ($latestTdr) {
+                        $tdrParams = Format-EventParameterEvidence -Parameters $latestTdr.Properties
+                        [void]$tdrEvidence.Add("Last parameters: {0}" -f $tdrParams)
+                    }
+
+                    Add-CategoryNormal -CategoryResult $result -Title 'Single recent GPU timeout event observed' -Evidence ($tdrEvidence -join '; ') -Subcategory 'Graphics' -CheckId 'System/GpuTdr'
+                } else {
+                    Add-CategoryNormal -CategoryResult $result -Title 'No recent GPU timeout events detected' -Evidence 'Count (7 days): 0' -Subcategory 'Graphics' -CheckId 'System/GpuTdr'
+                }
+            }
+        } elseif ($payload -and $payload.PSObject.Properties['Error']) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Targeted system event collection failed' -Evidence $payload.Error -Subcategory 'System stability'
+        } elseif ($payload) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Targeted system event data unavailable' -Subcategory 'System stability'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Targeted system event artifact missing' -Subcategory 'System stability'
     }
 
     $performanceArtifact = Get-AnalyzerArtifact -Context $Context -Name 'performance'

--- a/Collectors/System/Collect-SystemCriticalEvents.ps1
+++ b/Collectors/System/Collect-SystemCriticalEvents.ps1
@@ -1,0 +1,82 @@
+<#!
+.SYNOPSIS
+    Collects targeted system events related to bugchecks, power resets, and GPU timeouts.
+.DESCRIPTION
+    Queries the System event log for BugCheck (1001), Kernel-Power (41), Unexpected shutdown (6008),
+    and Display driver TDR (4101) events within a configurable time range. The collector emits the
+    events with timestamps and parameter values to support downstream heuristics.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output'),
+
+    [Parameter()]
+    [ValidateRange(1, 90)]
+    [int]$DaysToInclude = 30,
+
+    [Parameter()]
+    [ValidateRange(1, 1000)]
+    [int]$MaxEvents = 200
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-TargetedSystemEvents {
+    param(
+        [datetime]$StartTime,
+        [int[]]$EventIds,
+        [int]$MaxEvents
+    )
+
+    try {
+        $filter = @{ LogName = 'System'; Id = $EventIds; StartTime = $StartTime }
+        $events = Get-WinEvent -FilterHashtable $filter -MaxEvents $MaxEvents -ErrorAction Stop |
+            Sort-Object -Property TimeCreated -Descending
+
+        return $events | ForEach-Object {
+            $properties = @()
+            if ($_.Properties) {
+                foreach ($prop in $_.Properties) {
+                    $properties += $prop.Value
+                }
+            }
+
+            [ordered]@{
+                TimeCreated      = if ($_.TimeCreated) { $_.TimeCreated.ToString('o') } else { $null }
+                Id               = $_.Id
+                ProviderName     = $_.ProviderName
+                LevelDisplayName = $_.LevelDisplayName
+                Message          = $_.Message
+                Properties       = $properties
+            }
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Error = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $eventIds = @(41, 1001, 6008, 4101)
+    $startTime = (Get-Date).AddDays(-1 * [math]::Abs($DaysToInclude))
+
+    $events = Get-TargetedSystemEvents -StartTime $startTime -EventIds $eventIds -MaxEvents $MaxEvents
+
+    $payload = [ordered]@{
+        Parameters = [ordered]@{
+            EventIds      = $eventIds
+            StartTime     = $startTime.ToString('o')
+            DaysRequested = $DaysToInclude
+            MaxEvents     = $MaxEvents
+        }
+        Events = $events
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'system-critical-events.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add a collector that captures targeted system events (bugcheck 1001, kernel-power 41, unexpected shutdown 6008, and GPU TDR 4101) with timestamps and parameter values
- extend the system heuristics to evaluate recent bugchecks, power resets, and GPU timeouts, surfacing severity, evidence, and check identifiers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6ad284d58832d85390e92ce33aa93