### PR TITLE
Temporarily skip Active Directory heuristics

### DIFF
--- a/Analyzers/Analyze-Diagnostics.ps1
+++ b/Analyzers/Analyze-Diagnostics.ps1
@@ -33,7 +33,7 @@ if (Test-Path -Path $heuristicsPath) {
 . (Join-Path -Path $PSScriptRoot -ChildPath 'HtmlComposer.ps1')
 
 $script:progressActivity = 'Running diagnostics analysis'
-$script:progressTotal = 15
+$script:progressTotal = 14
 $script:progressIndex = 0
 
 function Update-AnalyzerProgress {
@@ -120,9 +120,7 @@ $categories += Invoke-AnalyzerPhase -Name 'Security heuristics' -ScriptBlock { I
 Update-AnalyzerProgress -Status 'Loading network heuristics'
 $categories += Invoke-AnalyzerPhase -Name 'Network heuristics' -ScriptBlock { Invoke-NetworkHeuristics -Context $context }
 
-Update-AnalyzerProgress -Status 'Loading Active Directory heuristics'
-$categories += Invoke-AnalyzerPhase -Name 'Active Directory heuristics' -ScriptBlock { Invoke-ADHeuristics -Context $context }
-
+# Active Directory heuristics temporarily disabled due to known stability issues.
 Update-AnalyzerProgress -Status 'Loading Microsoft 365 heuristics'
 $categories += Invoke-AnalyzerPhase -Name 'Microsoft 365 heuristics' -ScriptBlock { Invoke-OfficeHeuristics -Context $context }
 


### PR DESCRIPTION
## Summary
- adjust the analyzer progress total to account for the disabled Active Directory pass
- temporarily remove the Active Directory heuristic phase while the module is unstable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c7631f38832db83a5cd3c4c462b9