### PR TITLE
Use AddRange when aggregating runspace results

### DIFF
--- a/Collectors/Collect-All.ps1
+++ b/Collectors/Collect-All.ps1
@@ -109,8 +109,8 @@ try {
                     $entry.PowerShell.Dispose()
                 }
 
-                foreach ($item in $output) {
-                    $resultsList.Add($item)
+                if ($output) {
+                    $resultsList.AddRange($output)
                 }
 
                 $pending.RemoveAt($index)


### PR DESCRIPTION
## Summary
- replace the per-item results loop with a null-safe AddRange call to add runspace output in one batch

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d900e301d4832da2c4779758640e77