### PR TITLE
Prevent DHCP healthy summary when issues found

### DIFF
--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -469,7 +469,14 @@ function Invoke-DhcpAnalyzers {
                 Add-CategoryIssue -CategoryResult $CategoryResult -Severity $severity -Title $title -Evidence $evidence -Subcategory $subcategory
             }
         }
-    } else {
+    }
+
+    $existingDhcpIssues = @()
+    if ($CategoryResult -and $CategoryResult.PSObject.Properties['Issues'] -and $CategoryResult.Issues) {
+        $existingDhcpIssues = @($CategoryResult.Issues | Where-Object { $_ -and $_.PSObject.Properties['Subcategory'] -and $_.Subcategory -eq 'DHCP' })
+    }
+
+    if ($existingDhcpIssues.Count -eq 0) {
         $eligibleArtifactBases = @()
         foreach ($analyzer in $eligibleAnalyzers) {
             $eligibleArtifactBases += [string]$analyzer.ArtifactBase


### PR DESCRIPTION
## Summary
- stop adding the DHCP "healthy" summary when DHCP analyzers report issues
- leave the positive summary only when no DHCP issues are recorded for the category

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da8ba0a6ec832dad59dd9b6c447c78