### PR TITLE
Streamline overview layout

### DIFF
--- a/Analyzers/HtmlComposer.ps1
+++ b/Analyzers/HtmlComposer.ps1
@@ -568,7 +568,6 @@ function Build-SummaryCardHtml {
     $osArray = $osParts.ToArray()
     $osText = if ($osArray.Length -gt 0) { ($osArray -join ' | ') } else { 'Unknown' }
 
-    $serverText = if ($Summary.IsWindowsServer -eq $true) { 'Yes' } elseif ($Summary.IsWindowsServer -eq $false) { 'No' } else { 'Unknown' }
 
     $ipv4Text = if ($Summary.IPv4Addresses -and $Summary.IPv4Addresses.Count -gt 0) { ($Summary.IPv4Addresses -join ', ') } else { 'Unknown' }
     $gatewayText = if ($Summary.Gateways -and $Summary.Gateways.Count -gt 0) { ($Summary.Gateways -join ', ') } else { 'Unknown' }
@@ -643,15 +642,22 @@ function Build-SummaryCardHtml {
     $null = $sb.AppendLine("      <small class='report-note score-section__note'>Score is heuristic. Triage Critical/High items first.</small>")
     $null = $sb.AppendLine('    </div>')
     $null = $sb.AppendLine('  </div>')
-    $null = $sb.AppendLine("  <table class='report-table report-table--key-value' cellspacing='0' cellpadding='0'>")
-    $null = $sb.AppendLine("    <tr><td>Device Name</td><td>$(Encode-Html $deviceName)</td></tr>")
-    $null = $sb.AppendLine("    <tr><td>Device State</td><td>$(Encode-Html $deviceState)</td></tr>")
-    $null = $sb.AppendLine("    <tr><td>System</td><td>$(Encode-Html $osText)</td></tr>")
-    $null = $sb.AppendLine("    <tr><td>Windows Server</td><td>$(Encode-Html $serverText)</td></tr>")
-    $null = $sb.AppendLine("    <tr><td>IPv4</td><td>$(Encode-Html $ipv4Text)</td></tr>")
-    $null = $sb.AppendLine("    <tr><td>Gateway</td><td>$(Encode-Html $gatewayText)</td></tr>")
-    $null = $sb.AppendLine("    <tr><td>DNS</td><td>$(Encode-Html $dnsText)</td></tr>")
-    $null = $sb.AppendLine('  </table>')
+    $null = $sb.AppendLine("  <div class='report-overview__columns'>")
+    $null = $sb.AppendLine("    <div class='report-overview__column report-overview__column--primary'>")
+    $null = $sb.AppendLine("      <table class='report-table report-table--key-value' cellspacing='0' cellpadding='0'>")
+    $null = $sb.AppendLine("        <tr><td>Device Name</td><td>$(Encode-Html $deviceName)</td></tr>")
+    $null = $sb.AppendLine("        <tr><td>Device State</td><td>$(Encode-Html $deviceState)</td></tr>")
+    $null = $sb.AppendLine("        <tr><td>System</td><td>$(Encode-Html $osText)</td></tr>")
+    $null = $sb.AppendLine('      </table>')
+    $null = $sb.AppendLine('    </div>')
+    $null = $sb.AppendLine("    <div class='report-overview__column report-overview__column--secondary'>")
+    $null = $sb.AppendLine("      <table class='report-table report-table--key-value' cellspacing='0' cellpadding='0'>")
+    $null = $sb.AppendLine("        <tr><td>IPv4</td><td>$(Encode-Html $ipv4Text)</td></tr>")
+    $null = $sb.AppendLine("        <tr><td>Gateway</td><td>$(Encode-Html $gatewayText)</td></tr>")
+    $null = $sb.AppendLine("        <tr><td>DNS</td><td>$(Encode-Html $dnsText)</td></tr>")
+    $null = $sb.AppendLine('      </table>')
+    $null = $sb.AppendLine('    </div>')
+    $null = $sb.AppendLine('  </div>')
     $null = $sb.AppendLine('</div>')
 
     return $sb.ToString()

--- a/styles/device-health-report.css
+++ b/styles/device-health-report.css
@@ -584,6 +584,29 @@ details.report-card[open] > summary {
   margin-top: var(--space-sm);
 }
 
+.report-overview__columns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  margin-top: var(--space-sm);
+}
+
+.report-overview__column {
+  flex: 1 1 260px;
+}
+
+.report-overview__column--primary {
+  flex-basis: 70%;
+}
+
+.report-overview__column--secondary {
+  flex-basis: 30%;
+}
+
+.report-overview__column .report-table--key-value {
+  margin-top: 0;
+}
+
 .report-table--list {
   margin-top: var(--space-sm);
 }


### PR DESCRIPTION
## Summary
- remove redundant Windows Server row from the overview summary table
- split the overview details into two columns and shift network details to the narrow column
- add layout styles to enforce a 70/30 column ratio while keeping responsive wrapping

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd2083c734832d8b2f6f99321505d3