### PR TITLE
Fix pending reboot analyzer registry value

### DIFF
--- a/Analyzers/Heuristics/System/PendingReboot.ps1
+++ b/Analyzers/Heuristics/System/PendingReboot.ps1
@@ -53,10 +53,9 @@ function Invoke-SystemPendingRebootChecks {
 
     if ($payload.PSObject.Properties['PendingFileRenames']) {
         $renamePayload = $payload.PendingFileRenames
-        $sets = @('PendingFileRenameOperations','PendingFileRenameOperations2')
-        foreach ($name in $sets) {
-            if (-not $renamePayload.PSObject.Properties[$name]) { continue }
-            $values = $renamePayload.$name
+        $valueName = 'PendingFileRenameOperations'
+        if ($renamePayload.PSObject.Properties[$valueName]) {
+            $values = $renamePayload.$valueName
             if (-not ($values -is [System.Collections.IEnumerable] -and -not ($values -is [string]))) {
                 $values = @($values)
             }
@@ -69,7 +68,7 @@ function Invoke-SystemPendingRebootChecks {
                     if ($trimmed) {
                         $pendingFileRenames = $true
                         if ($fileRenameEvidence.Count -lt 6) {
-                            $fileRenameEvidence.Add(('{0}[{1}]: {2}' -f $name, $index, $trimmed)) | Out-Null
+                            $fileRenameEvidence.Add(('{0}[{1}]: {2}' -f $valueName, $index, $trimmed)) | Out-Null
                         }
                     }
                 } elseif ($value.PSObject.Properties['Error']) {

--- a/Collectors/System/Collect-PendingReboot.ps1
+++ b/Collectors/System/Collect-PendingReboot.ps1
@@ -93,11 +93,9 @@ function Get-PendingRenameStatus {
 function Get-PendingFileOperations {
     $sessionManagerPath = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Session Manager'
     $primary = Get-RegistryValueStrings -Path $sessionManagerPath -ValueName 'PendingFileRenameOperations'
-    $secondary = Get-RegistryValueStrings -Path $sessionManagerPath -ValueName 'PendingFileRenameOperations2'
 
     return [pscustomobject]@{
-        PendingFileRenameOperations  = $primary
-        PendingFileRenameOperations2 = $secondary
+        PendingFileRenameOperations = $primary
     }
 }
 


### PR DESCRIPTION
## Summary
- update the pending reboot collector to query the standard PendingFileRenameOperations value
- align the heuristic analyzer with the collector by removing references to the non-existent PendingFileRenameOperations2 value

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd0032c360832d9d96d4701ad4dff6