### PR TITLE
Revamp overview score section with health rings

### DIFF
--- a/styles/device-health-report.css
+++ b/styles/device-health-report.css
@@ -287,6 +287,232 @@ details.report-card[open] > summary {
   margin-bottom: var(--space-sm);
 }
 
+.report-card--overview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.score-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+}
+
+.score-section__primary,
+.score-section__breakdown {
+  flex: 1 1 280px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.score-section__primary {
+  align-items: center;
+  text-align: center;
+}
+
+.score-section__primary > .report-badge-group {
+  justify-content: center;
+  width: 100%;
+}
+
+.score-section__note {
+  display: block;
+  margin-top: var(--space-xs);
+  color: var(--color-text-note);
+}
+
+.score-section__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-heading);
+}
+
+.score-breakdown {
+  display: grid;
+  gap: var(--space-sm);
+  width: 100%;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.score-breakdown__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-card);
+  background-color: var(--color-surface-muted);
+}
+
+.score-breakdown__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.score-breakdown__label {
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.score-breakdown__details {
+  font-size: 0.85rem;
+  color: var(--color-text-primary);
+}
+
+.score-breakdown__details--muted {
+  color: var(--color-text-note);
+}
+
+.score-breakdown--empty {
+  padding: var(--space-sm);
+  border: 1px dashed var(--color-border-subtle);
+  border-radius: var(--radius-card);
+  color: var(--color-text-note);
+}
+
+.score-ring {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.score-ring__svg {
+  width: 100%;
+  height: auto;
+  transform: rotate(-90deg);
+}
+
+.score-ring__background {
+  fill: none;
+  stroke: var(--color-border-subtle);
+  stroke-width: 12;
+  opacity: 0.35;
+}
+
+.score-ring__value {
+  fill: none;
+  stroke: var(--color-heading);
+  stroke-width: 12;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.6s ease;
+}
+
+.score-ring__content {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.score-ring__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-note);
+}
+
+.score-ring__number {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--color-heading);
+}
+
+.score-ring__suffix {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-note);
+}
+
+.score-ring--overall {
+  width: 160px;
+  height: 160px;
+}
+
+.score-ring--overall .score-ring__background,
+.score-ring--overall .score-ring__value {
+  stroke-width: 14;
+}
+
+.score-ring--small {
+  width: 96px;
+  height: 96px;
+}
+
+.score-ring--small .score-ring__background,
+.score-ring--small .score-ring__value {
+  stroke-width: 10;
+}
+
+.score-ring__content--compact {
+  flex-direction: row;
+  gap: 0.15rem;
+}
+
+.score-ring__content--compact .score-ring__number {
+  font-size: 1.35rem;
+}
+
+.score-ring__content--compact .score-ring__suffix {
+  font-size: 0.75rem;
+  color: var(--color-text-note);
+}
+
+.score-ring--good .score-ring__value {
+  stroke: var(--color-state-good-border);
+}
+
+.score-ring--info .score-ring__value {
+  stroke: var(--color-state-info-border);
+}
+
+.score-ring--low .score-ring__value {
+  stroke: var(--color-state-ok-border);
+}
+
+.score-ring--medium .score-ring__value {
+  stroke: var(--color-state-medium-border);
+}
+
+.score-ring--warning .score-ring__value {
+  stroke: var(--color-state-warning-border);
+}
+
+.score-ring--high .score-ring__value {
+  stroke: var(--color-state-bad-border);
+}
+
+.score-ring--critical .score-ring__value {
+  stroke: var(--color-state-critical-border);
+}
+
+@media (max-width: 640px) {
+  .score-section__primary,
+  .score-section__breakdown {
+    flex: 1 1 100%;
+  }
+
+  .score-ring--overall {
+    width: 140px;
+    height: 140px;
+  }
+
+  .score-ring--small {
+    width: 88px;
+    height: 88px;
+  }
+}
+
 .report-badge {
   display: inline-flex;
   align-items: baseline;


### PR DESCRIPTION
## Summary
- Rebuild the summary composer to calculate per-category health metrics, render the overall score ring, and accept normals so the UI shows a richer overview.
- Add layout and visualization styles for the new overview score section, including circular health rings and the category breakdown grid.

## Testing
- `pwsh -NoLogo -Command ". ./Analyzers/HtmlComposer.ps1"` *(fails: PowerShell is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd15353c58832dbefaebb133c806c2