### PR TITLE
Add Windows Update failure heuristic

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -5,6 +5,80 @@
 
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
 
+function Normalize-WindowsUpdateHResult {
+    param(
+        [AllowNull()]
+        [object]$Value
+    )
+
+    if ($null -eq $Value) { return $null }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+
+    $trimmed = $text.Trim()
+    if ($trimmed -match '^0x[0-9a-fA-F]+$') {
+        $hex = $trimmed.Substring(2).ToUpperInvariant()
+        $padded = $hex.PadLeft(8, '0')
+        return '0x{0}' -f $padded
+    }
+
+    $number = 0L
+    if ([long]::TryParse($trimmed, [ref]$number)) {
+        $unsigned = [uint32]$number
+        return ('0x{0:X8}' -f $unsigned)
+    }
+
+    $match = [regex]::Match($trimmed, '0x[0-9a-fA-F]+')
+    if ($match.Success) {
+        $hex = $match.Value.Substring(2).ToUpperInvariant()
+        $padded = $hex.PadLeft(8, '0')
+        return '0x{0}' -f $padded
+    }
+
+    return $null
+}
+
+function Get-WindowsUpdateEventHResult {
+    param(
+        [AllowNull()]
+        [object]$Event
+    )
+
+    if (-not $Event) { return $null }
+    if (-not $Event.PSObject.Properties['EventData']) { return $null }
+
+    $eventData = $Event.EventData
+    if ($null -eq $eventData) { return $null }
+
+    $propertyHandler = {
+        param($Name, $Value)
+
+        if ([string]::IsNullOrWhiteSpace($Name)) { return $null }
+        $normalizedName = $Name.ToLowerInvariant()
+        if ($normalizedName -ne 'hr' -and $normalizedName -notmatch 'hresult' -and $normalizedName -notmatch 'errorcode' -and $normalizedName -notmatch 'resultcode') {
+            return $null
+        }
+
+        return Normalize-WindowsUpdateHResult -Value $Value
+    }
+
+    if ($eventData -is [System.Collections.IDictionary]) {
+        foreach ($key in $eventData.Keys) {
+            $candidate = & $propertyHandler $key $eventData[$key]
+            if ($candidate) { return $candidate }
+        }
+    } else {
+        foreach ($prop in $eventData.PSObject.Properties) {
+            if (-not $prop) { continue }
+            $candidate = & $propertyHandler $prop.Name $prop.Value
+            if ($candidate) { return $candidate }
+        }
+    }
+
+    return $null
+}
+
 function Invoke-EventsHeuristics {
     param(
         [Parameter(Mandatory)]
@@ -57,6 +131,97 @@ function Invoke-EventsHeuristics {
         }
     } else {
         Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Event log artifact missing, so noisy or unhealthy logs may be hidden.' -Subcategory 'Collection'
+    }
+
+    $wuArtifact = Get-AnalyzerArtifact -Context $Context -Name 'windows-update-events'
+    Write-HeuristicDebug -Source 'Events/WindowsUpdate' -Message 'Resolved Windows Update events artifact' -Data ([ordered]@{
+        Found = [bool]$wuArtifact
+    })
+    if ($wuArtifact) {
+        $wuPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $wuArtifact)
+        Write-HeuristicDebug -Source 'Events/WindowsUpdate' -Message 'Resolved Windows Update payload' -Data ([ordered]@{
+            HasPayload = [bool]$wuPayload
+        })
+        if ($wuPayload) {
+            if ($wuPayload.PSObject.Properties['Error'] -and $wuPayload.Error) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Windows Update event log unavailable' -Evidence ([ordered]@{
+                    Error  = $wuPayload.Error
+                    Source = if ($wuPayload.PSObject.Properties['ErrorSource']) { $wuPayload.ErrorSource } else { 'Microsoft-Windows-WindowsUpdateClient/Operational' }
+                }) -Subcategory 'Windows Update'
+            } else {
+                $events = Ensure-Array $wuPayload.Events
+                Write-HeuristicDebug -Source 'Events/WindowsUpdate' -Message 'Windows Update event count' -Data ([ordered]@{
+                    Count = $events.Count
+                })
+                if ($events.Count -gt 0) {
+                    $windowEnd = $null
+                    if ($wuPayload.PSObject.Properties['WindowEnd'] -and $wuPayload.WindowEnd) {
+                        $windowEnd = ConvertFrom-Iso8601 $wuPayload.WindowEnd
+                    }
+                    if (-not $windowEnd) { $windowEnd = Get-Date }
+                    $recentBoundary = $windowEnd.AddDays(-7)
+                    $failureIds = @(20, 25, 31, 34)
+                    $candidates = @()
+
+                    foreach ($event in $events) {
+                        if (-not $event) { continue }
+                        $idValue = $null
+                        if ($event.PSObject.Properties['Id'] -and $null -ne $event.Id) {
+                            try { $idValue = [int]$event.Id } catch { continue }
+                        }
+                        if (-not $idValue -or ($failureIds -notcontains $idValue)) { continue }
+
+                        $eventTime = $null
+                        if ($event.PSObject.Properties['TimeCreated'] -and $event.TimeCreated) {
+                            $eventTime = ConvertFrom-Iso8601 $event.TimeCreated
+                            if (-not $eventTime -and ($event.TimeCreated -is [datetime])) {
+                                $eventTime = [datetime]$event.TimeCreated
+                            }
+                        }
+                        if (-not $eventTime) { continue }
+                        if ($eventTime -lt $recentBoundary) { continue }
+
+                        $hresult = Get-WindowsUpdateEventHResult -Event $event
+                        if (-not $hresult) { continue }
+
+                        $candidates += [pscustomobject]@{
+                            Id      = $idValue
+                            Time    = $eventTime
+                            HResult = $hresult
+                        }
+                    }
+
+                    Write-HeuristicDebug -Source 'Events/WindowsUpdate' -Message 'Windows Update failure candidates' -Data ([ordered]@{
+                        Count = $candidates.Count
+                    })
+
+                    if ($candidates.Count -gt 0) {
+                        $grouped = $candidates | Group-Object -Property HResult
+                        foreach ($group in $grouped) {
+                            if (-not $group -or [string]::IsNullOrWhiteSpace($group.Name)) { continue }
+                            if ($group.Count -lt 3) { continue }
+
+                            $sorted = $group.Group | Sort-Object -Property Time -Descending
+                            $latest = $sorted | Select-Object -First 1
+                            $evidence = [ordered]@{
+                                hresult      = $group.Name
+                                occurrences  = $group.Count
+                                lastUtc      = if ($latest.Time) { $latest.Time.ToUniversalTime().ToString('o') } else { $null }
+                                remediation  = 'Run DISM /Online /Cleanup-Image /RestoreHealth and SFC /SCANNOW before retrying Windows Update.'
+                            }
+
+                            Write-HeuristicDebug -Source 'Events/WindowsUpdate' -Message 'Detected repeated Windows Update failure' -Data ([ordered]@{
+                                HResult     = $group.Name
+                                Occurrences = $group.Count
+                                LastUtc     = $evidence.lastUtc
+                            })
+
+                            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Windows Update repeatedly failing' -Evidence $evidence -Subcategory 'Windows Update'
+                        }
+                    }
+                }
+            }
+        }
     }
 
     return $result

