### PR TITLE
Fix static rendering for issue cards without evidence

### DIFF
--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -674,8 +674,6 @@ function New-IssueCardHtml {
   $hasMessage = -not [string]::IsNullOrWhiteSpace($messageValue)
   $summaryText = if ($hasMessage) { "<strong>$areaHtml</strong>: $messageHtml" } else { "<strong>$areaHtml</strong>" }
 
-  $cardHtml = "<details class='report-card report-card--$cardClass'><summary><span class='report-badge report-badge--$cardClass'>$badgeHtml</span><span class='report-card__summary-text'>$summaryText</span></summary>"
-
   $bodyParts = @()
 
   if (-not [string]::IsNullOrWhiteSpace($Entry.Explanation)) {
@@ -687,6 +685,15 @@ function New-IssueCardHtml {
     $evidenceHtml = Encode-Html $Entry.Evidence
     $bodyParts += "<pre class='report-pre'>$evidenceHtml</pre>"
   }
+
+  $badgeFragment = "<span class='report-badge report-badge--$cardClass'>$badgeHtml</span>"
+  $summaryFragment = "<span class='report-card__summary-text'>$summaryText</span>"
+
+  if ($bodyParts.Count -eq 0) {
+    return "<div class='report-card report-card--$cardClass report-card--static'>$badgeFragment$summaryFragment</div>"
+  }
+
+  $cardHtml = "<details class='report-card report-card--$cardClass'><summary>$badgeFragment$summaryFragment</summary>"
 
   if ($bodyParts.Count -gt 0) {
     $cardHtml += "<div class='report-card__body'>$($bodyParts -join '')</div>"


### PR DESCRIPTION
## Summary
- render issue cards without explanations or evidence as static blocks instead of expandable sections
- reuse the existing badge and summary layout when no details are available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe10ac264832db639a11624640401