### PR TITLE
Add verbose logging for silently handled errors

### DIFF
--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -315,7 +315,9 @@ function ConvertTo-NetworkAddressString {
 
         if ($addressValue -is [string] -and $addressValue) { return $addressValue }
         if ($addressValue -is [byte[]] -and $addressValue.Length -gt 0) {
-            try { return ([System.Net.IPAddress]::new($addressValue)).ToString() } catch {}
+            try { return ([System.Net.IPAddress]::new($addressValue)).ToString() } catch {
+                Write-Verbose -Message ("Failed to convert byte[] network address to string: {0}" -f $_.Exception.Message)
+            }
         }
 
         try {
@@ -323,6 +325,7 @@ function ConvertTo-NetworkAddressString {
                 return ([System.Net.IPAddress]::new([int64]$addressValue)).ToString()
             }
         } catch {
+            Write-Verbose -Message ("Failed to convert numeric network address to string: {0}" -f $_.Exception.Message)
             # fall through to default conversion
         }
     }

--- a/Collectors/Network/DHCP/Dhcp-Common.ps1
+++ b/Collectors/Network/DHCP/Dhcp-Common.ps1
@@ -12,9 +12,12 @@ function ConvertTo-Iso8601String {
         $dt = [datetime]::Parse($Value.ToString())
         return $dt.ToString('o')
     } catch {
+        Write-Verbose -Message ("ConvertTo-Iso8601String failed to parse value '{0}': {1}" -f $Value, $_.Exception.Message)
         try {
             if ($Value -is [datetime]) { return $Value.ToString('o') }
-        } catch { }
+        } catch {
+            Write-Verbose -Message ("ConvertTo-Iso8601String failed to treat value '{0}' as DateTime: {1}" -f $Value, $_.Exception.Message)
+        }
     }
 
     return $null
@@ -24,6 +27,7 @@ function Get-DhcpAdapterConfigurations {
     try {
         $instances = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled = True" -ErrorAction Stop
     } catch {
+        Write-Verbose -Message ("Win32_NetworkAdapterConfiguration query failed: {0}" -f $_.Exception.Message)
         return @([pscustomobject]@{
             Source = 'Get-CimInstance Win32_NetworkAdapterConfiguration'
             Error  = $_.Exception.Message
@@ -61,6 +65,7 @@ function Get-DhcpIpconfigAll {
         $raw = & ipconfig.exe /all 2>$null | Out-String
         return $raw.TrimEnd()
     } catch {
+        Write-Verbose -Message ("ipconfig.exe /all execution failed: {0}" -f $_.Exception.Message)
         return "ipconfig.exe /all failed: $($_.Exception.Message)"
     }
 }
@@ -78,6 +83,7 @@ function Get-DhcpClientEvents {
         }
         $events = Get-WinEvent -FilterHashtable $filter -MaxEvents $MaxEvents -ErrorAction Stop
     } catch {
+        Write-Verbose -Message ("Get-WinEvent for Microsoft-Windows-Dhcp-Client failed: {0}" -f $_.Exception.Message)
         return @([pscustomobject]@{
             Source = 'Get-WinEvent Microsoft-Windows-Dhcp-Client'
             Error  = $_.Exception.Message

--- a/Collectors/Office/Collect-AutodiscoverDiagnostics.ps1
+++ b/Collectors/Office/Collect-AutodiscoverDiagnostics.ps1
@@ -31,7 +31,9 @@ function Get-CandidateDomains {
         if ($cs -and $cs.PartOfDomain -eq $true -and $cs.Domain) {
             $domains.Add([string]$cs.Domain) | Out-Null
         }
-    } catch { }
+    } catch {
+        Write-Verbose -Message ("Win32_ComputerSystem query failed while discovering domains: {0}" -f $_.Exception.Message)
+    }
 
     try {
         $regPath = 'HKCU:\Software\Microsoft\Office\16.0\Common\Identity'
@@ -43,7 +45,9 @@ function Get-CandidateDomains {
                 }
             }
         }
-    } catch { }
+    } catch {
+        Write-Verbose -Message ("Failed to read Office identity registry for domain discovery: {0}" -f $_.Exception.Message)
+    }
 
     return @($domains | Where-Object { $_ })
 }

--- a/Collectors/Services/Collect-Printing.ps1
+++ b/Collectors/Services/Collect-Printing.ps1
@@ -436,7 +436,11 @@ function Invoke-PortTest {
                 $testResult.PingSucceeded = [bool]$result.PingSucceeded
             }
             if ($result.PSObject.Properties['PingReplyDetails'] -and $result.PingReplyDetails) {
-                try { $testResult.RoundTripTime = $result.PingReplyDetails.RoundtripTime } catch {}
+                try {
+                    $testResult.RoundTripTime = $result.PingReplyDetails.RoundtripTime
+                } catch {
+                    Write-Verbose -Message ("Failed to read PingReplyDetails.RoundtripTime for host {0}: {1}" -f $Host, $_.Exception.Message)
+                }
             }
         }
     } catch {

--- a/Collectors/System/KernelDMAStatus.ps1
+++ b/Collectors/System/KernelDMAStatus.ps1
@@ -154,11 +154,12 @@ function Get-KernelDmaMsInfoFallback {
     try {
         $completed = $process.WaitForExit($timeoutMilliseconds)
     } catch {
+        Write-Verbose -Message ("WaitForExit on msinfo32.exe failed: {0}" -f $_.Exception.Message)
         $completed = $false
     }
 
     if (-not $completed) {
-        try { $process.Kill() | Out-Null } catch {}
+        try { $process.Kill() | Out-Null } catch { Write-Verbose -Message ("Failed to terminate msinfo32.exe after timeout: {0}" -f $_.Exception.Message) }
         return [pscustomobject]@{
             Status  = 'Timeout'
             Message = "msinfo32.exe exceeded ${TimeoutSeconds}s timeout"
@@ -177,6 +178,7 @@ function Get-KernelDmaMsInfoFallback {
     try {
         $content = Get-Content -Path $tempPath -ErrorAction Stop
     } catch {
+        Write-Verbose -Message ("Failed to read msinfo32.exe output from '{0}': {1}" -f $tempPath, $_.Exception.Message)
         $content = @()
     }
 

--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -8,7 +8,8 @@ if (-not ([System.Collections.Specialized.OrderedDictionary].GetMethods() | Wher
       return $this.Contains($Key)
     } -ErrorAction Stop
   } catch {
-    # If type data registration fails, continue without interrupting import.
+    # If type data registration fails, continue without interrupting import, but capture the reason for verbose diagnostics.
+    Write-Verbose -Message ("Failed to extend OrderedDictionary with ContainsKey: {0}" -f $_.Exception.Message)
   }
 }
 


### PR DESCRIPTION
## Summary
- add Write-Verbose diagnostics to silent catch blocks across collectors and analyzers
- improve storage snapshot fallbacks and DHCP/autodiscover discovery logging
- record ping and network address conversion failures for easier troubleshooting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d908f5a470832d92b1695169c83cf3