### PR TITLE
Refine PowerShell loops for network diagnostics

### DIFF
--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -275,12 +275,22 @@ function Convert-DiskBlock {
 
   $operStatuses = @()
   if ($operRaw) {
-    $operStatuses = ($operRaw -split '\r?\n|,') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+    foreach ($operStatus in ($operRaw -split '\r?\n|,')) {
+      $trimmed = $operStatus.Trim()
+      if ($trimmed) {
+        $operStatuses += $trimmed
+      }
+    }
   }
 
   $healthStatuses = @()
   if ($healthRaw) {
-    $healthStatuses = ($healthRaw -split '\r?\n|,') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+    foreach ($healthStatus in ($healthRaw -split '\r?\n|,')) {
+      $trimmed = $healthStatus.Trim()
+      if ($trimmed) {
+        $healthStatuses += $trimmed
+      }
+    }
   }
 
   return [pscustomobject]@{


### PR DESCRIPTION
## Summary
- replace pipeline-based script blocks with foreach loops in network heuristics to avoid ForEach-Object and Where-Object usage
- streamline disk status parsing to trim values without pipeline helper commands
- ensure debugging output and evidence collection rely on native loops and property access

## Testing
- ⚠️ `pwsh -NoLogo -Command "[void][scriptblock]::Create((Get-Content -Raw 'Analyzers/Heuristics/Network/Network.ps1'))"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da005334c4832d867910a6dfd3082d