### PR TITLE
Use StringBuilder for looped string concatenation

### DIFF
--- a/Analyzers/HtmlComposer.ps1
+++ b/Analyzers/HtmlComposer.ps1
@@ -503,7 +503,8 @@ function Build-GoodSection {
     }
 
     $tabName = 'good-tabs'
-    $tabs = "<div class='report-tabs'><div class='report-tabs__list'>"
+    $tabsBuilder = [System.Text.StringBuilder]::new()
+    $null = $tabsBuilder.Append("<div class='report-tabs'><div class='report-tabs__list'>")
     $index = 0
     foreach ($category in $orderedCategories) {
         if (-not $categorized.ContainsKey($category)) { continue }
@@ -518,14 +519,14 @@ function Build-GoodSection {
         $labelText = Encode-Html "$category ($count)"
         $panelContent = if ($count -gt 0) { ($cards -join '') } else { "<div class='report-card'><i>No positives captured in this category.</i></div>" }
 
-        $tabs += "<input type='radio' name='$tabName' id='$tabId' class='report-tabs__radio'$checkedAttr>"
-        $tabs += "<label class='report-tabs__label' for='$tabId'>$labelText</label>"
-        $tabs += "<div class='report-tabs__panel'>$panelContent</div>"
+        $null = $tabsBuilder.Append("<input type='radio' name='$tabName' id='$tabId' class='report-tabs__radio'$checkedAttr>")
+        $null = $tabsBuilder.Append("<label class='report-tabs__label' for='$tabId'>$labelText</label>")
+        $null = $tabsBuilder.Append("<div class='report-tabs__panel'>$panelContent</div>")
         $index++
     }
 
-    $tabs += "</div></div>"
-    return $tabs
+    $null = $tabsBuilder.Append("</div></div>")
+    return $tabsBuilder.ToString()
 }
 
 function Build-IssueSection {
@@ -585,7 +586,8 @@ function Build-IssueSection {
     }
 
     $tabName = 'issue-tabs'
-    $tabs = "<div class='report-tabs'><div class='report-tabs__list'>"
+    $tabsBuilder = [System.Text.StringBuilder]::new()
+    $null = $tabsBuilder.Append("<div class='report-tabs'><div class='report-tabs__list'>")
     $index = 0
 
     foreach ($category in $orderedCategories) {
@@ -603,14 +605,14 @@ function Build-IssueSection {
         $labelText = Encode-Html "$category ($count)"
         $panelContent = if ($count -gt 0) { ($cards -join '') } else { "<div class='report-card'><i>No issues captured for this category.</i></div>" }
 
-        $tabs += "<input type='radio' name='$tabName' id='$tabId' class='report-tabs__radio'$checkedAttr>"
-        $tabs += "<label class='report-tabs__label' for='$tabId'>$labelText</label>"
-        $tabs += "<div class='report-tabs__panel'>$panelContent</div>"
+        $null = $tabsBuilder.Append("<input type='radio' name='$tabName' id='$tabId' class='report-tabs__radio'$checkedAttr>")
+        $null = $tabsBuilder.Append("<label class='report-tabs__label' for='$tabId'>$labelText</label>")
+        $null = $tabsBuilder.Append("<div class='report-tabs__panel'>$panelContent</div>")
         $index++
     }
 
-    $tabs += "</div></div>"
-    return $tabs
+    $null = $tabsBuilder.Append("</div></div>")
+    return $tabsBuilder.ToString()
 }
 
 function Get-TruncatedText {
@@ -836,7 +838,8 @@ function New-AnalyzerHtml {
     if ($failedReports.Count -eq 0) {
         $failedContent = "<div class='report-card'><i>All expected inputs produced output.</i></div>"
     } else {
-        $failedContent = "<div class='report-card'><table class='report-table report-table--list' cellspacing='0' cellpadding='0'><tr><th>Key</th><th>Status</th><th>Details</th></tr>"
+        $failedContentBuilder = [System.Text.StringBuilder]::new()
+        $null = $failedContentBuilder.Append("<div class='report-card'><table class='report-table report-table--list' cellspacing='0' cellpadding='0'><tr><th>Key</th><th>Status</th><th>Details</th></tr>")
         foreach ($entry in $failedReports) {
             $detailParts = @()
             if ($entry.Path) { $detailParts += "File: $($entry.Path)" }
@@ -851,9 +854,10 @@ function New-AnalyzerHtml {
             } else {
                 Encode-Html ''
             }
-            $failedContent += "<tr><td>$(Encode-Html $($entry.Key))</td><td>$(Encode-Html $($entry.Status))</td><td>$detailHtml</td></tr>"
+            $null = $failedContentBuilder.Append("<tr><td>$(Encode-Html $($entry.Key))</td><td>$(Encode-Html $($entry.Status))</td><td>$detailHtml</td></tr>")
         }
-        $failedContent += "</table></div>"
+        $null = $failedContentBuilder.Append("</table></div>")
+        $failedContent = $failedContentBuilder.ToString()
     }
     $failedHtml = New-ReportSection -Title $failedTitle -ContentHtml $failedContent -Open
     $rawHtml = New-ReportSection -Title 'Raw (key excerpts)' -ContentHtml (Build-RawSection -Context $Context)

--- a/backups/Legacy/Collect-SystemDiagnostics.ps1
+++ b/backups/Legacy/Collect-SystemDiagnostics.ps1
@@ -1298,7 +1298,8 @@ if (-not $NoHtml) {
   $cssContent = $cssSources | ForEach-Object { Get-Content -Raw -Path $_ }
   Set-Content -Path $cssOutputPath -Value ($cssContent -join "`n`n") -Encoding UTF8
 
-  $html = @"
+  $htmlBuilder = [System.Text.StringBuilder]::new()
+  $null = $htmlBuilder.Append(@"
 <!doctype html>
 <html>
 <head><meta charset='utf-8'><title>Diagnostics Report - $timestamp</title><link rel='stylesheet' href='styles/system-diagnostics-report.css'></head>
@@ -1316,17 +1317,17 @@ if (-not $NoHtml) {
   </div>
   <div class='diagnostics-section'>
     <h2>Raw outputs</h2>
-"@
+"@)
 
   foreach ($f in Get-ChildItem -Path $reportDir -Filter *.txt | Sort-Object Name) {
     $name = $f.BaseName
     $content = Get-Content $f.FullName -Raw
     $contentEscaped = [System.Web.HttpUtility]::HtmlEncode($content)
-    $html += "<h3>$name</h3>`n<pre class='diagnostics-pre'>$contentEscaped</pre>`n"
+    $null = $htmlBuilder.Append("<h3>$name</h3>`n<pre class='diagnostics-pre'>$contentEscaped</pre>`n")
   }
 
-  $html += "</body></html>"
-  $html | Out-File -FilePath $htmlFile -Encoding UTF8
+  $null = $htmlBuilder.Append("</body></html>")
+  $htmlBuilder.ToString() | Out-File -FilePath $htmlFile -Encoding UTF8
   Write-Host "HTML report written to: $htmlFile"
 } else {
   Write-Host "Skipping HTML report generation (-NoHtml specified)."


### PR DESCRIPTION
## Summary
- replace repeated string concatenation in HTML composer loops with System.Text.StringBuilder
- update the legacy system diagnostics collector to use a StringBuilder when building HTML output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da28e918c8832d9d093eb90f112932