### PR TITLE
Fix Collect-All documentation about execution order

### DIFF
--- a/Collectors/README.md
+++ b/Collectors/README.md
@@ -6,7 +6,7 @@ The collector layer captures raw diagnostics from Windows endpoints and writes t
 
 > **Tip:** Launch PowerShell **as Administrator** before running collectors. Several scripts query security logs, Defender status, or networking configuration that require elevated rights.
 
-- **Run everything:** `Collectors/Collect-All.ps1` discovers every `Collect-*.ps1` script under this directory, executes them (in parallel by default), and drops JSON into per-area subfolders (`output/Network`, `output/Security`, etc.). Override `-OutputRoot` to control the root folder or `-ThrottleLimit` to cap parallelism.
+- **Run everything:** `Collectors/Collect-All.ps1` discovers every `Collect-*.ps1` script under this directory, executes them sequentially, and drops JSON into per-area subfolders (`output/Network`, `output/Security`, etc.). Override `-OutputRoot` to control the root folder. The script currently runs one collector at a time; the `-ThrottleLimit` parameter is reserved for a future parallel implementation and does not change execution order today.
 - **Run a single collector:** Execute the script directly and supply an `-OutputDirectory` if you do not want to use the default timestamped folder that orchestrators create. Example:
   ```powershell
   powershell.exe -ExecutionPolicy Bypass -File .\Collectors\Network\Collect-Network.ps1 -OutputDirectory C:\Temp\Diag\Network


### PR DESCRIPTION
## Summary
- clarify that Collect-All.ps1 runs collectors sequentially
- document that the current ThrottleLimit parameter is reserved for a future parallel implementation

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68dccc06cc4c832d8aa33e00e21c2233