### PR TITLE
Persist category metadata on report cards

### DIFF
--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -436,7 +436,30 @@ function New-IssueCardHtml {
   $cardClass = if ($Entry.CssClass) { $Entry.CssClass } else { 'info' }
   $badgeText = if ($Entry.BadgeText) { $Entry.BadgeText } elseif ($Entry.Severity) { $Entry.Severity.ToUpperInvariant() } else { 'ISSUE' }
   $badgeHtml = Encode-Html $badgeText
-  $areaHtml = Encode-Html $Entry.Area
+  $classificationValue = $null
+  if ($Entry.PSObject.Properties['Classification']) {
+    $classificationValue = [string]$Entry.Classification
+  }
+  if ([string]::IsNullOrWhiteSpace($classificationValue) -and $Entry.PSObject.Properties['Category']) {
+    $categoryValue = [string]$Entry.Category
+    if (-not [string]::IsNullOrWhiteSpace($categoryValue)) {
+      if ($Entry.PSObject.Properties['Subcategory']) {
+        $subcategoryValue = [string]$Entry.Subcategory
+        if (-not [string]::IsNullOrWhiteSpace($subcategoryValue)) {
+          $classificationValue = "$categoryValue/$subcategoryValue"
+        }
+      }
+
+      if ([string]::IsNullOrWhiteSpace($classificationValue)) {
+        $classificationValue = $categoryValue
+      }
+    }
+  }
+  if ([string]::IsNullOrWhiteSpace($classificationValue) -and $Entry.PSObject.Properties['Area']) {
+    $classificationValue = [string]$Entry.Area
+  }
+  if ([string]::IsNullOrWhiteSpace($classificationValue)) { $classificationValue = 'General' }
+  $areaHtml = Encode-Html $classificationValue
   $messageValue = if ($null -ne $Entry.Message) { $Entry.Message } else { '' }
   $messageHtml = Encode-Html $messageValue
   $hasMessage = -not [string]::IsNullOrWhiteSpace($messageValue)
@@ -472,7 +495,30 @@ function New-GoodCardHtml {
   $cardClass = if ($Entry.CssClass) { $Entry.CssClass } else { 'good' }
   $badgeText = if ($Entry.BadgeText) { $Entry.BadgeText } else { 'GOOD' }
   $badgeHtml = Encode-Html $badgeText
-  $areaHtml = Encode-Html $Entry.Area
+  $classificationValue = $null
+  if ($Entry.PSObject.Properties['Classification']) {
+    $classificationValue = [string]$Entry.Classification
+  }
+  if ([string]::IsNullOrWhiteSpace($classificationValue) -and $Entry.PSObject.Properties['Category']) {
+    $categoryValue = [string]$Entry.Category
+    if (-not [string]::IsNullOrWhiteSpace($categoryValue)) {
+      if ($Entry.PSObject.Properties['Subcategory']) {
+        $subcategoryValue = [string]$Entry.Subcategory
+        if (-not [string]::IsNullOrWhiteSpace($subcategoryValue)) {
+          $classificationValue = "$categoryValue/$subcategoryValue"
+        }
+      }
+
+      if ([string]::IsNullOrWhiteSpace($classificationValue)) {
+        $classificationValue = $categoryValue
+      }
+    }
+  }
+  if ([string]::IsNullOrWhiteSpace($classificationValue) -and $Entry.PSObject.Properties['Area']) {
+    $classificationValue = [string]$Entry.Area
+  }
+  if ([string]::IsNullOrWhiteSpace($classificationValue)) { $classificationValue = 'General' }
+  $areaHtml = Encode-Html $classificationValue
   $messageValue = if ($null -ne $Entry.Message) { $Entry.Message } else { '' }
   $messageHtml = Encode-Html $messageValue
   $hasMessage = -not [string]::IsNullOrWhiteSpace($messageValue)


### PR DESCRIPTION
## Summary
- add a helper to derive category, subcategory, and classification data for findings
- store category and subcategory on good/issue cards and group tabs by the saved category
- render cards using the combined classification label so entries show "Category/Subcategory"

## Testing
- Not run (PowerShell is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d8b4beefe8832da4a1fa79ddd1e80d