### PR TITLE
Add pending reboot collector and heuristic

### DIFF
--- a/Analyzers/Heuristics/System.ps1
+++ b/Analyzers/Heuristics/System.ps1
@@ -9,6 +9,7 @@ $systemModuleRoot = Join-Path -Path $PSScriptRoot -ChildPath 'System'
 . (Join-Path -Path $systemModuleRoot -ChildPath 'SystemHelpers.ps1')
 . (Join-Path -Path $systemModuleRoot -ChildPath 'OperatingSystem.ps1')
 . (Join-Path -Path $systemModuleRoot -ChildPath 'Uptime.ps1')
+. (Join-Path -Path $systemModuleRoot -ChildPath 'PendingReboot.ps1')
 . (Join-Path -Path $systemModuleRoot -ChildPath 'Power.ps1')
 . (Join-Path -Path $systemModuleRoot -ChildPath 'Performance.ps1')
 . (Join-Path -Path $systemModuleRoot -ChildPath 'Startup.ps1')
@@ -23,6 +24,7 @@ function Invoke-SystemHeuristics {
 
     Invoke-SystemOperatingSystemChecks -Context $Context -Result $result
     Invoke-SystemUptimeChecks -Context $Context -Result $result
+    Invoke-SystemPendingRebootChecks -Context $Context -Result $result
     Invoke-SystemPowerChecks -Context $Context -Result $result
     Invoke-SystemPerformanceChecks -Context $Context -Result $result
     Invoke-SystemStartupChecks -Context $Context -Result $result

--- a/Analyzers/Heuristics/System/PendingReboot.ps1
+++ b/Analyzers/Heuristics/System/PendingReboot.ps1
@@ -1,0 +1,137 @@
+function Invoke-SystemPendingRebootChecks {
+    param(
+        [Parameter(Mandatory)]
+        $Context,
+        [Parameter(Mandatory)]
+        $Result
+    )
+
+    $artifact = Get-AnalyzerArtifact -Context $Context -Name 'pendingreboot'
+    if (-not $artifact) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Pending reboot inventory missing' -Subcategory 'Pending Reboot'
+        return
+    }
+
+    $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $artifact)
+    if (-not $payload) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Pending reboot data unavailable' -Subcategory 'Pending Reboot'
+        return
+    }
+
+    $indicatorEntries = @()
+    if ($payload.PSObject.Properties['Indicators']) {
+        $indicatorEntries = $payload.Indicators
+        if (-not ($indicatorEntries -is [System.Collections.IEnumerable] -and -not ($indicatorEntries -is [string]))) {
+            $indicatorEntries = @($indicatorEntries)
+        }
+    }
+
+    $presentIndicators = @()
+    foreach ($entry in $indicatorEntries) {
+        if (-not $entry) { continue }
+        $present = $false
+        if ($entry.PSObject.Properties['Present']) {
+            $present = [bool]$entry.Present
+        }
+        if ($present) {
+            $presentIndicators += $entry
+        }
+    }
+
+    $fileRenameEvidence = New-Object System.Collections.Generic.List[string]
+    $fileRenameErrors = New-Object System.Collections.Generic.List[string]
+    $pendingFileRenames = $false
+
+    if ($payload.PSObject.Properties['PendingFileRenames']) {
+        $renamePayload = $payload.PendingFileRenames
+        $sets = @('PendingFileRenameOperations','PendingFileRenameOperations2')
+        foreach ($name in $sets) {
+            if (-not $renamePayload.PSObject.Properties[$name]) { continue }
+            $values = $renamePayload.$name
+            if (-not ($values -is [System.Collections.IEnumerable] -and -not ($values -is [string]))) {
+                $values = @($values)
+            }
+
+            $index = 0
+            foreach ($value in $values) {
+                if ($null -eq $value) { continue }
+                if ($value -is [string]) {
+                    $trimmed = $value.Trim()
+                    if ($trimmed) {
+                        $pendingFileRenames = $true
+                        if ($fileRenameEvidence.Count -lt 6) {
+                            $fileRenameEvidence.Add(('{0}[{1}]: {2}' -f $name, $index, $trimmed)) | Out-Null
+                        }
+                    }
+                } elseif ($value.PSObject.Properties['Error']) {
+                    $err = [string]$value.Error
+                    if ($err) { $fileRenameErrors.Add($err) | Out-Null }
+                }
+                $index++
+            }
+        }
+    }
+
+    $renameState = $null
+    $nameMismatch = $false
+    $tcpMismatch = $false
+    if ($payload.PSObject.Properties['ComputerRenameState']) {
+        $renameState = $payload.ComputerRenameState
+        if ($renameState) {
+            if ($renameState.PSObject.Properties['NameMismatch']) {
+                $nameMismatch = [bool]$renameState.NameMismatch
+            }
+            if ($renameState.PSObject.Properties['TcpipMismatch']) {
+                $tcpMismatch = [bool]$renameState.TcpipMismatch
+            }
+        }
+    }
+
+    if ($fileRenameErrors.Count -gt 0) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Unable to enumerate pending file rename operations' -Evidence (($fileRenameErrors | Select-Object -First 5) -join "`n") -Subcategory 'Pending Reboot'
+    }
+
+    if (($presentIndicators.Count -eq 0) -and -not $pendingFileRenames -and -not $nameMismatch -and -not $tcpMismatch) {
+        Add-CategoryNormal -CategoryResult $Result -Title 'No pending reboot indicators detected' -Subcategory 'Pending Reboot'
+        return
+    }
+
+    if ($presentIndicators.Count -gt 0) {
+        $evidenceLines = New-Object System.Collections.Generic.List[string]
+        foreach ($entry in $presentIndicators) {
+            $line = $entry.Name
+            if ($entry.PSObject.Properties['Path'] -and $entry.Path) {
+                $line = '{0} ({1})' -f $entry.Name, $entry.Path
+            }
+            $evidenceLines.Add($line) | Out-Null
+        }
+        Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Updates pending reboot' -Evidence (($evidenceLines | Select-Object -First 8) -join "`n") -Subcategory 'Pending Reboot'
+    }
+
+    if ($pendingFileRenames) {
+        $evidence = $fileRenameEvidence
+        if ($evidence.Count -eq 0) {
+            $evidence = @('PendingFileRenameOperations contains entries.')
+        }
+        Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'File rename operations require a reboot' -Evidence (($evidence | Select-Object -First 8) -join "`n") -Subcategory 'Pending Reboot'
+    }
+
+    if ($renameState -and ($nameMismatch -or $tcpMismatch)) {
+        $details = New-Object System.Collections.Generic.List[string]
+        if ($renameState.PSObject.Properties['ActiveName'] -and $renameState.ActiveName) {
+            $details.Add("Active name: $($renameState.ActiveName)") | Out-Null
+        }
+        if ($renameState.PSObject.Properties['PendingName'] -and $renameState.PendingName) {
+            $details.Add("Pending name: $($renameState.PendingName)") | Out-Null
+        }
+        if ($renameState.PSObject.Properties['TcpipHostname'] -and $renameState.TcpipHostname) {
+            $details.Add("TCP/IP hostname: $($renameState.TcpipHostname)") | Out-Null
+        }
+        if ($renameState.PSObject.Properties['TcpipPendingName'] -and $renameState.TcpipPendingName) {
+            $details.Add("TCP/IP pending hostname: $($renameState.TcpipPendingName)") | Out-Null
+        }
+
+        $title = if ($nameMismatch) { 'Computer rename pending reboot' } else { 'Hostname change pending reboot' }
+        Add-CategoryIssue -CategoryResult $Result -Severity 'low' -Title $title -Evidence (($details | Where-Object { $_ }) -join "`n") -Subcategory 'Pending Reboot'
+    }
+}

