### PR TITLE
Refactor services heuristics into modular scripts

### DIFF
--- a/Analyzers/Heuristics/Services.ps1
+++ b/Analyzers/Heuristics/Services.ps1
@@ -5,124 +5,10 @@
 
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
 
-function Normalize-ServiceStateValue {
-    param([string]$Value)
-
-    if (-not $Value) { return 'unknown' }
-    $trimmed = $Value.Trim()
-    if (-not $trimmed) { return 'unknown' }
-
-    $lower = $trimmed.ToLowerInvariant()
-    if ($lower -like 'run*') { return 'running' }
-    if ($lower -like 'stop*') { return 'stopped' }
-    return 'other'
-}
-
-function Normalize-ServiceStartValue {
-    param([string]$Value)
-
-    if (-not $Value) { return 'unknown' }
-    $trimmed = $Value.Trim()
-    if (-not $trimmed) { return 'unknown' }
-
-    $lower = $trimmed.ToLowerInvariant()
-    if ($lower -like 'auto*' -and $lower -like '*delay*') { return 'automatic-delayed' }
-    if ($lower -like 'auto*') { return 'automatic' }
-    if ($lower -like 'manual*') { return 'manual' }
-    if ($lower -like 'disabled*') { return 'disabled' }
-    return 'other'
-}
-
-function Get-ServiceStateInfo {
-    param(
-        $Lookup,
-        [string]$Name
-    )
-
-    if (-not $Lookup -or -not $Lookup.ContainsKey($Name)) {
-        return [pscustomobject]@{
-            Exists              = $false
-            Name                = $Name
-            DisplayName         = $Name
-            Status              = 'Unknown'
-            StatusNormalized    = 'unknown'
-            StartMode           = 'Unknown'
-            StartModeNormalized = 'unknown'
-        }
-    }
-
-    $service = $Lookup[$Name]
-    $status = 'Unknown'
-    if ($service.PSObject.Properties['State']) { $status = [string]$service.State }
-    elseif ($service.PSObject.Properties['Status']) { $status = [string]$service.Status }
-
-    $startMode = 'Unknown'
-    if ($service.PSObject.Properties['StartMode']) { $startMode = [string]$service.StartMode }
-    elseif ($service.PSObject.Properties['StartType']) { $startMode = [string]$service.StartType }
-
-    $displayName = if ($service.PSObject.Properties['DisplayName']) { [string]$service.DisplayName } else { $Name }
-
-    return [pscustomobject]@{
-        Exists              = $true
-        Name                = $Name
-        DisplayName         = $displayName
-        Status              = if ($status) { $status } else { 'Unknown' }
-        StatusNormalized    = Normalize-ServiceStateValue -Value $status
-        StartMode           = if ($startMode) { $startMode } else { 'Unknown' }
-        StartModeNormalized = Normalize-ServiceStartValue -Value $startMode
-    }
-}
-
-function Get-DevicePlatformInfo {
-    param($Context)
-
-    $isWindowsServer = $null
-    $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
-    if ($systemArtifact) {
-        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact)
-        if ($payload -and $payload.OperatingSystem -and -not $payload.OperatingSystem.Error) {
-            $caption = [string]$payload.OperatingSystem.Caption
-            if ($caption) {
-                $isWindowsServer = ($caption -match '(?i)windows\s+server')
-            }
-        }
-    }
-
-    $isWorkstation = $null
-    if ($isWindowsServer -eq $true) { $isWorkstation = $false }
-    elseif ($isWindowsServer -eq $false) { $isWorkstation = $true }
-
-    return [pscustomobject]@{
-        IsWindowsServer = $isWindowsServer
-        IsWorkstation   = $isWorkstation
-    }
-}
-
-function Get-SystemProxyInfo {
-    param($Context)
-
-    $hasSystemProxy = $false
-    $proxyEvidence = $null
-
-    $proxyArtifact = Get-AnalyzerArtifact -Context $Context -Name 'proxy'
-    if ($proxyArtifact) {
-        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $proxyArtifact)
-        if ($payload -and $payload.WinHttp) {
-            if ($payload.WinHttp -is [System.Collections.IEnumerable] -and -not ($payload.WinHttp -is [string])) {
-                $proxyEvidence = ($payload.WinHttp -join "`n").Trim()
-            } else {
-                $proxyEvidence = ([string]$payload.WinHttp).Trim()
-            }
-
-            if ($proxyEvidence -and ($proxyEvidence -notmatch '(?i)direct\s+access')) {
-                $hasSystemProxy = $true
-            }
-        }
-    }
-
-    return [pscustomobject]@{
-        HasSystemProxy = $hasSystemProxy
-        Evidence       = $proxyEvidence
+$servicesModuleRoot = Join-Path -Path $PSScriptRoot -ChildPath 'Services'
+if (Test-Path -LiteralPath $servicesModuleRoot) {
+    Get-ChildItem -Path $servicesModuleRoot -Filter '*.ps1' -File | Sort-Object Name | ForEach-Object {
+        . $_.FullName
     }
 }
 
@@ -140,213 +26,37 @@ function Invoke-ServicesHeuristics {
     $proxyInfo = Get-SystemProxyInfo -Context $Context
 
     $servicesArtifact = Get-AnalyzerArtifact -Context $Context -Name 'services'
-    if ($servicesArtifact) {
-        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $servicesArtifact)
-        if ($payload -and $payload.Services -and -not $payload.Services.Error) {
-            $services = $payload.Services
-            if ($services -is [System.Collections.IEnumerable] -and -not ($services -is [string])) {
-                $services = @($services)
-            } else {
-                $services = @($services)
-            }
-
-            $lookup = @{}
-            foreach ($service in $services) {
-                if (-not $service) { continue }
-                if ($service.PSObject.Properties['Name']) {
-                    $lookup[[string]$service.Name] = $service
-                }
-            }
-
-            $wsearch = Get-ServiceStateInfo -Lookup $lookup -Name 'WSearch'
-            if (-not $wsearch.Exists) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Search service missing' -Evidence 'Service entry not found; search and Outlook indexing will fail.' -Subcategory 'Windows Search Service'
-            } elseif ($wsearch.StatusNormalized -eq 'running') {
-                Add-CategoryNormal -CategoryResult $result -Title 'Windows Search service running' -Evidence ("Status: {0}; StartType: {1}" -f $wsearch.Status, $wsearch.StartMode) -Subcategory 'Windows Search Service'
-            } else {
-                $title = "Windows Search service not running (Status: {0}; StartType: {1})." -f $wsearch.Status, $wsearch.StartMode
-                if ($wsearch.StartModeNormalized -eq 'manual') {
-                    if ($isWorkstation) {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Windows Search set to Manual and stopped' -Evidence $title -Subcategory 'Windows Search Service'
-                    } elseif ($isServer) {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Windows Search manual start and currently stopped' -Evidence $title -Subcategory 'Windows Search Service'
-                    } else {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Windows Search manual start and currently stopped' -Evidence $title -Subcategory 'Windows Search Service'
-                    }
-                } elseif ($wsearch.StartModeNormalized -eq 'disabled') {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Search disabled' -Evidence $title -Subcategory 'Windows Search Service'
-                } else {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Search not running' -Evidence $title -Subcategory 'Windows Search Service'
-                }
-            }
-
-            $dnsCache = Get-ServiceStateInfo -Lookup $lookup -Name 'Dnscache'
-            if (-not $dnsCache.Exists) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'critical' -Title 'DNS Client (Dnscache) service missing' -Evidence 'Service entry not found; DNS resolution will fail.' -Subcategory 'DNS Client Service'
-            } elseif ($dnsCache.StatusNormalized -eq 'running') {
-                Add-CategoryNormal -CategoryResult $result -Title 'DNS Client service running' -Evidence ("Status: {0}; StartType: {1}" -f $dnsCache.Status, $dnsCache.StartMode) -Subcategory 'DNS Client Service'
-            } else {
-                $dnsTitle = "DNS Client service not running (Status: {0}; StartType: {1})." -f $dnsCache.Status, $dnsCache.StartMode
-                Add-CategoryIssue -CategoryResult $result -Severity 'critical' -Title 'DNS Client service offline — name resolution will break' -Evidence $dnsTitle -Subcategory 'DNS Client Service'
-            }
-
-            $nla = Get-ServiceStateInfo -Lookup $lookup -Name 'NlaSvc'
-            if (-not $nla.Exists) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Network Location Awareness service missing' -Evidence 'Service entry not found; network profile detection will fail.' -Subcategory 'Network Location Awareness'
-            } elseif ($nla.StatusNormalized -eq 'running') {
-                Add-CategoryNormal -CategoryResult $result -Title 'Network Location Awareness running' -Evidence ("Status: {0}; StartType: {1}" -f $nla.Status, $nla.StartMode) -Subcategory 'Network Location Awareness'
-            } else {
-                $nlaEvidence = "Status: {0}; StartType: {1}" -f $nla.Status, $nla.StartMode
-                if ($nla.StartModeNormalized -eq 'manual' -and $isWorkstation) {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Network Location Awareness set to Manual and stopped' -Evidence $nlaEvidence -Subcategory 'Network Location Awareness'
-                } else {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Network Location Awareness service not running' -Evidence $nlaEvidence -Subcategory 'Network Location Awareness'
-                }
-            }
-
-            $lanmanWk = Get-ServiceStateInfo -Lookup $lookup -Name 'LanmanWorkstation'
-            if (-not $lanmanWk.Exists) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Workstation (LanmanWorkstation) service missing' -Evidence 'Service entry not found; SMB client functionality unavailable.' -Subcategory 'Workstation Service'
-            } elseif ($lanmanWk.StatusNormalized -eq 'running') {
-                Add-CategoryNormal -CategoryResult $result -Title 'Workstation service running' -Evidence ("Status: {0}; StartType: {1}" -f $lanmanWk.Status, $lanmanWk.StartMode) -Subcategory 'Workstation Service'
-            } else {
-                $lanmanEvidence = "Status: {0}; StartType: {1}" -f $lanmanWk.Status, $lanmanWk.StartMode
-                $lanmanTitle = if ($lanmanWk.StartModeNormalized -eq 'disabled') { 'Workstation service disabled — SMB connectivity broken' } else { 'Workstation service stopped — SMB connectivity broken' }
-                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title $lanmanTitle -Evidence $lanmanEvidence -Subcategory 'Workstation Service'
-            }
-
-            $spooler = Get-ServiceStateInfo -Lookup $lookup -Name 'Spooler'
-            if (-not $spooler.Exists) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Print Spooler service missing' -Evidence 'Service entry not found; printing features unavailable.' -Subcategory 'Print Spooler Service'
-            } elseif ($spooler.StatusNormalized -eq 'running') {
-                if ($isWorkstation) {
-                    $title = 'Print Spooler running — disable if this workstation does not require printing (PrintNightmare risk).'
-                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title $title -Evidence ("Status: {0}; StartType: {1}" -f $spooler.Status, $spooler.StartMode) -Subcategory 'Print Spooler Service'
-                } else {
-                    Add-CategoryNormal -CategoryResult $result -Title 'Print Spooler running' -Evidence ("Status: {0}; StartType: {1}" -f $spooler.Status, $spooler.StartMode) -Subcategory 'Print Spooler Service'
-                }
-            } else {
-                $note = if ($isWorkstation) { 'PrintNightmare guidance: disable spooler unless required.' } else { 'Printing functionality will be unavailable while stopped.' }
-                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Print Spooler not running' -Evidence ("Status: {0}; StartType: {1}; Note: {2}" -f $spooler.Status, $spooler.StartMode, $note) -Subcategory 'Print Spooler Service'
-            }
-
-            $rpc = Get-ServiceStateInfo -Lookup $lookup -Name 'RpcSs'
-            if (-not $rpc.Exists) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'critical' -Title 'RPC (RpcSs) service missing' -Evidence 'Service entry not found; Windows cannot operate without RPC.' -Subcategory 'RPC Services'
-            } elseif ($rpc.StatusNormalized -eq 'running') {
-                Add-CategoryNormal -CategoryResult $result -Title 'RPC (RpcSs) service running' -Evidence ("Status: {0}; StartType: {1}" -f $rpc.Status, $rpc.StartMode) -Subcategory 'RPC Services'
-            } else {
-                $rpcEvidence = "Status: {0}; StartType: {1}" -f $rpc.Status, $rpc.StartMode
-                Add-CategoryIssue -CategoryResult $result -Severity 'critical' -Title 'RPC (RpcSs) service not running — system instability expected' -Evidence $rpcEvidence -Subcategory 'RPC Services'
-            }
-
-            $rpcMapper = Get-ServiceStateInfo -Lookup $lookup -Name 'RpcEptMapper'
-            if (-not $rpcMapper.Exists) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'critical' -Title 'RPC Endpoint Mapper service missing' -Evidence 'Service entry not found; RPC endpoint resolution unavailable.' -Subcategory 'RPC Services'
-            } elseif ($rpcMapper.StatusNormalized -eq 'running') {
-                Add-CategoryNormal -CategoryResult $result -Title 'RPC Endpoint Mapper running' -Evidence ("Status: {0}; StartType: {1}" -f $rpcMapper.Status, $rpcMapper.StartMode) -Subcategory 'RPC Services'
-            } else {
-                $rpcMapperEvidence = "Status: {0}; StartType: {1}" -f $rpcMapper.Status, $rpcMapper.StartMode
-                Add-CategoryIssue -CategoryResult $result -Severity 'critical' -Title 'RPC Endpoint Mapper not running — RPC clients will fail' -Evidence $rpcMapperEvidence -Subcategory 'RPC Services'
-            }
-
-            $winHttp = Get-ServiceStateInfo -Lookup $lookup -Name 'WinHttpAutoProxySvc'
-            if (-not $winHttp.Exists) {
-                if ($proxyInfo.HasSystemProxy) {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'WinHTTP Auto Proxy service missing while a proxy is configured' -Evidence $proxyInfo.Evidence -Subcategory 'WinHTTP Auto Proxy Service'
-                } else {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'WinHTTP Auto Proxy service missing' -Subcategory 'WinHTTP Auto Proxy Service'
-                }
-            } elseif ($winHttp.StatusNormalized -eq 'running') {
-                $evidence = "Status: {0}; StartType: {1}" -f $winHttp.Status, $winHttp.StartMode
-                if ($winHttp.StartModeNormalized -eq 'manual' -and -not $proxyInfo.HasSystemProxy) {
-                    $evidence = "{0}; Manual trigger start with no system proxy configured." -f $evidence
-                }
-                Add-CategoryNormal -CategoryResult $result -Title 'WinHTTP Auto Proxy service running' -Evidence $evidence -Subcategory 'WinHTTP Auto Proxy Service'
-            } else {
-                $winHttpEvidence = "Status: {0}; StartType: {1}" -f $winHttp.Status, $winHttp.StartMode
-                if ($proxyInfo.Evidence) {
-                    $winHttpEvidence = "{0}`nProxy: {1}" -f $winHttpEvidence, $proxyInfo.Evidence
-                }
-
-                if ($winHttp.StartModeNormalized -eq 'manual') {
-                    if ($proxyInfo.HasSystemProxy) {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'WinHTTP Auto Proxy manual start while a proxy is configured' -Evidence $winHttpEvidence -Subcategory 'WinHTTP Auto Proxy Service'
-                    } else {
-                        Add-CategoryNormal -CategoryResult $result -Title 'WinHTTP Auto Proxy in manual mode with no proxy configured' -Evidence $winHttpEvidence -Subcategory 'WinHTTP Auto Proxy Service'
-                    }
-                } elseif ($winHttp.StartModeNormalized -in @('automatic','automatic-delayed')) {
-                    $severity = if ($proxyInfo.HasSystemProxy) { 'high' } else { 'medium' }
-                    Add-CategoryIssue -CategoryResult $result -Severity $severity -Title 'WinHTTP Auto Proxy service not running' -Evidence $winHttpEvidence -Subcategory 'WinHTTP Auto Proxy Service'
-                } elseif ($winHttp.StartModeNormalized -eq 'disabled') {
-                    if ($proxyInfo.HasSystemProxy) {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'WinHTTP Auto Proxy disabled while a proxy is configured' -Evidence $winHttpEvidence -Subcategory 'WinHTTP Auto Proxy Service'
-                    } else {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'WinHTTP Auto Proxy disabled' -Evidence $winHttpEvidence -Subcategory 'WinHTTP Auto Proxy Service'
-                    }
-                } else {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'WinHTTP Auto Proxy service in unexpected state' -Evidence $winHttpEvidence -Subcategory 'WinHTTP Auto Proxy Service'
-                }
-            }
-
-            $bits = Get-ServiceStateInfo -Lookup $lookup -Name 'BITS'
-            if (-not $bits.Exists) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'BITS service missing' -Evidence 'Background transfers for Windows Update, AV, and Office will fail.' -Subcategory 'BITS Service'
-            } else {
-                $bitsEvidence = "Status: {0}; StartType: {1}" -f $bits.Status, $bits.StartMode
-                if ($bits.StatusNormalized -eq 'running' -and $bits.StartModeNormalized -notin @('manual','disabled')) {
-                    Add-CategoryNormal -CategoryResult $result -Title 'BITS running' -Evidence $bitsEvidence -Subcategory 'BITS Service'
-                }
-
-                if ($bits.StartModeNormalized -eq 'disabled') {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'BITS disabled — background transfers stopped' -Evidence $bitsEvidence -Subcategory 'BITS Service'
-                } elseif ($bits.StartModeNormalized -in @('automatic','automatic-delayed')) {
-                    if ($bits.StatusNormalized -ne 'running') {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'BITS automatic but not running' -Evidence $bitsEvidence -Subcategory 'BITS Service'
-                    }
-                } elseif ($bits.StartModeNormalized -eq 'manual') {
-                    if ($isWorkstation) {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'BITS configured for manual start on workstation' -Evidence $bitsEvidence -Subcategory 'BITS Service'
-                    } elseif ($bits.StatusNormalized -ne 'running') {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'BITS manual start and currently stopped' -Evidence $bitsEvidence -Subcategory 'BITS Service'
-                    }
-                }
-            }
-
-            $clickToRun = Get-ServiceStateInfo -Lookup $lookup -Name 'ClickToRunSvc'
-            if ($clickToRun.Exists) {
-                $clickEvidence = "Status: {0}; StartType: {1}" -f $clickToRun.Status, $clickToRun.StartMode
-                if ($clickToRun.StatusNormalized -eq 'running') {
-                    Add-CategoryNormal -CategoryResult $result -Title 'Office Click-to-Run service running' -Evidence $clickEvidence -Subcategory 'Office Click-to-Run'
-                }
-
-                if ($clickToRun.StartModeNormalized -in @('automatic','automatic-delayed')) {
-                    if ($clickToRun.StatusNormalized -ne 'running') {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Office Click-to-Run automatic but not running' -Evidence $clickEvidence -Subcategory 'Office Click-to-Run'
-                    }
-                } elseif ($clickToRun.StartModeNormalized -eq 'manual' -or $clickToRun.StartModeNormalized -eq 'disabled') {
-                    if ($isWorkstation) {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Office Click-to-Run not set to automatic on workstation' -Evidence $clickEvidence -Subcategory 'Office Click-to-Run'
-                    } else {
-                        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Office Click-to-Run manual/disabled on server' -Evidence $clickEvidence -Subcategory 'Office Click-to-Run'
-                    }
-                }
-            }
-
-            $stoppedAuto = $services | Where-Object {
-                ($_.StartMode -eq 'Auto' -or $_.StartType -eq 'Automatic') -and ($_.State -ne 'Running' -and $_.Status -ne 'Running')
-            }
-            if ($stoppedAuto.Count -gt 0) {
-                $summary = $stoppedAuto | Select-Object -First 5 | ForEach-Object { "{0} ({1})" -f $_.DisplayName, ($_.State ? $_.State : $_.Status) }
-                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Automatic services not running' -Evidence ($summary -join "`n") -Subcategory 'Service Inventory'
-            } else {
-                Add-CategoryNormal -CategoryResult $result -Title 'Automatic services running'
-            }
-        } elseif ($payload.Services.Error) {
-            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Unable to query services' -Evidence $payload.Services.Error -Subcategory 'Service Inventory'
-        }
-    } else {
+    if (-not $servicesArtifact) {
         Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Services artifact missing' -Subcategory 'Collection'
+        return $result
+    }
+
+    $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $servicesArtifact)
+    if (-not $payload) {
+        return $result
+    }
+
+    $servicesNode = $null
+    if ($payload.PSObject.Properties['Services']) {
+        $servicesNode = $payload.Services
+    }
+
+    if ($servicesNode -and -not $servicesNode.Error) {
+        $services = ConvertTo-ServiceCollection -Value $servicesNode
+        $lookup = New-ServiceLookup -Services $services
+
+        Invoke-ServiceCheckWindowsSearch      -Result $result -Lookup $lookup -IsWorkstation $isWorkstation -IsServer $isServer
+        Invoke-ServiceCheckDnsClient          -Result $result -Lookup $lookup
+        Invoke-ServiceCheckNetworkLocation    -Result $result -Lookup $lookup -IsWorkstation $isWorkstation
+        Invoke-ServiceCheckWorkstation        -Result $result -Lookup $lookup
+        Invoke-ServiceCheckPrintSpooler       -Result $result -Lookup $lookup -IsWorkstation $isWorkstation
+        Invoke-ServiceCheckRpc                -Result $result -Lookup $lookup
+        Invoke-ServiceCheckWinHttpAutoProxy   -Result $result -Lookup $lookup -ProxyInfo $proxyInfo
+        Invoke-ServiceCheckBits               -Result $result -Lookup $lookup -IsWorkstation $isWorkstation
+        Invoke-ServiceCheckOfficeClickToRun   -Result $result -Lookup $lookup -IsWorkstation $isWorkstation
+        Invoke-ServiceCheckAutomaticInventory -Result $result -Services $services
+    } elseif ($servicesNode -and $servicesNode.Error) {
+        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Unable to query services' -Evidence $servicesNode.Error -Subcategory 'Service Inventory'
     }
 
     return $result

