### PR TITLE
Fix Add invocation in printer network test generation

### DIFF
--- a/Collectors/Services/Collect-Printing.ps1
+++ b/Collectors/Services/Collect-Printing.ps1
@@ -491,7 +491,8 @@ function Get-NetworkTestsForPrinters {
 
         $tests = [System.Collections.Generic.List[object]]::new()
         foreach ($definition in $definitions) {
-            $null = $tests.Add(Invoke-PortTest -Host $entry.Host -Kind $entry.Kind -Definition $definition)
+            $test = Invoke-PortTest -Host $entry.Host -Kind $entry.Kind -Definition $definition
+            $null = $tests.Add($test)
         }
 
         $null = $results.Add([ordered]@{


### PR DESCRIPTION
## Summary
- ensure printer network port tests are added from a stored variable to avoid PowerShell parsing errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6cb8efe4c832dabfecb363bdcdd17