### PR TITLE
Fix DHCP analyzer name mapper

### DIFF
--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -338,8 +338,8 @@ function ConvertTo-KebabCase {
 
     if (-not $Text) { return $Text }
 
-    $normalized = $Text -replace '([a-z0-9])([A-Z])', '$1-$2'
-    $normalized = $normalized -replace '([A-Z]+)([A-Z][a-z])', '$1-$2'
+    $normalized = $Text -creplace '([a-z0-9])([A-Z])', '$1-$2'
+    $normalized = $normalized -creplace '([A-Z]+)([A-Z][a-z])', '$1-$2'
 
     return $normalized.ToLowerInvariant()
 }


### PR DESCRIPTION
## Summary
- ensure the DHCP analyzer artifact name mapper uses case-sensitive replacements
- prevent hyphenation of every character so analyzer payloads map to the expected JSON files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d937e098ec832d88a1adcb0a2dbb5f