### PR TITLE
Fix analyzer module imports after folder restructuring

### DIFF
--- a/Analyzers/Analyze-Diagnostics.ps1
+++ b/Analyzers/Analyze-Diagnostics.ps1
@@ -28,6 +28,11 @@ if (Test-Path -Path $heuristicsPath) {
     Get-ChildItem -Path $heuristicsPath -Filter '*.ps1' -File | Sort-Object Name | ForEach-Object {
         . $_.FullName
     }
+
+    $networkModulePath = Join-Path -Path $heuristicsPath -ChildPath 'Network/Network.ps1'
+    if (Test-Path -Path $networkModulePath) {
+        . $networkModulePath
+    }
 }
 . (Join-Path -Path $PSScriptRoot -ChildPath 'SummaryBuilder.ps1')
 . (Join-Path -Path $PSScriptRoot -ChildPath 'HtmlComposer.ps1')

--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -3,7 +3,8 @@
     Network diagnostics heuristics covering connectivity, DNS, proxy, and Outlook health.
 #>
 
-. (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+$analyzersRoot = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
+. (Join-Path -Path $analyzersRoot -ChildPath 'AnalyzerCommon.ps1')
 
 function Test-NetworkPrivateIpv4 {
     param([string]$Address)
@@ -363,7 +364,7 @@ function Invoke-DhcpAnalyzers {
     $inputFolder = Split-Path -Path $firstEntry.Path -Parent
     if (-not $inputFolder -or -not (Test-Path -LiteralPath $inputFolder)) { return }
 
-    $analyzerRoot = Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath 'Network/DHCP'
+    $analyzerRoot = Join-Path -Path $PSScriptRoot -ChildPath 'DHCP'
     if (-not (Test-Path -LiteralPath $analyzerRoot)) { return }
 
     $scriptFiles = Get-ChildItem -Path $analyzerRoot -Filter 'Analyze-Dhcp*.ps1' -File -ErrorAction SilentlyContinue | Sort-Object Name

--- a/Analyzers/Heuristics/System.ps1
+++ b/Analyzers/Heuristics/System.ps1
@@ -5,7 +5,7 @@
 
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
 
-$systemModuleRoot = Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'System'
+$systemModuleRoot = Join-Path -Path $PSScriptRoot -ChildPath 'System'
 . (Join-Path -Path $systemModuleRoot -ChildPath 'SystemHelpers.ps1')
 . (Join-Path -Path $systemModuleRoot -ChildPath 'OperatingSystem.ps1')
 . (Join-Path -Path $systemModuleRoot -ChildPath 'Uptime.ps1')


### PR DESCRIPTION
## Summary
- ensure the analyzer orchestrator loads the network heuristics module from its new subfolder
- update the system heuristics bootstrap to import helper scripts from the relocated directory
- adjust the network heuristics script to locate AnalyzerCommon and DHCP analyzers under the new layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d765c70c04832da42929fa012e9b16