### PR TITLE
Fix legacy analyzer CSS path

### DIFF
--- a/backups/Legacy/Analyze-Diagnostics.ps1
+++ b/backups/Legacy/Analyze-Diagnostics.ps1
@@ -5791,12 +5791,12 @@ $reportName = "DeviceHealth_Report_{0}.html" -f (Get-Date -Format "yyyyMMdd_HHmm
 $reportPath = Join-Path $InputFolder $reportName
 
 # CSS assets
-$repoRoot = Split-Path $PSScriptRoot -Parent
-$cssSources = @(
-  Join-Path $repoRoot 'styles/base.css'
-  Join-Path $repoRoot 'styles/layout.css'
-  Join-Path $PSScriptRoot 'styles/device-health-report.css'
-)
+  $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+  $cssSources = @(
+    Join-Path $repoRoot 'styles/base.css'
+    Join-Path $repoRoot 'styles/layout.css'
+    Join-Path $repoRoot 'Scripts/styles/device-health-report.css'
+  )
 
 foreach ($source in $cssSources) {
   if (-not (Test-Path $source)) {


### PR DESCRIPTION
## Summary
- update the legacy analyzer script to load device-health-report.css from Scripts/styles after the stylesheet relocation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da2be5ba3c832db6e996c517176992