--- a/Collectors/System/Collect-WindowsUpdateEvents.ps1
+++ b/Collectors/System/Collect-WindowsUpdateEvents.ps1
@@ -1,0 +1,97 @@
+<#!
+.SYNOPSIS
+    Collects recent Windows Update Client events for failure analysis.
+.DESCRIPTION
+    Queries the Microsoft-Windows-WindowsUpdateClient/Operational log for key installation
+    and download events (IDs 19, 20, 25, 31, 34) within the last 14 days. The events are
+    exported with basic metadata plus parsed EventData fields so analyzers can correlate
+    repeated failures by HRESULT.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Convert-WindowsUpdateEvent {
+    param(
+        [Parameter(Mandatory)]
+        [System.Diagnostics.Eventing.Reader.EventRecord]$Event
+    )
+
+    $record = [ordered]@{
+        TimeCreated     = if ($Event.TimeCreated) { $Event.TimeCreated.ToString('o') } else { $null }
+        Id              = $Event.Id
+        LevelDisplayName = $Event.LevelDisplayName
+        ProviderName    = $Event.ProviderName
+        RecordId        = $Event.RecordId
+    }
+
+    try {
+        $message = $Event.FormatDescription()
+        if ($message) {
+            $record['Message'] = $message
+        }
+    } catch {
+        $record['MessageError'] = $_.Exception.Message
+    }
+
+    try {
+        $xml = [xml]$Event.ToXml()
+        if ($xml.Event -and $xml.Event.EventData -and $xml.Event.EventData.Data) {
+            $eventData = [ordered]@{}
+            $index = 0
+            foreach ($node in $xml.Event.EventData.Data) {
+                $name = if ($node.Name) { [string]$node.Name } else { "Data$index" }
+                if ($eventData.Contains($name)) {
+                    $name = "{0}_{1}" -f $name, $index
+                }
+                $value = $null
+                if ($node.'#text') {
+                    $value = [string]$node.'#text'
+                }
+                $eventData[$name] = $value
+                $index++
+            }
+
+            if ($eventData.Count -gt 0) {
+                $record['EventData'] = [pscustomobject]$eventData
+            }
+        }
+    } catch {
+        $record['EventDataError'] = $_.Exception.Message
+    }
+
+    return [pscustomobject]$record
+}
+
+function Invoke-Main {
+    $windowEnd = Get-Date
+    $windowStart = $windowEnd.AddDays(-14)
+
+    $payload = [ordered]@{
+        WindowStart = $windowStart.ToUniversalTime().ToString('o')
+        WindowEnd   = $windowEnd.ToUniversalTime().ToString('o')
+        Events      = @()
+    }
+
+    try {
+        $filter = @{ LogName = 'Microsoft-Windows-WindowsUpdateClient/Operational'; Id = @(19, 20, 25, 31, 34); StartTime = $windowStart }
+        $rawEvents = Get-WinEvent -FilterHashtable $filter -ErrorAction Stop
+        $payload.Events = @()
+        foreach ($event in $rawEvents) {
+            $payload.Events += Convert-WindowsUpdateEvent -Event $event
+        }
+    } catch {
+        $payload['Error'] = $_.Exception.Message
+        $payload['ErrorSource'] = 'Get-WinEvent Microsoft-Windows-WindowsUpdateClient/Operational'
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'windows-update-events.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following sections list the analysis functions and issue card heuristics gro
 
 ## Services & Events Heuristics
 - **Services** – Issues adopt the per-service severity computed earlier (e.g., medium/high/critical for critical service failures) and explicitly raise high severity when legacy essentials like Dhcp or WinDefend are stopped.
-- **Events** – Adds informational issues for logs showing five or more errors and low-severity issues for logs with at least ten warnings in the sampled data.
+- **Events** – Adds informational issues for logs showing five or more errors and low-severity issues for logs with at least ten warnings in the sampled data, and raises a high-severity issue when Windows Update client events (IDs 20/25/31/34) repeat the same HRESULT at least three times within seven days.
 - **Printing** – Flags high severity when the Spooler service is stopped/disabled or when print hosts are unreachable, raises medium/high issues for offline queues and long-running jobs, warns on WSD ports, SNMP "public" communities, and legacy drivers, enforces Point-and-Print hardening posture, surfaces PrintService event storms and recurring driver crashes, and records GOOD findings for healthy spooler state, reachable printer ports, packaged drivers, and quiet event logs.
 
 ## Hardware Heuristics


### PR DESCRIPTION
## Summary
- collect Windows Update Client operational events for targeted IDs and expose EventData
- analyze Windows Update failures within the Events category and flag repeated HRESULTs in the last seven days
- document the new Windows Update heuristic in the Events catalogue

## Testing
- not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd221a6564832dbe3499cbb47e0e8a