### PR TITLE
Update BITS manual-start issue card messaging

### DIFF
--- a/Analyzers/Heuristics/Services/Services.Checks.ps1
+++ b/Analyzers/Heuristics/Services/Services.Checks.ps1
@@ -250,7 +250,9 @@ function Invoke-ServiceCheckBits {
         }
     } elseif ($service.StartModeNormalized -eq 'manual') {
         if ($IsWorkstation) {
-            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'BITS configured for manual start on workstation' -Evidence $evidence -Subcategory 'BITS Service'
+            $manualWorkstationTitle = 'BITS service stopped; Windows Update, Defender/AV signature updates, Office 365 Click-to-Run updates/repairs, WSUS/SCCM client content downloads, and some Microsoft Store/app servicing will fail or stall.'
+            $manualWorkstationEvidence = 'BITS service stopped; configured for manual start on workstation.'
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title $manualWorkstationTitle -Evidence $manualWorkstationEvidence -Subcategory 'BITS Service'
         } elseif ($service.StatusNormalized -ne 'running') {
             Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'BITS manual start and currently stopped' -Evidence $evidence -Subcategory 'BITS Service'
         }


### PR DESCRIPTION
## Summary
- update the manual-start BITS issue card title to describe the downstream update failures
- move the workstation manual-start detail into the evidence field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc3a3f130832d840f717403436afe