--- a/Collectors/System/Collect-PendingReboot.ps1
+++ b/Collectors/System/Collect-PendingReboot.ps1
@@ -1,0 +1,140 @@
+<#!
+.SYNOPSIS
+    Collects signals indicating whether a reboot is pending on the device.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Test-RegistryPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    try {
+        return Test-Path -LiteralPath $Path -ErrorAction Stop
+    } catch {
+        return $false
+    }
+}
+
+function Get-RegistryValueStrings {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$ValueName
+    )
+
+    try {
+        if (-not (Test-Path -LiteralPath $Path)) { return @() }
+        $value = Get-ItemProperty -LiteralPath $Path -Name $ValueName -ErrorAction Stop | Select-Object -ExpandProperty $ValueName -ErrorAction Stop
+        if ($null -eq $value) { return @() }
+        if ($value -is [string]) { return @($value) }
+        if ($value -is [System.Collections.IEnumerable]) {
+            return ($value | ForEach-Object { [string]$_ })
+        }
+        return @([string]$value)
+    } catch {
+        return @([pscustomobject]@{ Error = $_.Exception.Message })
+    }
+}
+
+function Get-RegistryValueAsString {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$ValueName
+    )
+
+    try {
+        if (-not (Test-Path -LiteralPath $Path)) { return $null }
+        $value = Get-ItemProperty -LiteralPath $Path -Name $ValueName -ErrorAction Stop | Select-Object -ExpandProperty $ValueName -ErrorAction Stop
+        if ($null -eq $value) { return $null }
+        return [string]$value
+    } catch {
+        return $null
+    }
+}
+
+function Get-PendingRenameStatus {
+    $activeName = Get-RegistryValueAsString -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\ComputerName\\ActiveComputerName' -ValueName 'ComputerName'
+    $pendingName = Get-RegistryValueAsString -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\ComputerName\\ComputerName' -ValueName 'ComputerName'
+
+    $tcpipCurrent = Get-RegistryValueAsString -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters' -ValueName 'Hostname'
+    $tcpipPending = Get-RegistryValueAsString -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters' -ValueName 'NV Hostname'
+
+    $mismatch = $false
+    if ($activeName -and $pendingName -and ($activeName -ne $pendingName)) {
+        $mismatch = $true
+    }
+
+    $tcpMismatch = $false
+    if ($tcpipCurrent -and $tcpipPending -and ($tcpipCurrent -ne $tcpipPending)) {
+        $tcpMismatch = $true
+    }
+
+    return [pscustomobject]@{
+        ActiveName        = $activeName
+        PendingName       = $pendingName
+        TcpipHostname     = $tcpipCurrent
+        TcpipPendingName  = $tcpipPending
+        NameMismatch      = $mismatch
+        TcpipMismatch     = $tcpMismatch
+    }
+}
+
+function Get-PendingFileOperations {
+    $sessionManagerPath = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Session Manager'
+    $primary = Get-RegistryValueStrings -Path $sessionManagerPath -ValueName 'PendingFileRenameOperations'
+    $secondary = Get-RegistryValueStrings -Path $sessionManagerPath -ValueName 'PendingFileRenameOperations2'
+
+    return [pscustomobject]@{
+        PendingFileRenameOperations  = $primary
+        PendingFileRenameOperations2 = $secondary
+    }
+}
+
+function Get-PendingRebootIndicators {
+    $registryPaths = @(
+        [pscustomobject]@{ Name = 'WindowsUpdateRebootRequired'; Path = 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update\\RebootRequired' },
+        [pscustomobject]@{ Name = 'ComponentBasedServicingRebootPending'; Path = 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\RebootPending' },
+        [pscustomobject]@{ Name = 'ComponentBasedServicingRebootInProgress'; Path = 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\RebootInProgress' },
+        [pscustomobject]@{ Name = 'ComponentBasedServicingPackagesPending'; Path = 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\PackagesPending' },
+        [pscustomobject]@{ Name = 'ComponentBasedServicingSessionsPending'; Path = 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\SessionsPending' },
+        [pscustomobject]@{ Name = 'UpdateExeVolatile'; Path = 'HKLM:\\SOFTWARE\\Microsoft\\Updates\\UpdateExeVolatile' },
+        [pscustomobject]@{ Name = 'ServerManagerCurrentRebootAttempts'; Path = 'HKLM:\\SOFTWARE\\Microsoft\\ServerManager\\CurrentRebootAttempts' }
+    )
+
+    $results = @()
+    foreach ($entry in $registryPaths) {
+        $exists = Test-RegistryPath -Path $entry.Path
+        $results += [pscustomobject]@{
+            Name    = $entry.Name
+            Path    = $entry.Path
+            Present = $exists
+        }
+    }
+
+    return $results
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Indicators          = Get-PendingRebootIndicators
+        PendingFileRenames  = Get-PendingFileOperations
+        ComputerRenameState = Get-PendingRenameStatus
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'pendingreboot.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following sections list the analysis functions and issue card heuristics gro
 - **System/Firmware** – Raises a medium issue when firmware is still in legacy BIOS mode and a low issue when the analyzer cannot determine firmware mode from `Get-ComputerInfo`.
 - **System/Secure Boot** – Marks Secure Boot as a high-severity issue if it is disabled, unsupported, or reports an unexpected state, and still escalates to high if Secure Boot details are missing even though UEFI is present.
 - **System/Fast Startup** – Emits warning-severity findings when Fast Startup is enabled or when its state cannot be determined from power settings; otherwise records a healthy status when it is disabled.
+- **System/Pending Reboot** – Highlights medium-severity issues when Windows Update or servicing registry keys signal a required reboot, warns on outstanding file rename operations, and captures pending computer rename evidence, while recording a normal finding when no reboot indicators are detected.
 - **System/Startup Programs** – Flags low issues when Autoruns output is unrecognized or empty, escalates to medium when non-Microsoft startup items exceed 10, and warns at low severity when the count is between 6 and 10.
 - **System/Uptime** – Uses the uptime classification to emit issues whose severity matches the computed range (for example, medium/high/critical depending on days since reboot) when the device exceeds healthy thresholds.
 


### PR DESCRIPTION
## Summary
- add a system collector that records registry-based signals for pending reboots, file rename operations, and computer rename state
- introduce a pending reboot heuristic that surfaces update, rename, and file operation reboot requirements while documenting clean results
- document the new heuristic and wire it into the system analyzer module

## Testing
- attempted `pwsh -NoLogo -Command ". (Join-Path (Resolve-Path .).Path 'Analyzers/AnalyzerCommon.ps1'); . (Join-Path (Resolve-Path .).Path 'Analyzers/Heuristics/System/PendingReboot.ps1'); 'Loaded pending reboot heuristic successfully.'"` *(fails: PowerShell is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e0a6b54c832da8244e6919b3bda7