### PR TITLE
Add security baseline section to report output

### DIFF
--- a/Scripts/styles/device-health-report.css
+++ b/Scripts/styles/device-health-report.css
@@ -437,6 +437,15 @@ details.report-card[open] > summary {
   background-color: var(--color-surface);
 }
 
+.security-checks__table .security-checks__status {
+  white-space: nowrap;
+  width: 1%;
+}
+
+.security-checks__table .security-checks__label {
+  width: 32%;
+}
+
 .report-pre {
   margin-top: var(--space-sm);
   padding: var(--space-sm);


### PR DESCRIPTION
## Summary
- tag core security heuristics with check identifiers so their status is always surfaced
- render a dedicated "Security Baseline Checks" table in the report and style it appropriately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d895e2f26c832dbb6c1c3b29b205e7