### PR TITLE
Add NetBIOS duplicate name heuristic

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -5,6 +5,90 @@
 
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
 
+function ConvertTo-EventDateTime {
+    param($Value)
+
+    if ($null -eq $Value) { return $null }
+
+    if ($Value -is [datetime]) { return $Value }
+
+    if ($Value -is [string]) {
+        $text = $Value.Trim()
+        if (-not $text) { return $null }
+
+        $parsed = [datetime]::MinValue
+        if ([datetime]::TryParse($text, [ref]$parsed)) { return $parsed }
+        try { return [datetime]::Parse($text, [System.Globalization.CultureInfo]::InvariantCulture) } catch { return $null }
+    }
+
+    return $null
+}
+
+function Get-MaskedNetBiosName {
+    param([string]$Name)
+
+    if ([string]::IsNullOrWhiteSpace($Name)) { return $null }
+
+    $trimmed = [regex]::Replace($Name.Trim(), "^[\"']+|[\"']+$", '')
+    if (-not $trimmed) { return $null }
+
+    if ($trimmed.Length -le 1) { return '***' }
+    if ($trimmed.Length -eq 2) { return ('{0}**' -f $trimmed.Substring(0, 1)) }
+
+    $first = $trimmed.Substring(0, 1)
+    $last = $trimmed.Substring($trimmed.Length - 1, 1)
+    return ('{0}***{1}' -f $first, $last)
+}
+
+function Get-DuplicateNameFromMessage {
+    param([string]$Message)
+
+    if ([string]::IsNullOrWhiteSpace($Message)) { return $null }
+
+    $patterns = @(
+        '(?i)name\s+"([^"\r\n]+)"',
+        "(?i)name\s+'([^'\r\n]+)'",
+        '(?i)duplicate\s+name\s+([A-Za-z0-9._$-]+)'
+    )
+
+    foreach ($pattern in $patterns) {
+        $match = [regex]::Match($Message, $pattern)
+        if ($match.Success -and $match.Groups.Count -gt 1) {
+            $candidate = $match.Groups[1].Value.Trim()
+            if ($candidate) { return $candidate }
+        }
+    }
+
+    return $null
+}
+
+function Get-EventMessageSnippet {
+    param(
+        [string]$Message,
+        [string]$OriginalName,
+        [string]$MaskedName,
+        [int]$MaxLength = 160
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Message)) { return $null }
+
+    $text = [System.Text.RegularExpressions.Regex]::Replace($Message.Trim(), '\s+', ' ')
+
+    if ($OriginalName -and $MaskedName) {
+        $escaped = [regex]::Escape($OriginalName)
+        $text = [regex]::Replace(
+            $text,
+            $escaped,
+            [System.Text.RegularExpressions.MatchEvaluator]{ param($match) $MaskedName },
+            [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+        )
+    }
+
+    if ($text.Length -le $MaxLength) { return $text }
+
+    return ($text.Substring(0, $MaxLength).TrimEnd() + '…')
+}
+
 function Invoke-EventsHeuristics {
     param(
         [Parameter(Mandatory)]
@@ -27,11 +111,24 @@ function Invoke-EventsHeuristics {
             HasPayload = [bool]$payload
         })
         if ($payload) {
+            $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
+            $systemPayload = if ($systemArtifact) { Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact) } else { $null }
+            $localComputerName = $null
+            $localComputerNameMasked = $null
+            if ($systemPayload -and $systemPayload.ComputerSystem -and -not $systemPayload.ComputerSystem.Error) {
+                if ($systemPayload.ComputerSystem.PSObject.Properties['Name']) {
+                    $localComputerName = [string]$systemPayload.ComputerSystem.Name
+                    $localComputerNameMasked = Get-MaskedNetBiosName -Name $localComputerName
+                }
+            }
+
+            $systemEntries = $null
             foreach ($logName in @('System','Application','GroupPolicy')) {
                 Write-HeuristicDebug -Source 'Events' -Message ('Inspecting {0} log entries' -f $logName)
                 if (-not $payload.PSObject.Properties[$logName]) { continue }
                 $entries = $payload.$logName
                 if ($entries -and -not $entries.Error) {
+                    if ($logName -eq 'System') { $systemEntries = $entries }
                     $logSubcategory = ("{0} Event Log" -f $logName)
                     $errorCount = ($entries | Where-Object { $_.LevelDisplayName -eq 'Error' }).Count
                     $warnCount = ($entries | Where-Object { $_.LevelDisplayName -eq 'Warning' }).Count
@@ -52,6 +149,64 @@ function Invoke-EventsHeuristics {
                 } elseif ($entries.Error) {
                     $logSubcategory = ("{0} Event Log" -f $logName)
                     Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Unable to read {0} event log, so noisy or unhealthy logs may be hidden." -f $logName) -Evidence $entries.Error -Subcategory $logSubcategory
+                }
+            }
+
+            if ($systemEntries) {
+                $cutoffUtc = (Get-Date).ToUniversalTime().AddDays(-7)
+                $matchingEvents = @()
+
+                foreach ($entry in $systemEntries) {
+                    if (-not $entry) { continue }
+
+                    $message = if ($entry.PSObject.Properties['Message']) { [string]$entry.Message } else { $null }
+                    $id = if ($entry.PSObject.Properties['Id']) { [int]$entry.Id } else { $null }
+                    $matchesDuplicate = $false
+
+                    if ($id -eq 4319) {
+                        $matchesDuplicate = $true
+                    } elseif ($message -and ($message -match '(?i)duplicate\s+name')) {
+                        $matchesDuplicate = $true
+                    }
+
+                    if (-not $matchesDuplicate) { continue }
+
+                    $eventTime = $null
+                    if ($entry.PSObject.Properties['TimeCreated'] -and $entry.TimeCreated) {
+                        $eventTime = ConvertTo-EventDateTime -Value $entry.TimeCreated
+                    }
+
+                    if (-not $eventTime) { continue }
+
+                    $eventUtc = $eventTime.ToUniversalTime()
+                    if ($eventUtc -lt $cutoffUtc) { continue }
+
+                    $matchingEvents += [pscustomobject]@{ Entry = $entry; Time = $eventTime }
+                }
+
+                if ($matchingEvents.Count -gt 0) {
+                    $selected = $matchingEvents | Sort-Object -Property @{ Expression = { $_.Time }; Descending = $true } | Select-Object -First 1
+                    $selectedEntry = $selected.Entry
+                    $selectedMessage = if ($selectedEntry.PSObject.Properties['Message']) { [string]$selectedEntry.Message } else { $null }
+                    $nameFromMessage = Get-DuplicateNameFromMessage -Message $selectedMessage
+
+                    $maskedName = $localComputerNameMasked
+                    if (-not $maskedName -and $nameFromMessage) {
+                        $maskedName = Get-MaskedNetBiosName -Name $nameFromMessage
+                    }
+                    if (-not $maskedName) { $maskedName = 'Unknown' }
+
+                    $originalNameForSnippet = if ($nameFromMessage) { $nameFromMessage } elseif ($localComputerName) { $localComputerName } else { $null }
+                    $snippet = Get-EventMessageSnippet -Message $selectedMessage -OriginalName $originalNameForSnippet -MaskedName $maskedName
+                    if (-not $snippet) { $snippet = 'Event message unavailable.' }
+
+                    $evidence = [ordered]@{
+                        localNameMasked = $maskedName
+                        lastUtc         = $selected.Time.ToUniversalTime().ToString('o')
+                        messageSnippet  = $snippet
+                    }
+
+                    Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title 'Duplicate machine name detected on network (NetBT 4319)' -Evidence $evidence -Subcategory 'Networking / NetBIOS'
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following sections list the analysis functions and issue card heuristics gro
 
 ## Services & Events Heuristics
 - **Services** – Issues adopt the per-service severity computed earlier (e.g., medium/high/critical for critical service failures) and explicitly raise high severity when legacy essentials like Dhcp or WinDefend are stopped.
-- **Events** – Adds informational issues for logs showing five or more errors and low-severity issues for logs with at least ten warnings in the sampled data.
+- **Events** – Adds informational issues for logs showing five or more errors, low-severity issues for logs with at least ten warnings in the sampled data, and flags low-severity duplicate NetBIOS name conflicts (NetBT 4319 or equivalent "duplicate name" messages) observed within the past week.
 - **Printing** – Flags high severity when the Spooler service is stopped/disabled or when print hosts are unreachable, raises medium/high issues for offline queues and long-running jobs, warns on WSD ports, SNMP "public" communities, and legacy drivers, enforces Point-and-Print hardening posture, surfaces PrintService event storms and recurring driver crashes, and records GOOD findings for healthy spooler state, reachable printer ports, packaged drivers, and quiet event logs.
 
 ## Hardware Heuristics


### PR DESCRIPTION
## Summary
- add reusable helpers in the events analyzer to detect duplicate NetBIOS name system events
- surface a low-severity Networking/NetBIOS issue when NetBT 4319 or duplicate-name messages occurred within the last week
- document the new heuristic in the repository overview

## Testing
- not run (PowerShell is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd22080138832d85c5431cc8f167a2