### PR TITLE
Add remaining space to critical volume titles

### DIFF
--- a/Analyzers/Heuristics/Storage.ps1
+++ b/Analyzers/Heuristics/Storage.ps1
@@ -264,7 +264,7 @@ function Invoke-StorageHeuristics {
                 $warnPercent = $threshold.WarnPercent * 100
                 if ($freeGb -le $threshold.CritFloorGB -or $freePct -le $critPercent) {
                     $evidence = "Free {0} GB ({1}%); critical floor {2} GB or {3}%" -f $freeGb, [math]::Round($freePct,1), $threshold.CritFloorGB, [math]::Round($critPercent,1)
-                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Volume {0} critically low on space" -f $label) -Evidence $evidence -Subcategory 'Free Space'
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Volume {0} critically low on space ({1} GB remaining)" -f $label, $freeGb) -Evidence $evidence -Subcategory 'Free Space'
                 } elseif ($freeGb -le $threshold.WarnFloorGB -or $freePct -le $warnPercent) {
                     $evidence = "Free {0} GB ({1}%); warning floor {2} GB or {3}%" -f $freeGb, [math]::Round($freePct,1), $threshold.WarnFloorGB, [math]::Round($warnPercent,1)
                     Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ("Volume {0} approaching capacity" -f $label) -Evidence $evidence -Subcategory 'Free Space'


### PR DESCRIPTION
## Summary
- include the remaining gigabytes value directly in critical free space card titles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcca45c828832d91823136d60f6ad7