### PR TITLE
Add debug logging for analyzer artifact name matching

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -92,15 +92,32 @@ function Get-AnalyzerArtifact {
         $lookupKeys += ($key + '.json')
     }
 
+    Write-HeuristicDebug -Source 'AnalyzerCommon' -Message 'Resolving analyzer artifact' -Data ([ordered]@{
+        RequestedName = $Name
+        LookupKeys    = ($lookupKeys -join ', ')
+    })
+
     $entries = $null
     foreach ($candidate in $lookupKeys) {
         if ($Context.Artifacts.ContainsKey($candidate)) {
+            Write-HeuristicDebug -Source 'AnalyzerCommon' -Message 'Matched analyzer artifact key' -Data ([ordered]@{
+                RequestedName = $Name
+                MatchedKey    = $candidate
+                MatchCount    = $Context.Artifacts[$candidate].Count
+            })
+
             $entries = $Context.Artifacts[$candidate]
             break
         }
     }
 
-    if (-not $entries) { return $null }
+    if (-not $entries) {
+        Write-HeuristicDebug -Source 'AnalyzerCommon' -Message 'No analyzer artifact match found' -Data ([ordered]@{
+            RequestedName = $Name
+            LookupKeys    = ($lookupKeys -join ', ')
+        })
+        return $null
+    }
 
     if ($entries.Count -gt 1) { return $entries }
     return $entries[0]


### PR DESCRIPTION
## Summary
- add heuristic debug output describing analyzer artifact lookup
- log matched keys and counts to aid diagnosing name resolution issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d916f0ffcc832db7f80f5cef40a8ef