### PR TITLE
Replace string concatenation loops with StringBuilder

### DIFF
--- a/Analyzers/HtmlComposer.ps1
+++ b/Analyzers/HtmlComposer.ps1
@@ -481,7 +481,8 @@ function Build-GoodSection {
     }
 
     $tabName = 'good-tabs'
-    $tabs = "<div class='report-tabs'><div class='report-tabs__list'>"
+    $tabsBuilder = [System.Text.StringBuilder]::new()
+    $null = $tabsBuilder.Append("<div class='report-tabs'><div class='report-tabs__list'>")
     $index = 0
     foreach ($category in $orderedCategories) {
         if (-not $categorized.ContainsKey($category)) { continue }
@@ -496,14 +497,14 @@ function Build-GoodSection {
         $labelText = Encode-Html "$category ($count)"
         $panelContent = if ($count -gt 0) { ($cards -join '') } else { "<div class='report-card'><i>No positives captured in this category.</i></div>" }
 
-        $tabs += "<input type='radio' name='$tabName' id='$tabId' class='report-tabs__radio'$checkedAttr>"
-        $tabs += "<label class='report-tabs__label' for='$tabId'>$labelText</label>"
-        $tabs += "<div class='report-tabs__panel'>$panelContent</div>"
+        $null = $tabsBuilder.Append("<input type='radio' name='$tabName' id='$tabId' class='report-tabs__radio'$checkedAttr>")
+        $null = $tabsBuilder.Append("<label class='report-tabs__label' for='$tabId'>$labelText</label>")
+        $null = $tabsBuilder.Append("<div class='report-tabs__panel'>$panelContent</div>")
         $index++
     }
 
-    $tabs += "</div></div>"
-    return $tabs
+    $null = $tabsBuilder.Append("</div></div>")
+    return $tabsBuilder.ToString()
 }
 
 function Build-IssueSection {
@@ -561,7 +562,8 @@ function Build-IssueSection {
     }
 
     $tabName = 'issue-tabs'
-    $tabs = "<div class='report-tabs'><div class='report-tabs__list'>"
+    $tabsBuilder = [System.Text.StringBuilder]::new()
+    $null = $tabsBuilder.Append("<div class='report-tabs'><div class='report-tabs__list'>")
     $firstDefinition = $activeDefinitions[0]
     $firstKey = if ($firstDefinition.Key) { [string]$firstDefinition.Key } else { '' }
     $index = 0
@@ -584,14 +586,14 @@ function Build-IssueSection {
         $labelInner = "<span class='report-badge report-badge--$($definition.BadgeClass) report-tabs__label-badge'>$badgeLabel</span><span class='report-tabs__label-count'>$countLabel</span>"
         $panelContent = if ($count -gt 0) { ($cards -join '') } else { "<div class='report-card'><i>No issues captured for this severity.</i></div>" }
 
-        $tabs += "<input type='radio' name='$tabName' id='$tabId' class='report-tabs__radio'$checkedAttr>"
-        $tabs += "<label class='report-tabs__label' for='$tabId'>$labelInner</label>"
-        $tabs += "<div class='report-tabs__panel'>$panelContent</div>"
+        $null = $tabsBuilder.Append("<input type='radio' name='$tabName' id='$tabId' class='report-tabs__radio'$checkedAttr>")
+        $null = $tabsBuilder.Append("<label class='report-tabs__label' for='$tabId'>$labelInner</label>")
+        $null = $tabsBuilder.Append("<div class='report-tabs__panel'>$panelContent</div>")
         $index++
     }
 
-    $tabs += "</div></div>"
-    return $tabs
+    $null = $tabsBuilder.Append("</div></div>")
+    return $tabsBuilder.ToString()
 }
 
 function Get-TruncatedText {
@@ -817,15 +819,17 @@ function New-AnalyzerHtml {
     if ($failedReports.Count -eq 0) {
         $failedContent = "<div class='report-card'><i>All expected inputs produced output.</i></div>"
     } else {
-        $failedContent = "<div class='report-card'><table class='report-table report-table--list' cellspacing='0' cellpadding='0'><tr><th>Key</th><th>Status</th><th>Details</th></tr>"
+        $failedContentBuilder = [System.Text.StringBuilder]::new()
+        $null = $failedContentBuilder.Append("<div class='report-card'><table class='report-table report-table--list' cellspacing='0' cellpadding='0'><tr><th>Key</th><th>Status</th><th>Details</th></tr>")
         foreach ($entry in $failedReports) {
             $detailParts = @()
             if ($entry.Path) { $detailParts += "File: $($entry.Path)" }
             if ($entry.Details) { $detailParts += $entry.Details }
             $detailHtml = if ($detailParts.Count -gt 0) { ($detailParts | ForEach-Object { Encode-Html $_ }) -join '<br>' } else { Encode-Html '' }
-            $failedContent += "<tr><td>$(Encode-Html $($entry.Key))</td><td>$(Encode-Html $($entry.Status))</td><td>$detailHtml</td></tr>"
+            $null = $failedContentBuilder.Append("<tr><td>$(Encode-Html $($entry.Key))</td><td>$(Encode-Html $($entry.Status))</td><td>$detailHtml</td></tr>")
         }
-        $failedContent += "</table></div>"
+        $null = $failedContentBuilder.Append("</table></div>")
+        $failedContent = $failedContentBuilder.ToString()
     }
     $failedHtml = New-ReportSection -Title $failedTitle -ContentHtml $failedContent -Open
     $rawHtml = New-ReportSection -Title 'Raw (key excerpts)' -ContentHtml (Build-RawSection -Context $Context)

--- a/Get-InfrastructureMap.ps1
+++ b/Get-InfrastructureMap.ps1
@@ -35,77 +35,79 @@ $sites = Get-ADReplicationSite -Filter *
 $subnets = Get-ADReplicationSubnet -Filter *
 $sitelinks = Get-ADReplicationSiteLink -Filter *
 
-$md = @()
-$md += "# Infrastructure Report ($stamp)`n"
-$md += "## Domain / Forest"
-$md += "- Domain: **$($dom.DNSRoot)** (NetBIOS: $($dom.NetBIOSName))"
-$md += "- Forest: **$($forest.Name)**"
-$md += "- Forest Mode: $($forest.ForestMode)  |  Domain Mode: $($dom.DomainMode)`n"
+$mdBuilder = [System.Text.StringBuilder]::new()
+$null = $mdBuilder.AppendLine("# Infrastructure Report ($stamp)")
+$null = $mdBuilder.AppendLine('')
+$null = $mdBuilder.AppendLine('## Domain / Forest')
+$null = $mdBuilder.AppendLine("- Domain: **$($dom.DNSRoot)** (NetBIOS: $($dom.NetBIOSName))")
+$null = $mdBuilder.AppendLine("- Forest: **$($forest.Name)**")
+$null = $mdBuilder.AppendLine("- Forest Mode: $($forest.ForestMode)  |  Domain Mode: $($dom.DomainMode)")
+$null = $mdBuilder.AppendLine('')
 
-$md += "## Domain Controllers"
+$null = $mdBuilder.AppendLine('## Domain Controllers')
 foreach($dc in $dcs | Sort-Object HostName){
-  $md += "- $($dc.HostName)  Site:$($dc.Site)  IPv4:$($dc.IPv4Address)  GC:$($dc.IsGlobalCatalog)"
+  $null = $mdBuilder.AppendLine("- $($dc.HostName)  Site:$($dc.Site)  IPv4:$($dc.IPv4Address)  GC:$($dc.IsGlobalCatalog)")
 }
-$md += ""
+$null = $mdBuilder.AppendLine('')
 
-$md += "## DNS Zones"
+$null = $mdBuilder.AppendLine('## DNS Zones')
 foreach($z in $zones){
-  $md += "- $($z.ZoneName)  Type:$($z.ZoneType)  AD-Integrated:$($z.IsDsIntegrated)  Replication:$($z.ReplicationScope)"
+  $null = $mdBuilder.AppendLine("- $($z.ZoneName)  Type:$($z.ZoneType)  AD-Integrated:$($z.IsDsIntegrated)  Replication:$($z.ReplicationScope)")
 }
-$md += ""
+$null = $mdBuilder.AppendLine('')
 
-$md += "## DHCP (local server overview)"
+$null = $mdBuilder.AppendLine('## DHCP (local server overview)')
 foreach($s in $scopes){
-  $md += "- Scope $($s.ScopeId)  $($s.Name)  Lease:$([int]$s.LeaseDuration.TotalHours)h"
+  $null = $mdBuilder.AppendLine("- Scope $($s.ScopeId)  $($s.Name)  Lease:$([int]$s.LeaseDuration.TotalHours)h")
 }
-$md += ""
+$null = $mdBuilder.AppendLine('')
 
-$md += "## AD Sites/Subnets"
-$md += "Sites:"
-foreach($s in $sites){ $md += "- $($s.Name)" }
-$md += "Subnets:"
-foreach($sn in $subnets){ $md += "- $($sn.Name)  Site:$($sn.Site) " }
-$md += "Site Links:"
-foreach($sl in $sitelinks){ $md += "- $($sl.Name)  Sites: $((($sl.SitesIncluded | ForEach-Object {$_.Name}) -join ', '))" }
+$null = $mdBuilder.AppendLine('## AD Sites/Subnets')
+$null = $mdBuilder.AppendLine('Sites:')
+foreach($s in $sites){ $null = $mdBuilder.AppendLine("- $($s.Name)") }
+$null = $mdBuilder.AppendLine('Subnets:')
+foreach($sn in $subnets){ $null = $mdBuilder.AppendLine("- $($sn.Name)  Site:$($sn.Site) ") }
+$null = $mdBuilder.AppendLine('Site Links:')
+foreach($sl in $sitelinks){ $null = $mdBuilder.AppendLine("- $($sl.Name)  Sites: $((($sl.SitesIncluded | ForEach-Object {$_.Name}) -join ', '))") }
 
 # Optional Hyper-V
 if ($IncludeHyperV){
   try{
     Import-Module Hyper-V -ErrorAction Stop
     $hosts = @(Get-VMHost)
-    $md += "## Hyper-V Hosts/VMs"
+    $null = $mdBuilder.AppendLine('## Hyper-V Hosts/VMs')
     foreach($h in $hosts){
-      $md += "- Host $($h.ComputerName) CPUs:$($h.LogicalProcessorCount) MemGB:$([math]::Round($h.MemoryCapacity/1GB,1))"
+      $null = $mdBuilder.AppendLine("- Host $($h.ComputerName) CPUs:$($h.LogicalProcessorCount) MemGB:$([math]::Round($h.MemoryCapacity/1GB,1))")
       Get-VM -ComputerName $h.ComputerName | ForEach-Object {
-        $md += "  - VM $($_.Name) State:$($_.State) CPU:$($_.ProcessorCount) RAMMB:$($_.MemoryAssigned/1MB)"
+        $null = $mdBuilder.AppendLine("  - VM $($_.Name) State:$($_.State) CPU:$($_.ProcessorCount) RAMMB:$($_.MemoryAssigned/1MB)")
       }
     }
   }catch{
-    $md += "_Hyper-V module not available on this machine._"
+    $null = $mdBuilder.AppendLine('_Hyper-V module not available on this machine._')
   }
 }
 
 $mdPath = Join-Path $reportDir "Infrastructure_Report_$stamp.md"
-$md -join "`n" | Out-File -Encoding UTF8 $mdPath
+$mdBuilder.ToString().TrimEnd([Environment]::NewLine.ToCharArray()) | Out-File -Encoding UTF8 $mdPath
 
 # Graphviz DOT (very simple)
-$dot = @()
-$dot += 'digraph Infra {'
-$dot += '  rankdir=LR; node [shape=box, fontsize=10];'
-$dot += "  subgraph cluster_domain { label=\"Domain: $($dom.DNSRoot)\"; style=dashed;"
-foreach($dc in $dcs){ $dot += "    \"DC:$($dc.HostName)\";" }
-$dot += "  }"
-foreach($z in $zones){ $dot += "  \"Zone:$($z.ZoneName)\";" }
-foreach($s in $sites){ $dot += "  \"Site:$($s.Name)\";"; }
+$dotBuilder = [System.Text.StringBuilder]::new()
+$null = $dotBuilder.AppendLine('digraph Infra {')
+$null = $dotBuilder.AppendLine('  rankdir=LR; node [shape=box, fontsize=10];')
+$null = $dotBuilder.AppendLine("  subgraph cluster_domain { label=\"Domain: $($dom.DNSRoot)\"; style=dashed;")
+foreach($dc in $dcs){ $null = $dotBuilder.AppendLine("    \"DC:$($dc.HostName)\";") }
+$null = $dotBuilder.AppendLine('  }')
+foreach($z in $zones){ $null = $dotBuilder.AppendLine("  \"Zone:$($z.ZoneName)\";") }
+foreach($s in $sites){ $null = $dotBuilder.AppendLine("  \"Site:$($s.Name)\";") }
 foreach($dc in $dcs){
-  $dot += "  \"Site:$($dc.Site)\" -> \"DC:$($dc.HostName)\";"
+  $null = $dotBuilder.AppendLine("  \"Site:$($dc.Site)\" -> \"DC:$($dc.HostName)\";")
 }
 foreach($z in $zones){
-  foreach($dc in $dcs){ $dot += "  \"DC:$($dc.HostName)\" -> \"Zone:$($z.ZoneName)\" [style=dotted];" }
+  foreach($dc in $dcs){ $null = $dotBuilder.AppendLine("  \"DC:$($dc.HostName)\" -> \"Zone:$($z.ZoneName)\" [style=dotted];") }
 }
-$dot += '}'
+$null = $dotBuilder.AppendLine('}')
 $dotPath = Join-Path $reportDir "Infrastructure_Map_$stamp.dot"
-$dot -join "`n" | Out-File -Encoding UTF8 $dotPath
+$dotBuilder.ToString().TrimEnd([Environment]::NewLine.ToCharArray()) | Out-File -Encoding UTF8 $dotPath
 
 Write-Host "Report: $mdPath"
 Write-Host "Graphviz DOT: $dotPath (render with 'dot -Tpng file.dot -o file.png')"


### PR DESCRIPTION
## Summary
- replace report generation loops in Get-InfrastructureMap.ps1 to use StringBuilder append operations instead of `+=`
- update HTML composition helpers to build tab content and failed report tables with StringBuilder for efficient concatenation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b6240c20832dad149e3902dae26e