### PR TITLE
Add DHCP debugging output

### DIFF
--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaticConfiguration.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaticConfiguration.ps1
@@ -13,6 +13,7 @@ Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Forc
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-static-configuration.json'
+$ads = Ensure-Array $payload.AdapterConfigurations; Write-Host ("DBG DHCP PAYLOAD: adapters={0} dhcpEnabled={1} gateway={2} dns0={3}" -f $ads.Count,($ads | Select-Object -First 1 -ExpandProperty DHCPEnabled),($ads | Select-Object -First 1 -ExpandProperty DefaultIPGateway | Select-Object -First 1),($ads | Select-Object -First 1 -ExpandProperty DNSServerSearchOrder | Select-Object -First 1))
 if ($null -eq $payload) { return @() }
 if ($payload.PSObject.Properties['Error']) {
     return @(New-DhcpFinding -Check 'DHCP disabled without static config' -Severity 'warning' -Message "Unable to parse DHCP static configuration collector output." -Evidence ([ordered]@{ Error = $payload.Error; File = $payload.File }))

--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -716,6 +716,7 @@ function Invoke-NetworkHeuristics {
         }
     }
 
+    Write-Host ("DBG DHCP ENTRY: dhcpFolder={0} exists={1} files={2} keys={3}" -f $dhcpFolder,(Test-Path $dhcpFolder),(Get-ChildItem -Path $dhcpFolder -Filter 'dhcp-*.json' -ErrorAction SilentlyContinue | Measure-Object).Count,($Context.Artifacts.Keys | Where-Object { $_ -like 'dhcp-*.json' } | Measure-Object).Count)
     Invoke-DhcpAnalyzers -Context $Context -CategoryResult $result
 
     return $result


### PR DESCRIPTION
## Summary
- add debug logging before invoking DHCP analyzers to show folder state
- emit payload details when loading DHCP static configuration data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8ea0474b0832d808937c78b4eb72e