### PR TITLE
Reuse captured timestamp in status scripts

### DIFF
--- a/Get-ADQuickHealth.ps1
+++ b/Get-ADQuickHealth.ps1
@@ -18,7 +18,8 @@ param(
   [switch]$SaveReport
 )
 $ErrorActionPreference = 'Stop'
-$stamp = (Get-Date).ToString('yyyyMMdd_HHmmss')
+$now = Get-Date
+$stamp = $now.ToString('yyyyMMdd_HHmmss')
 $reportDir = Join-Path -Path $PSScriptRoot -ChildPath "Reports"
 if ($SaveReport -and -not (Test-Path $reportDir)) { New-Item -ItemType Directory -Path $reportDir | Out-Null }
 $sb = New-Object System.Text.StringBuilder
@@ -36,7 +37,7 @@ $sb = New-Object System.Text.StringBuilder
 #>
 function Add-Line($txt){[void]$sb.AppendLine($txt); $txt}
 
-Add-Line "=== AD QUICK HEALTH $(Get-Date) ==="
+Add-Line "=== AD QUICK HEALTH $now ==="
 
 # Domain/Forest basics
 try{

--- a/Get-DHCPStatus.ps1
+++ b/Get-DHCPStatus.ps1
@@ -21,7 +21,8 @@ param(
   [switch]$SaveReport
 )
 $ErrorActionPreference = 'Stop'
-$stamp = (Get-Date).ToString('yyyyMMdd_HHmmss')
+$now = Get-Date
+$stamp = $now.ToString('yyyyMMdd_HHmmss')
 $reportDir = Join-Path -Path $PSScriptRoot -ChildPath "Reports"
 if ($SaveReport -and -not (Test-Path $reportDir)) { New-Item -ItemType Directory -Path $reportDir | Out-Null }
 $sb = New-Object System.Text.StringBuilder
@@ -35,7 +36,7 @@ $sb = New-Object System.Text.StringBuilder
 #>
 function Add-Line($t){[void]$sb.AppendLine($t); $t}
 
-Add-Line "=== DHCP STATUS on $ComputerName $(Get-Date) ==="
+Add-Line "=== DHCP STATUS on $ComputerName $now ==="
 
 try{
   Add-Line "`n--- Authorized DHCP servers in AD ---"

--- a/Get-DNSStatus.ps1
+++ b/Get-DNSStatus.ps1
@@ -21,7 +21,8 @@ param(
   [switch]$SaveReport
 )
 $ErrorActionPreference = 'Stop'
-$stamp = (Get-Date).ToString('yyyyMMdd_HHmmss')
+$now = Get-Date
+$stamp = $now.ToString('yyyyMMdd_HHmmss')
 $reportDir = Join-Path -Path $PSScriptRoot -ChildPath "Reports"
 if ($SaveReport -and -not (Test-Path $reportDir)) { New-Item -ItemType Directory -Path $reportDir | Out-Null }
 $sb = New-Object System.Text.StringBuilder
@@ -35,7 +36,7 @@ $sb = New-Object System.Text.StringBuilder
 #>
 function Add-Line($t){[void]$sb.AppendLine($t); $t}
 
-Add-Line "=== DNS STATUS on $ComputerName $(Get-Date) ==="
+Add-Line "=== DNS STATUS on $ComputerName $now ==="
 
 try{
   Add-Line "`n--- Forwarders ---"


### PR DESCRIPTION
## Summary
- capture the current time once in DHCP, DNS, and AD quick health scripts
- reuse the cached timestamp for both filenames and banner text to avoid repeated Get-Date calls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b67d72a0832daa5fae7b004d5cb9