--- a/Analyzers/Heuristics/Services/Services.Checks.ps1
+++ b/Analyzers/Heuristics/Services/Services.Checks.ps1
@@ -1,0 +1,288 @@
+function Invoke-ServiceCheckWindowsSearch {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Lookup,
+        [bool]$IsWorkstation,
+        [bool]$IsServer
+    )
+
+    $service = Get-ServiceStateInfo -Lookup $Lookup -Name 'WSearch'
+    if (-not $service.Exists) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Windows Search service missing' -Evidence 'Service entry not found; search and Outlook indexing will fail.' -Subcategory 'Windows Search Service'
+        return
+    }
+
+    if ($service.StatusNormalized -eq 'running') {
+        Add-CategoryNormal -CategoryResult $Result -Title 'Windows Search service running' -Evidence ("Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode) -Subcategory 'Windows Search Service'
+        return
+    }
+
+    $title = "Windows Search service not running (Status: {0}; StartType: {1})." -f $service.Status, $service.StartMode
+    if ($service.StartModeNormalized -eq 'manual') {
+        if ($IsWorkstation) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Windows Search set to Manual and stopped' -Evidence $title -Subcategory 'Windows Search Service'
+        } elseif ($IsServer) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Windows Search manual start and currently stopped' -Evidence $title -Subcategory 'Windows Search Service'
+        } else {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Windows Search manual start and currently stopped' -Evidence $title -Subcategory 'Windows Search Service'
+        }
+    } elseif ($service.StartModeNormalized -eq 'disabled') {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Windows Search disabled' -Evidence $title -Subcategory 'Windows Search Service'
+    } else {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Windows Search not running' -Evidence $title -Subcategory 'Windows Search Service'
+    }
+}
+
+function Invoke-ServiceCheckDnsClient {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Lookup
+    )
+
+    $service = Get-ServiceStateInfo -Lookup $Lookup -Name 'Dnscache'
+    if (-not $service.Exists) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'critical' -Title 'DNS Client (Dnscache) service missing' -Evidence 'Service entry not found; DNS resolution will fail.' -Subcategory 'DNS Client Service'
+        return
+    }
+
+    if ($service.StatusNormalized -eq 'running') {
+        Add-CategoryNormal -CategoryResult $Result -Title 'DNS Client service running' -Evidence ("Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode) -Subcategory 'DNS Client Service'
+    } else {
+        $evidence = "DNS Client service not running (Status: {0}; StartType: {1})." -f $service.Status, $service.StartMode
+        Add-CategoryIssue -CategoryResult $Result -Severity 'critical' -Title 'DNS Client service offline — name resolution will break' -Evidence $evidence -Subcategory 'DNS Client Service'
+    }
+}
+
+function Invoke-ServiceCheckNetworkLocation {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Lookup,
+        [bool]$IsWorkstation
+    )
+
+    $service = Get-ServiceStateInfo -Lookup $Lookup -Name 'NlaSvc'
+    if (-not $service.Exists) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Network Location Awareness service missing' -Evidence 'Service entry not found; network profile detection will fail.' -Subcategory 'Network Location Awareness'
+        return
+    }
+
+    if ($service.StatusNormalized -eq 'running') {
+        Add-CategoryNormal -CategoryResult $Result -Title 'Network Location Awareness running' -Evidence ("Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode) -Subcategory 'Network Location Awareness'
+        return
+    }
+
+    $evidence = "Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode
+    if ($service.StartModeNormalized -eq 'manual' -and $IsWorkstation) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Network Location Awareness set to Manual and stopped' -Evidence $evidence -Subcategory 'Network Location Awareness'
+    } else {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Network Location Awareness service not running' -Evidence $evidence -Subcategory 'Network Location Awareness'
+    }
+}
+
+function Invoke-ServiceCheckWorkstation {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Lookup
+    )
+
+    $service = Get-ServiceStateInfo -Lookup $Lookup -Name 'LanmanWorkstation'
+    if (-not $service.Exists) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Workstation (LanmanWorkstation) service missing' -Evidence 'Service entry not found; SMB client functionality unavailable.' -Subcategory 'Workstation Service'
+        return
+    }
+
+    if ($service.StatusNormalized -eq 'running') {
+        Add-CategoryNormal -CategoryResult $Result -Title 'Workstation service running' -Evidence ("Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode) -Subcategory 'Workstation Service'
+        return
+    }
+
+    $evidence = "Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode
+    $title = if ($service.StartModeNormalized -eq 'disabled') { 'Workstation service disabled — SMB connectivity broken' } else { 'Workstation service stopped — SMB connectivity broken' }
+    Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title $title -Evidence $evidence -Subcategory 'Workstation Service'
+}
+
+function Invoke-ServiceCheckPrintSpooler {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Lookup,
+        [bool]$IsWorkstation
+    )
+
+    $service = Get-ServiceStateInfo -Lookup $Lookup -Name 'Spooler'
+    if (-not $service.Exists) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Print Spooler service missing' -Evidence 'Service entry not found; printing features unavailable.' -Subcategory 'Print Spooler Service'
+        return
+    }
+
+    if ($service.StatusNormalized -eq 'running') {
+        if ($IsWorkstation) {
+            $title = 'Print Spooler running — disable if this workstation does not require printing (PrintNightmare risk).'
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title $title -Evidence ("Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode) -Subcategory 'Print Spooler Service'
+        } else {
+            Add-CategoryNormal -CategoryResult $Result -Title 'Print Spooler running' -Evidence ("Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode) -Subcategory 'Print Spooler Service'
+        }
+        return
+    }
+
+    $note = if ($IsWorkstation) { 'PrintNightmare guidance: disable spooler unless required.' } else { 'Printing functionality will be unavailable while stopped.' }
+    $evidence = "Status: {0}; StartType: {1}; Note: {2}" -f $service.Status, $service.StartMode, $note
+    Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Print Spooler not running' -Evidence $evidence -Subcategory 'Print Spooler Service'
+}
+
+function Invoke-ServiceCheckRpc {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Lookup
+    )
+
+    $rpc = Get-ServiceStateInfo -Lookup $Lookup -Name 'RpcSs'
+    if (-not $rpc.Exists) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'critical' -Title 'RPC (RpcSs) service missing' -Evidence 'Service entry not found; Windows cannot operate without RPC.' -Subcategory 'RPC Services'
+    } elseif ($rpc.StatusNormalized -eq 'running') {
+        Add-CategoryNormal -CategoryResult $Result -Title 'RPC (RpcSs) service running' -Evidence ("Status: {0}; StartType: {1}" -f $rpc.Status, $rpc.StartMode) -Subcategory 'RPC Services'
+    } else {
+        $evidence = "Status: {0}; StartType: {1}" -f $rpc.Status, $rpc.StartMode
+        Add-CategoryIssue -CategoryResult $Result -Severity 'critical' -Title 'RPC (RpcSs) service not running — system instability expected' -Evidence $evidence -Subcategory 'RPC Services'
+    }
+
+    $mapper = Get-ServiceStateInfo -Lookup $Lookup -Name 'RpcEptMapper'
+    if (-not $mapper.Exists) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'critical' -Title 'RPC Endpoint Mapper service missing' -Evidence 'Service entry not found; RPC endpoint resolution unavailable.' -Subcategory 'RPC Services'
+    } elseif ($mapper.StatusNormalized -eq 'running') {
+        Add-CategoryNormal -CategoryResult $Result -Title 'RPC Endpoint Mapper running' -Evidence ("Status: {0}; StartType: {1}" -f $mapper.Status, $mapper.StartMode) -Subcategory 'RPC Services'
+    } else {
+        $evidence = "Status: {0}; StartType: {1}" -f $mapper.Status, $mapper.StartMode
+        Add-CategoryIssue -CategoryResult $Result -Severity 'critical' -Title 'RPC Endpoint Mapper not running — RPC clients will fail' -Evidence $evidence -Subcategory 'RPC Services'
+    }
+}
+
+function Invoke-ServiceCheckWinHttpAutoProxy {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Lookup,
+        [Parameter(Mandatory)]$ProxyInfo
+    )
+
+    $service = Get-ServiceStateInfo -Lookup $Lookup -Name 'WinHttpAutoProxySvc'
+    if (-not $service.Exists) {
+        if ($ProxyInfo.HasSystemProxy) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'WinHTTP Auto Proxy service missing while a proxy is configured' -Evidence $ProxyInfo.Evidence -Subcategory 'WinHTTP Auto Proxy Service'
+        } else {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'WinHTTP Auto Proxy service missing' -Subcategory 'WinHTTP Auto Proxy Service'
+        }
+        return
+    }
+
+    $evidence = "Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode
+    if ($service.StatusNormalized -eq 'running') {
+        if ($service.StartModeNormalized -eq 'manual' -and -not $ProxyInfo.HasSystemProxy) {
+            $evidence = "{0}; Manual trigger start with no system proxy configured." -f $evidence
+        }
+        Add-CategoryNormal -CategoryResult $Result -Title 'WinHTTP Auto Proxy service running' -Evidence $evidence -Subcategory 'WinHTTP Auto Proxy Service'
+        return
+    }
+
+    if ($ProxyInfo.Evidence) {
+        $evidence = "{0}`nProxy: {1}" -f $evidence, $ProxyInfo.Evidence
+    }
+
+    if ($service.StartModeNormalized -eq 'manual') {
+        if ($ProxyInfo.HasSystemProxy) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'WinHTTP Auto Proxy manual start while a proxy is configured' -Evidence $evidence -Subcategory 'WinHTTP Auto Proxy Service'
+        } else {
+            Add-CategoryNormal -CategoryResult $Result -Title 'WinHTTP Auto Proxy in manual mode with no proxy configured' -Evidence $evidence -Subcategory 'WinHTTP Auto Proxy Service'
+        }
+    } elseif ($service.StartModeNormalized -in @('automatic','automatic-delayed')) {
+        $severity = if ($ProxyInfo.HasSystemProxy) { 'high' } else { 'medium' }
+        Add-CategoryIssue -CategoryResult $Result -Severity $severity -Title 'WinHTTP Auto Proxy service not running' -Evidence $evidence -Subcategory 'WinHTTP Auto Proxy Service'
+    } elseif ($service.StartModeNormalized -eq 'disabled') {
+        if ($ProxyInfo.HasSystemProxy) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'WinHTTP Auto Proxy disabled while a proxy is configured' -Evidence $evidence -Subcategory 'WinHTTP Auto Proxy Service'
+        } else {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'WinHTTP Auto Proxy disabled' -Evidence $evidence -Subcategory 'WinHTTP Auto Proxy Service'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'WinHTTP Auto Proxy service in unexpected state' -Evidence $evidence -Subcategory 'WinHTTP Auto Proxy Service'
+    }
+}
+
+function Invoke-ServiceCheckBits {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Lookup,
+        [bool]$IsWorkstation
+    )
+
+    $service = Get-ServiceStateInfo -Lookup $Lookup -Name 'BITS'
+    if (-not $service.Exists) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'BITS service missing' -Evidence 'Background transfers for Windows Update, AV, and Office will fail.' -Subcategory 'BITS Service'
+        return
+    }
+
+    $evidence = "Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode
+    if ($service.StatusNormalized -eq 'running' -and $service.StartModeNormalized -notin @('manual','disabled')) {
+        Add-CategoryNormal -CategoryResult $Result -Title 'BITS running' -Evidence $evidence -Subcategory 'BITS Service'
+    }
+
+    if ($service.StartModeNormalized -eq 'disabled') {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'BITS disabled — background transfers stopped' -Evidence $evidence -Subcategory 'BITS Service'
+    } elseif ($service.StartModeNormalized -in @('automatic','automatic-delayed')) {
+        if ($service.StatusNormalized -ne 'running') {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'BITS automatic but not running' -Evidence $evidence -Subcategory 'BITS Service'
+        }
+    } elseif ($service.StartModeNormalized -eq 'manual') {
+        if ($IsWorkstation) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'BITS configured for manual start on workstation' -Evidence $evidence -Subcategory 'BITS Service'
+        } elseif ($service.StatusNormalized -ne 'running') {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'BITS manual start and currently stopped' -Evidence $evidence -Subcategory 'BITS Service'
+        }
+    }
+}
+
+function Invoke-ServiceCheckOfficeClickToRun {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Lookup,
+        [bool]$IsWorkstation
+    )
+
+    $service = Get-ServiceStateInfo -Lookup $Lookup -Name 'ClickToRunSvc'
+    if (-not $service.Exists) {
+        return
+    }
+
+    $evidence = "Status: {0}; StartType: {1}" -f $service.Status, $service.StartMode
+    if ($service.StatusNormalized -eq 'running') {
+        Add-CategoryNormal -CategoryResult $Result -Title 'Office Click-to-Run service running' -Evidence $evidence -Subcategory 'Office Click-to-Run'
+    }
+
+    if ($service.StartModeNormalized -in @('automatic','automatic-delayed')) {
+        if ($service.StatusNormalized -ne 'running') {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Office Click-to-Run automatic but not running' -Evidence $evidence -Subcategory 'Office Click-to-Run'
+        }
+    } elseif ($service.StartModeNormalized -in @('manual','disabled')) {
+        if ($IsWorkstation) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Office Click-to-Run not set to automatic on workstation' -Evidence $evidence -Subcategory 'Office Click-to-Run'
+        } else {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Office Click-to-Run manual/disabled on server' -Evidence $evidence -Subcategory 'Office Click-to-Run'
+        }
+    }
+}
+
+function Invoke-ServiceCheckAutomaticInventory {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Services
+    )
+
+    $stoppedAuto = $Services | Where-Object {
+        ($_.StartMode -eq 'Auto' -or $_.StartType -eq 'Automatic') -and ($_.State -ne 'Running' -and $_.Status -ne 'Running')
+    }
+
+    if ($stoppedAuto.Count -gt 0) {
+        $summary = $stoppedAuto | Select-Object -First 5 | ForEach-Object { "{0} ({1})" -f $_.DisplayName, ($_.State ? $_.State : $_.Status) }
+        Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Automatic services not running' -Evidence ($summary -join "`n") -Subcategory 'Service Inventory'
+    } else {
+        Add-CategoryNormal -CategoryResult $Result -Title 'Automatic services running'
+    }
+}

