### PR TITLE
Flatten DHCP evidence and harden formatter

### DIFF
--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -470,14 +470,14 @@ function Invoke-DhcpAnalyzers {
             }
         }
     } else {
-        $eligibleArtifactBases = [System.Collections.Generic.List[object]]::new()
+        $eligibleArtifactBases = @()
         foreach ($analyzer in $eligibleAnalyzers) {
-            $null = $eligibleArtifactBases.Add($analyzer.ArtifactBase)
+            $eligibleArtifactBases += [string]$analyzer.ArtifactBase
         }
 
         $evidence = [ordered]@{
-            Checks = $eligibleArtifactBases
-            Folder = $inputFolder
+            Checks = ($eligibleArtifactBases -join [Environment]::NewLine)
+            Folder = [string]$InputFolder
         }
 
         Add-CategoryNormal -CategoryResult $CategoryResult -Title ("DHCP diagnostics healthy ({0} checks)" -f $eligibleAnalyzers.Count) -Evidence $evidence -Subcategory 'DHCP'


### PR DESCRIPTION
## Summary
- flatten DHCP analyzer success evidence into simple string data before composing the report
- harden Format-AnalyzerEvidence to cap recursion depth and handle dictionaries and enumerables without expensive concatenation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8490cba4832dbcbf1e90b9094788