### PR TITLE
Add diagnostics when key artifacts are missing

### DIFF
--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -823,6 +823,8 @@ function Invoke-NetworkHeuristics {
                 }
             }
         }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'DNS diagnostics not collected, so latency and name resolution issues may be missed.' -Subcategory 'DNS Resolution'
     }
 
     $outlookArtifact = Get-AnalyzerArtifact -Context $Context -Name 'outlook-connectivity'
@@ -899,6 +901,15 @@ function Invoke-NetworkHeuristics {
         } else {
             Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'No active network adapters reported, so the device has no path for network connectivity.' -Subcategory 'Network Adapters'
         }
+    } elseif ($adapterPayload -and $adapterPayload.PSObject.Properties['Adapters']) {
+        $adapterNode = $adapterPayload.Adapters
+        if ($adapterNode -is [pscustomobject] -and $adapterNode.PSObject.Properties['Error'] -and $adapterNode.Error) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to enumerate network adapters, so link status is unknown.' -Evidence $adapterNode.Error -Subcategory 'Network Adapters'
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Network adapter inventory incomplete, so link status is unknown.' -Subcategory 'Network Adapters'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Network adapter inventory not collected, so link status is unknown.' -Subcategory 'Network Adapters'
     }
 
     $proxyArtifact = Get-AnalyzerArtifact -Context $Context -Name 'proxy'

--- a/Analyzers/Heuristics/Office.ps1
+++ b/Analyzers/Heuristics/Office.ps1
@@ -61,6 +61,10 @@ function Invoke-OfficeHeuristics {
             Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Office macro notifications - no data, so macro security gaps could expose the organization to macro malware.' -Subcategory 'Macro Policies'
             Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Office Protected View - no data, so disabled Protected View could let untrusted files open directly.' -Subcategory 'Protected View Policies'
         }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Office MOTW macro blocking - no data, so disabled MOTW or permissive macro settings could expose the organization to macro malware.' -Subcategory 'Macro Policies'
+        Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Office macro notifications - no data, so macro security gaps could expose the organization to macro malware.' -Subcategory 'Macro Policies'
+        Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Office Protected View - no data, so disabled Protected View could let untrusted files open directly.' -Subcategory 'Protected View Policies'
     }
 
     $cacheArtifact = Get-AnalyzerArtifact -Context $Context -Name 'outlook-caches'
@@ -81,6 +85,8 @@ function Invoke-OfficeHeuristics {
                 Add-CategoryNormal -CategoryResult $result -Title ('Outlook cache files present ({0})' -f $payload.Caches.Count) -Subcategory 'Outlook Cache'
             }
         }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Outlook cache inventory not collected, so oversized cache files may be missed.' -Subcategory 'Outlook Cache'
     }
 
     $connectivityArtifact = Get-AnalyzerArtifact -Context $Context -Name 'outlook-connectivity'
@@ -101,6 +107,8 @@ function Invoke-OfficeHeuristics {
                 Add-CategoryNormal -CategoryResult $result -Title ('OST files present ({0})' -f $payload.OstFiles.Count) -Subcategory 'Outlook Data Files'
             }
         }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Outlook data file inventory not collected, so oversized OST files may be missed.' -Subcategory 'Outlook Data Files'
     }
 
     $autodiscoverArtifact = Get-AnalyzerArtifact -Context $Context -Name 'autodiscover-dns'

--- a/Analyzers/Heuristics/Security.ps1
+++ b/Analyzers/Heuristics/Security.ps1
@@ -650,6 +650,8 @@ function Invoke-SecurityHeuristics {
         } elseif ($smartAppState -ne $null) {
             Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Smart App Control disabled, so app trust enforcement is reduced.' -Evidence $evidenceText -Subcategory 'Smart App Control'
         }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'WDAC/Smart App Control diagnostics not collected, so app trust enforcement is unknown.' -Subcategory 'Smart App Control'
     }
 
     $lapsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'laps_localadmin'

--- a/Analyzers/Heuristics/Storage.ps1
+++ b/Analyzers/Heuristics/Storage.ps1
@@ -360,6 +360,8 @@ function Invoke-StorageHeuristics {
                     }
                 }
             }
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'SMART wear data not collected, so SSD end-of-life risks may be hidden.' -Subcategory 'SMART Wear'
         }
     }
 
@@ -413,8 +415,12 @@ function Invoke-StorageHeuristics {
         }
     }
 
-    if (-not $storageArtifact -and -not $snapshotArtifact) {
-        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Storage artifact missing, so storage health and capacity risks may be hidden.' -Subcategory 'Collection'
+    if (-not $storageArtifact) {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Storage inventory artifact missing, so storage health and wear cannot be evaluated.' -Subcategory 'Collection'
+    }
+
+    if (-not $snapshotArtifact) {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Storage snapshot artifact missing, so SMART status cannot be evaluated.' -Subcategory 'Collection'
     }
 
     return $result


### PR DESCRIPTION
## Summary
- flag missing WDAC payloads so Smart App Control status is still reported
- surface missing Office cache, OST, and macro policy data to highlight collection gaps
- report absent SMART wear counters, storage artifacts, DNS diagnostics, and adapter inventories

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db55af4e4c832da12be373d4bf4ab7