### PR TITLE
Add disk integrity event heuristic

### DIFF
--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -28,12 +28,125 @@ function Get-RecentEvents {
     }
 }
 
+function Get-StorageDeviceHintFromMessage {
+    param(
+        [string]$Message
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Message)) { return $null }
+
+    $patterns = @(
+        '\\Device\\[^\\\s\.,;:)]+',
+        'Harddisk\d+(?:\\DR\d+)?',
+        '(?i)volume\s+([A-Z]:)',
+        '(?i)volume\s+({[^}]+})'
+    )
+
+    foreach ($pattern in $patterns) {
+        $match = [regex]::Match($Message, $pattern)
+        if (-not $match.Success) { continue }
+
+        $value = $match.Value
+        if ($match.Groups.Count -gt 1 -and $match.Groups[1].Success) {
+            $value = $match.Groups[1].Value
+        }
+
+        if ([string]::IsNullOrWhiteSpace($value)) { continue }
+
+        $trimmed = $value.Trim().TrimEnd('.', ';', ',', ':', ')')
+        if ($trimmed.StartsWith('Volume ', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $trimmed = $trimmed.Substring(7).Trim()
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($trimmed)) {
+            return $trimmed
+        }
+    }
+
+    return $null
+}
+
+function Get-StorageDiskEventSummary {
+    param(
+        [Parameter(Mandatory)]
+        [datetime]$StartTime
+    )
+
+    $windowStartUtc = $StartTime.ToUniversalTime()
+    $result = [ordered]@{
+        WindowStartUtc = $windowStartUtc.ToString('o')
+    }
+
+    try {
+        $filter = @{
+            LogName   = 'System'
+            Id        = @(51, 55, 153)
+            StartTime = $StartTime
+        }
+
+        $rawEvents = Get-WinEvent -FilterHashtable $filter -ErrorAction Stop |
+            Where-Object { $_.ProviderName -in @('Disk', 'Ntfs') } |
+            Select-Object TimeCreated, Id, ProviderName, Message
+
+        $summaries = @()
+
+        if ($rawEvents) {
+            $grouped = $rawEvents | Group-Object -Property Id
+            foreach ($group in $grouped) {
+                if (-not $group -or -not $group.Group) { continue }
+
+                $entries = $group.Group | Sort-Object -Property TimeCreated -Descending
+                if (-not $entries -or $entries.Count -eq 0) { continue }
+
+                $eventId = [int]$entries[0].Id
+                $provider = $entries[0].ProviderName
+                $lastTime = $entries[0].TimeCreated
+
+                $deviceHints = $entries | ForEach-Object { Get-StorageDeviceHintFromMessage -Message $_.Message } |
+                    Where-Object { $_ } | Select-Object -Unique
+
+                $summary = [ordered]@{
+                    EventId = $eventId
+                    Count   = $entries.Count
+                }
+
+                if ($provider) { $summary.Provider = $provider }
+                if ($lastTime) { $summary.LastUtc = $lastTime.ToUniversalTime().ToString('o') }
+
+                if ($deviceHints) {
+                    $normalizedHints = @()
+                    foreach ($hint in $deviceHints) {
+                        if ([string]::IsNullOrWhiteSpace($hint)) { continue }
+                        $normalizedHints += $hint.Trim()
+                    }
+                    if ($normalizedHints.Count -eq 1) {
+                        $summary.DeviceHint = $normalizedHints[0]
+                    } elseif ($normalizedHints.Count -gt 1) {
+                        $summary.DeviceHints = $normalizedHints
+                    }
+                }
+
+                $summaries += [PSCustomObject]$summary
+            }
+        }
+
+        $result.Events = $summaries
+    } catch {
+        $result.Error = $_.Exception.Message
+    }
+
+    return [PSCustomObject]$result
+}
+
 function Invoke-Main {
     $payload = [ordered]@{
         System      = Get-RecentEvents -LogName 'System'
         Application = Get-RecentEvents -LogName 'Application'
         GroupPolicy = Get-RecentEvents -LogName 'Microsoft-Windows-GroupPolicy/Operational' -MaxEvents 200
     }
+
+    $windowStart = (Get-Date).AddDays(-7)
+    $payload.StorageDiskEvents = Get-StorageDiskEventSummary -StartTime $windowStart
 
     $result = New-CollectorMetadata -Payload $payload
     $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'events.json' -Data $result -Depth 6

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The following sections list the analysis functions and issue card heuristics gro
 ## Services & Events Heuristics
 - **Services** – Issues adopt the per-service severity computed earlier (e.g., medium/high/critical for critical service failures) and explicitly raise high severity when legacy essentials like Dhcp or WinDefend are stopped.
 - **Events** – Adds informational issues for logs showing five or more errors and low-severity issues for logs with at least ten warnings in the sampled data.
+- **Events/Storage / Disk** – Surfaces high severity when NTFS event 55 appears in the last seven days and medium severity for Disk 51/153 events, summarizing event counts and device hints to highlight intermittent storage stalls and filesystem integrity risks.
 - **Printing** – Flags high severity when the Spooler service is stopped/disabled or when print hosts are unreachable, raises medium/high issues for offline queues and long-running jobs, warns on WSD ports, SNMP "public" communities, and legacy drivers, enforces Point-and-Print hardening posture, surfaces PrintService event storms and recurring driver crashes, and records GOOD findings for healthy spooler state, reachable printer ports, packaged drivers, and quiet event logs.
 
 ## Hardware Heuristics


### PR DESCRIPTION
## Summary
- extend the events collector with a seven-day Disk/Ntfs event summary that captures counts, last occurrence, and device hints
- add an Events category heuristic that surfaces medium/high severity issues for Disk 51/153 and Ntfs 55 activity and reports collection failures
- document the new Events/Storage / Disk heuristic in the README catalogue

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd2214834c832dbf53b171d534f37e