### PR TITLE
Use ToArray when formatting domain controller evidence

### DIFF
--- a/Analyzers/Heuristics/AD.ps1
+++ b/Analyzers/Heuristics/AD.ps1
@@ -123,7 +123,7 @@ function Invoke-ADHeuristics {
                 if ($candidate.Hostname) { [void]$dcNames.Add($candidate.Hostname) }
             }
         }
-        $dcEvidence = if ($dcNames.Count -gt 0) { (@($dcNames) | Sort-Object -Unique) -join ', ' } else { 'SRV queries resolved.' }
+        $dcEvidence = if ($dcNames.Count -gt 0) { ($dcNames.ToArray() | Sort-Object -Unique) -join ', ' } else { 'SRV queries resolved.' }
         Add-CategoryNormal -CategoryResult $result -Title 'GOOD AD/DNS (SRV resolves)' -Evidence $dcEvidence
     } else {
         $srvErrors = $srvLookups | Where-Object { $_ -and $_.Succeeded -ne $true }


### PR DESCRIPTION
## Summary
- avoid using array concatenation when building domain controller evidence
- convert the collected hostnames to an array via ToArray() before sorting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6ca5fed18832dbd230025e1e5c9c0