--- a/Analyzers/Heuristics/Services/Services.Common.ps1
+++ b/Analyzers/Heuristics/Services/Services.Common.ps1
@@ -1,0 +1,145 @@
+function Normalize-ServiceStateValue {
+    param([string]$Value)
+
+    if (-not $Value) { return 'unknown' }
+    $trimmed = $Value.Trim()
+    if (-not $trimmed) { return 'unknown' }
+
+    $lower = $trimmed.ToLowerInvariant()
+    if ($lower -like 'run*') { return 'running' }
+    if ($lower -like 'stop*') { return 'stopped' }
+    return 'other'
+}
+
+function Normalize-ServiceStartValue {
+    param([string]$Value)
+
+    if (-not $Value) { return 'unknown' }
+    $trimmed = $Value.Trim()
+    if (-not $trimmed) { return 'unknown' }
+
+    $lower = $trimmed.ToLowerInvariant()
+    if ($lower -like 'auto*' -and $lower -like '*delay*') { return 'automatic-delayed' }
+    if ($lower -like 'auto*') { return 'automatic' }
+    if ($lower -like 'manual*') { return 'manual' }
+    if ($lower -like 'disabled*') { return 'disabled' }
+    return 'other'
+}
+
+function Get-ServiceStateInfo {
+    param(
+        $Lookup,
+        [string]$Name
+    )
+
+    if (-not $Lookup -or -not $Lookup.ContainsKey($Name)) {
+        return [pscustomobject]@{
+            Exists              = $false
+            Name                = $Name
+            DisplayName         = $Name
+            Status              = 'Unknown'
+            StatusNormalized    = 'unknown'
+            StartMode           = 'Unknown'
+            StartModeNormalized = 'unknown'
+        }
+    }
+
+    $service = $Lookup[$Name]
+    $status = 'Unknown'
+    if ($service.PSObject.Properties['State']) { $status = [string]$service.State }
+    elseif ($service.PSObject.Properties['Status']) { $status = [string]$service.Status }
+
+    $startMode = 'Unknown'
+    if ($service.PSObject.Properties['StartMode']) { $startMode = [string]$service.StartMode }
+    elseif ($service.PSObject.Properties['StartType']) { $startMode = [string]$service.StartType }
+
+    $displayName = if ($service.PSObject.Properties['DisplayName']) { [string]$service.DisplayName } else { $Name }
+
+    return [pscustomobject]@{
+        Exists              = $true
+        Name                = $Name
+        DisplayName         = $displayName
+        Status              = if ($status) { $status } else { 'Unknown' }
+        StatusNormalized    = Normalize-ServiceStateValue -Value $status
+        StartMode           = if ($startMode) { $startMode } else { 'Unknown' }
+        StartModeNormalized = Normalize-ServiceStartValue -Value $startMode
+    }
+}
+
+function ConvertTo-ServiceCollection {
+    param($Value)
+
+    if (-not $Value) { return @() }
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string])) {
+        return @($Value)
+    }
+
+    return @($Value)
+}
+
+function New-ServiceLookup {
+    param([array]$Services)
+
+    $lookup = @{}
+    foreach ($service in $Services) {
+        if (-not $service) { continue }
+        if ($service.PSObject.Properties['Name']) {
+            $lookup[[string]$service.Name] = $service
+        }
+    }
+
+    return $lookup
+}
+
+function Get-DevicePlatformInfo {
+    param($Context)
+
+    $isWindowsServer = $null
+    $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
+    if ($systemArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact)
+        if ($payload -and $payload.OperatingSystem -and -not $payload.OperatingSystem.Error) {
+            $caption = [string]$payload.OperatingSystem.Caption
+            if ($caption) {
+                $isWindowsServer = ($caption -match '(?i)windows\s+server')
+            }
+        }
+    }
+
+    $isWorkstation = $null
+    if ($isWindowsServer -eq $true) { $isWorkstation = $false }
+    elseif ($isWindowsServer -eq $false) { $isWorkstation = $true }
+
+    return [pscustomobject]@{
+        IsWindowsServer = $isWindowsServer
+        IsWorkstation   = $isWorkstation
+    }
+}
+
+function Get-SystemProxyInfo {
+    param($Context)
+
+    $hasSystemProxy = $false
+    $proxyEvidence = $null
+
+    $proxyArtifact = Get-AnalyzerArtifact -Context $Context -Name 'proxy'
+    if ($proxyArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $proxyArtifact)
+        if ($payload -and $payload.WinHttp) {
+            if ($payload.WinHttp -is [System.Collections.IEnumerable] -and -not ($payload.WinHttp -is [string])) {
+                $proxyEvidence = ($payload.WinHttp -join "`n").Trim()
+            } else {
+                $proxyEvidence = ([string]$payload.WinHttp).Trim()
+            }
+
+            if ($proxyEvidence -and ($proxyEvidence -notmatch '(?i)direct\s+access')) {
+                $hasSystemProxy = $true
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        HasSystemProxy = $hasSystemProxy
+        Evidence       = $proxyEvidence
+    }
+}


### PR DESCRIPTION
## Summary
- extract shared service helper utilities into a dedicated Services.Common module
- split individual service health checks into Services.Checks for easier maintenance
- streamline Services.ps1 to load modular scripts and orchestrate the heuristic execution

## Testing
- `pwsh -NoLogo -Command ". 'Analyzers/Heuristics/Services.ps1'; Get-Command Invoke-ServicesHeuristics"` *(fails: `pwsh` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b8afa990832da8c6f99413ea21e5