### PR TITLE
Allow Resolve-SinglePayload to accept null payloads

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -261,6 +261,7 @@ function Get-ArtifactPayload {
 function Resolve-SinglePayload {
     param(
         [Parameter(Mandatory)]
+        [AllowNull()]
         $Payload
     )
 


### PR DESCRIPTION
## Summary
- allow Resolve-SinglePayload to accept null payloads so analyzers can gracefully handle missing artifacts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da298fa550832d91fc4b6145e571b4