### PR TITLE
Reclassify OST presence under Office heuristics

### DIFF
--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -646,15 +646,6 @@ function Invoke-NetworkHeuristics {
             }
         }
 
-        if ($payload -and $payload.OstFiles) {
-            $largeOst = $payload.OstFiles | Where-Object { $_.Length -gt 25GB }
-            if ($largeOst.Count -gt 0) {
-                $names = $largeOst | Select-Object -ExpandProperty Name
-                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ('Large OST files detected: {0}' -f ($names -join ', ')) -Subcategory 'Outlook Data Files'
-            } elseif ($payload.OstFiles.Count -gt 0) {
-                Add-CategoryNormal -CategoryResult $result -Title ('OST files present ({0})' -f $payload.OstFiles.Count)
-            }
-        }
     }
 
     $autodiscoverArtifact = Get-AnalyzerArtifact -Context $Context -Name 'autodiscover-dns'

--- a/Analyzers/Heuristics/Office.ps1
+++ b/Analyzers/Heuristics/Office.ps1
@@ -64,6 +64,20 @@ function Invoke-OfficeHeuristics {
         }
     }
 
+    $connectivityArtifact = Get-AnalyzerArtifact -Context $Context -Name 'outlook-connectivity'
+    if ($connectivityArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $connectivityArtifact)
+        if ($payload -and $payload.OstFiles) {
+            $largeOst = $payload.OstFiles | Where-Object { $_.Length -gt 25GB }
+            if ($largeOst.Count -gt 0) {
+                $names = $largeOst | Select-Object -ExpandProperty Name
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ('Large OST files detected: {0}' -f ($names -join ', ')) -Subcategory 'Outlook Data Files'
+            } elseif ($payload.OstFiles.Count -gt 0) {
+                Add-CategoryNormal -CategoryResult $result -Title ('OST files present ({0})' -f $payload.OstFiles.Count)
+            }
+        }
+    }
+
     $autodiscoverArtifact = Get-AnalyzerArtifact -Context $Context -Name 'autodiscover-dns'
     if ($autodiscoverArtifact) {
         $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $autodiscoverArtifact)


### PR DESCRIPTION
## Summary
- remove the informational OST presence message from the network heuristics results
- surface OST file presence and sizing under the Office heuristics category using the outlook connectivity artifact
- remove the large OST detection from the network heuristics so the Office category owns all OST reporting

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d894735e70832db3dd7cb2304fa804