### PR TITLE
Fix DHCP analyzers to resolve common module path

### DIFF
--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpClientEvents.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpClientEvents.ps1
@@ -16,8 +16,15 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP client events' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
+try {
+    $repoRoot = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath '..\\..\\..\\..')).ProviderPath
+} catch {
+    $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+}
+$commonModulePath = if ($repoRoot) { Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1' } else { $null }
+if ($commonModulePath -and (Test-Path -LiteralPath $commonModulePath)) {
+    Import-Module $commonModulePath -Force
+}
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-client-events.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpLeaseExpiry.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpLeaseExpiry.ps1
@@ -16,8 +16,15 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP lease expiry' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
+try {
+    $repoRoot = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath '..\\..\\..\\..')).ProviderPath
+} catch {
+    $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+}
+$commonModulePath = if ($repoRoot) { Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1' } else { $null }
+if ($commonModulePath -and (Test-Path -LiteralPath $commonModulePath)) {
+    Import-Module $commonModulePath -Force
+}
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-lease-expiry.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpMissingServerDetails.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpMissingServerDetails.ps1
@@ -16,8 +16,15 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP server details' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
+try {
+    $repoRoot = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath '..\\..\\..\\..')).ProviderPath
+} catch {
+    $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+}
+$commonModulePath = if ($repoRoot) { Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1' } else { $null }
+if ($commonModulePath -and (Test-Path -LiteralPath $commonModulePath)) {
+    Import-Module $commonModulePath -Force
+}
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-missing-server-details.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpScopeExhaustion.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpScopeExhaustion.ps1
@@ -16,8 +16,15 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP scope utilization' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
+try {
+    $repoRoot = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath '..\\..\\..\\..')).ProviderPath
+} catch {
+    $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+}
+$commonModulePath = if ($repoRoot) { Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1' } else { $null }
+if ($commonModulePath -and (Test-Path -LiteralPath $commonModulePath)) {
+    Import-Module $commonModulePath -Force
+}
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-scope-exhaustion.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaleLeases.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaleLeases.ps1
@@ -16,8 +16,15 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP stale leases' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
+try {
+    $repoRoot = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath '..\\..\\..\\..')).ProviderPath
+} catch {
+    $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+}
+$commonModulePath = if ($repoRoot) { Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1' } else { $null }
+if ($commonModulePath -and (Test-Path -LiteralPath $commonModulePath)) {
+    Import-Module $commonModulePath -Force
+}
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-stale-leases.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaticConfiguration.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaticConfiguration.ps1
@@ -16,8 +16,15 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP static configuration' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
+try {
+    $repoRoot = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath '..\\..\\..\\..')).ProviderPath
+} catch {
+    $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+}
+$commonModulePath = if ($repoRoot) { Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1' } else { $null }
+if ($commonModulePath -and (Test-Path -LiteralPath $commonModulePath)) {
+    Import-Module $commonModulePath -Force
+}
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-static-configuration.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpUnexpectedServers.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpUnexpectedServers.ps1
@@ -16,8 +16,15 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP unexpected servers' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
+try {
+    $repoRoot = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath '..\\..\\..\\..')).ProviderPath
+} catch {
+    $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+}
+$commonModulePath = if ($repoRoot) { Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1' } else { $null }
+if ($commonModulePath -and (Test-Path -LiteralPath $commonModulePath)) {
+    Import-Module $commonModulePath -Force
+}
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-unexpected-servers.json'


### PR DESCRIPTION
## Summary
- resolve the repository root before importing the shared Common module in each DHCP analyzer
- guard the import with an existence check so the analyzers no longer fail when the module path is miscomputed

## Testing
- not run (PowerShell is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da3c7a669c832d87f836fe3fb10871