### PR TITLE
Fix analyzer script parameter declaration order

### DIFF
--- a/Analyzers/Analyze-Diagnostics.ps1
+++ b/Analyzers/Analyze-Diagnostics.ps1
@@ -1,12 +1,3 @@
-$global:EnableDiag = ($env:ANALYZER_DEBUG -eq '1')
-$EnableDiag = $global:EnableDiag
-if ($EnableDiag) { $VerbosePreference = 'Continue' }
-
-trap {
-    try { if ($EnableDiag) { Get-PSCallStack | Format-List -Force | Out-Host } } catch {}
-    throw
-}
-
 <#!
 .SYNOPSIS
     Analyzer orchestrator that loads JSON artifacts, runs heuristic modules, and generates an HTML report.
@@ -23,6 +14,15 @@ param(
     [Parameter()]
     [string]$OutputPath
 )
+
+$global:EnableDiag = ($env:ANALYZER_DEBUG -eq '1')
+$EnableDiag = $global:EnableDiag
+if ($EnableDiag) { $VerbosePreference = 'Continue' }
+
+trap {
+    try { if ($EnableDiag) { Get-PSCallStack | Format-List -Force | Out-Host } } catch {}
+    throw
+}
 
 $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
## Summary
- move the CmdletBinding/param block to the top of the analyzer script so it loads correctly in PowerShell
- keep diagnostic initialization and trap logic after the param block to preserve behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d16de4a4832da70d7e8ff879e5e6