### PR TITLE
Ensure analyzer context preloads JSON metadata

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -18,21 +18,18 @@ function New-AnalyzerContext {
 
     $files = Get-ChildItem -Path $resolved -File -Recurse -ErrorAction SilentlyContinue
     foreach ($file in $files) {
-        $data = $null
-        if ($file.Extension -ieq '.json') {
-            $content = Get-Content -Path $file.FullName -Raw -ErrorAction SilentlyContinue
-            if ($content) {
-                try {
-                    $data = $content | ConvertFrom-Json -ErrorAction Stop
-                } catch {
-                    $data = [pscustomobject]@{ Error = $_.Exception.Message }
-                }
-            }
-        }
-
         $entry = [pscustomobject]@{
             Path = $file.FullName
-            Data = $data
+            Data = $null
+        }
+
+        if ($file.Extension -ieq '.json') {
+            try {
+                $content = Get-Content -Raw -LiteralPath $file.FullName
+                $entry.Data = @{ Payload = ($content | ConvertFrom-Json -ErrorAction Stop) }
+            } catch {
+                $entry.Data = @{ Error = $_.Exception.Message }
+            }
         }
 
         $key = $file.Name.ToLowerInvariant()


### PR DESCRIPTION
## Summary
- initialize analyzer context entries with null data and preload JSON artifacts into structured payload or error metadata
- ensure artifact lookup keys remain case-insensitive by using lowercase file names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db1291ba14832db7924dee3a06eaa7