### PR TITLE
Add persistent pending reboot heuristic to events analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following sections list the analysis functions and issue card heuristics gro
 
 ## Services & Events Heuristics
 - **Services** – Issues adopt the per-service severity computed earlier (e.g., medium/high/critical for critical service failures) and explicitly raise high severity when legacy essentials like Dhcp or WinDefend are stopped.
-- **Events** – Adds informational issues for logs showing five or more errors and low-severity issues for logs with at least ten warnings in the sampled data.
+- **Events** – Adds informational issues for logs showing five or more errors, low-severity issues for logs with at least ten warnings in the sampled data, and a medium-severity finding when pending file rename operations persist for 24 hours or longer without any servicing reboot-required keys to explain the reboot state.
 - **Printing** – Flags high severity when the Spooler service is stopped/disabled or when print hosts are unreachable, raises medium/high issues for offline queues and long-running jobs, warns on WSD ports, SNMP "public" communities, and legacy drivers, enforces Point-and-Print hardening posture, surfaces PrintService event storms and recurring driver crashes, and records GOOD findings for healthy spooler state, reachable printer ports, packaged drivers, and quiet event logs.
 
 ## Hardware Heuristics


### PR DESCRIPTION
## Summary
- collect Windows Update Client operational events alongside existing event logs
- add an Events category heuristic that flags persistent pending file rename operations without servicing reboot indicators
- document the new Events heuristic behavior in the root README

## Testing
- `pwsh -NoLogo -NoProfile -Command ". (Resolve-Path ./Analyzers/AnalyzerCommon.ps1); . (Resolve-Path ./Analyzers/Heuristics/Events.ps1)"` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd226fef98832dbf70cb5d85be4611