### PR TITLE
Refine macro context filtering to avoid redundant Where-Object

### DIFF
--- a/backups/Legacy/Analyze-Diagnostics.ps1
+++ b/backups/Legacy/Analyze-Diagnostics.ps1
@@ -2917,7 +2917,16 @@ if ($raw['office_security']) {
 
     $hasIssue = $false
 
-    $blockCompliant = @($appContexts | Where-Object { $_.BlockValue -eq 1 })
+    $blockCompliant = @()
+    $pvDisabledContexts = @()
+    foreach ($context in $appContexts) {
+      if ($context.BlockValue -eq 1) {
+        $blockCompliant += $context
+      }
+      if (($context.PvInternetValue -eq 1) -or ($context.PvUnsafeValue -eq 1)) {
+        $pvDisabledContexts += $context
+      }
+    }
     $blockFullyEnforced = ($appContexts.Count -gt 0 -and $blockCompliant.Count -eq $appContexts.Count)
     if ($blockCompliant.Count -eq 0) {
       $blockEvidence = ($appContexts | ForEach-Object { Format-MacroContextEvidence $_ }) -join "`n`n"
@@ -2946,7 +2955,6 @@ if ($raw['office_security']) {
       $hasIssue = $true
     }
 
-    $pvDisabledContexts = @($appContexts | Where-Object { ($_.PvInternetValue -eq 1) -or ($_.PvUnsafeValue -eq 1) })
     if ($pvDisabledContexts.Count -gt 0) {
       $pvReasons = @()
       foreach ($ctx in $pvDisabledContexts) {


### PR DESCRIPTION
## Summary
- replace macro context Where-Object comparisons that checked for a value of 1 with a single foreach loop to collect matching entries
- reuse the collected results for both block enforcement and protected view checks to avoid repeated filtering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da026363a4832dbfd2b4163e828f35