### PR TITLE
Handle relative analyzer output paths

### DIFF
--- a/Analyzers/Analyze-Diagnostics.ps1
+++ b/Analyzers/Analyze-Diagnostics.ps1
@@ -60,6 +60,10 @@ if (-not $OutputPath) {
 }
 
 $directory = Split-Path -Path $OutputPath -Parent
+if ([string]::IsNullOrWhiteSpace($directory)) {
+    $directory = (Get-Location).ProviderPath
+}
+
 if (-not (Test-Path -Path $directory)) {
     $null = New-Item -Path $directory -ItemType Directory -Force
 }


### PR DESCRIPTION
## Summary
- default the analyzer output directory to the current location when the supplied output path has no parent component
- prevent null/empty path errors when writing reports and bundling CSS assets

## Testing
- PowerShell not available in container environment


------
https://chatgpt.com/codex/tasks/task_e_68d8f1d4e190832d8b802ad62a655bf6