### PR TITLE
Fix DHCP analyzer module import path

### DIFF
--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpClientEvents.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpClientEvents.ps1
@@ -16,8 +16,6 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP client events' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-client-events.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpLeaseExpiry.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpLeaseExpiry.ps1
@@ -16,8 +16,6 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP lease expiry' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-lease-expiry.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpMissingServerDetails.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpMissingServerDetails.ps1
@@ -16,8 +16,6 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP server details' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-missing-server-details.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpScopeExhaustion.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpScopeExhaustion.ps1
@@ -16,8 +16,6 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP scope utilization' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-scope-exhaustion.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaleLeases.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaleLeases.ps1
@@ -16,8 +16,6 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP stale leases' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-stale-leases.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaticConfiguration.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpStaticConfiguration.ps1
@@ -16,8 +16,6 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP static configuration' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-static-configuration.json'

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpUnexpectedServers.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpUnexpectedServers.ps1
@@ -16,8 +16,6 @@ param(
 
 Write-DhcpDebug -Message 'Analyzing DHCP unexpected servers' -Data ([ordered]@{ InputFolder = $InputFolder })
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
-Import-Module (Join-Path -Path $repoRoot -ChildPath 'Modules/Common.psm1') -Force
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Dhcp-AnalyzerCommon.ps1')
 
 $payload = Get-DhcpCollectorPayload -InputFolder $InputFolder -FileName 'dhcp-unexpected-servers.json'

--- a/Analyzers/Heuristics/Network/DHCP/Dhcp-AnalyzerCommon.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Dhcp-AnalyzerCommon.ps1
@@ -3,6 +3,36 @@
     Shared helper functions for DHCP analyzers.
 #>
 
+$script:DhcpCommonModuleImported = $false
+
+function Import-DhcpCommonModule {
+    if ($script:DhcpCommonModuleImported) { return }
+
+    $current = $PSScriptRoot
+    $modulePath = $null
+
+    while ($current) {
+        $candidate = Join-Path -Path $current -ChildPath 'Modules/Common.psm1'
+        if (Test-Path -LiteralPath $candidate) {
+            $modulePath = (Resolve-Path -LiteralPath $candidate).ProviderPath
+            break
+        }
+
+        $parent = Split-Path -Parent $current
+        if (-not $parent -or $parent -eq $current) { break }
+        $current = $parent
+    }
+
+    if (-not $modulePath) {
+        throw "Unable to locate Modules/Common.psm1 relative to DHCP analyzer root."
+    }
+
+    Import-Module -Name $modulePath -Force
+    $script:DhcpCommonModuleImported = $true
+}
+
+Import-DhcpCommonModule
+
 function Get-DhcpCollectorPayload {
     param(
         [Parameter(Mandatory)]


### PR DESCRIPTION
## Summary
- ensure DHCP analyzers load the shared Common module by locating it relative to their script directory
- simplify DHCP analyzer scripts to rely on the shared import helper

## Testing
- Not run (PowerShell is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68da78ff527c832da1499eb19d9d4274