### PR TITLE
Fix Ensure-Array helper for DHCP analyzer

### DIFF
--- a/Analyzers/Heuristics/Network/DHCP/Dhcp-AnalyzerCommon.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Dhcp-AnalyzerCommon.ps1
@@ -48,15 +48,12 @@ function Ensure-Array {
     param($Value)
 
     if ($null -eq $Value) { return @() }
-    if ($Value -is [string]) { return @($Value) }
-    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [hashtable])) {
-        $results = @()
-        foreach ($item in $Value) {
-            if ($null -ne $item) { $results += [string]$item }
-        }
-        return $results
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string])) {
+        $out = @()
+        foreach ($item in $Value) { if ($null -ne $item) { $out += $item } }
+        return $out
     }
-    return @([string]$Value)
+    return @($Value)
 }
 
 function Get-AdapterIdentity {


### PR DESCRIPTION
## Summary
- update the DHCP analyzer Ensure-Array helper to preserve objects while wrapping scalar values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dbe5a928832da46829eb19efa1e9