### PR TITLE
Add runtime logging for analyzer workflow

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -3,6 +3,28 @@
     Shared helper functions for analyzer modules.
 #>
 
+function Write-AnalyzerLog {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message,
+
+        [ValidateSet('INFO', 'WARN', 'DEBUG', 'ERROR')]
+        [string]$Level = 'INFO'
+    )
+
+    $timestamp = Get-Date -Format 'HH:mm:ss'
+    $normalizedLevel = $Level.ToUpperInvariant()
+    $line = "[{0}] [{1}] {2}" -f $timestamp, $normalizedLevel, $Message
+
+    Write-Verbose $line
+
+    switch ($normalizedLevel) {
+        'WARN'  { Write-Warning $line }
+        'ERROR' { Write-Host $line }
+        default { Write-Host $line }
+    }
+}
+
 function New-AnalyzerContext {
     param(
         [Parameter(Mandatory)]


### PR DESCRIPTION
## Summary
- add a shared Write-AnalyzerLog helper to standardize analyzer logging output
- emit additional analyzer workflow logging during phase execution, CSS bundling, and report persistence
- log HTML composition milestones including category counts and timing insights

## Testing
- not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6cdfcc08c832db800a09ac83794b8