### PR TITLE
Refactor PowerShell array accumulation to use generic lists

### DIFF
--- a/Analyzers/Heuristics/Storage.ps1
+++ b/Analyzers/Heuristics/Storage.ps1
@@ -11,9 +11,9 @@ function ConvertTo-StorageArray {
     if ($null -eq $Value) { return @() }
     if ($Value -is [string]) { return @($Value) }
     if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [hashtable])) {
-        $items = @()
-        foreach ($item in $Value) { $items += $item }
-        return $items
+        $itemsList = New-Object System.Collections.Generic.List[object]
+        foreach ($item in $Value) { $itemsList.Add($item) | Out-Null }
+        return $itemsList.ToArray()
     }
     return @($Value)
 }

--- a/Analyzers/Heuristics/System/PendingReboot.ps1
+++ b/Analyzers/Heuristics/System/PendingReboot.ps1
@@ -34,7 +34,7 @@ function Invoke-SystemPendingRebootChecks {
         }
     }
 
-    $presentIndicators = @()
+    $presentIndicatorsList = New-Object System.Collections.Generic.List[object]
     foreach ($entry in $indicatorEntries) {
         if (-not $entry) { continue }
         $present = $false
@@ -42,9 +42,10 @@ function Invoke-SystemPendingRebootChecks {
             $present = [bool]$entry.Present
         }
         if ($present) {
-            $presentIndicators += $entry
+            $presentIndicatorsList.Add($entry) | Out-Null
         }
     }
+    $presentIndicators = $presentIndicatorsList.ToArray()
 
     $fileRenameEvidence = New-Object System.Collections.Generic.List[string]
     $fileRenameErrors = New-Object System.Collections.Generic.List[string]


### PR DESCRIPTION
## Summary
- replace array concatenation in pending reboot heuristics with List[object] accumulation
- update printing heuristics to collect offline printers, WSD printers, and stale jobs via lists before converting to arrays
- adjust shared array conversion helpers to use List[object] for enumeration expansion

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da02ab2230832db332e3e6ccaaf6a7