### PR TITLE
Add USB device install failure heuristic

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -3,7 +3,52 @@
     Event log heuristics summarizing recent error and warning volume.
 #>
 
+
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
+
+function Get-UsbDeviceIdTail {
+    param(
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $null }
+
+    $pattern = 'VID_[0-9A-Fa-f]{4}&PID_[0-9A-Fa-f]{4}(?:&[A-Za-z0-9_]+)*'
+    $match = [regex]::Match($Value, $pattern)
+    if ($match.Success) {
+        return $match.Value.ToUpperInvariant()
+    }
+
+    return $null
+}
+
+function ConvertTo-UtcDateTime {
+    param(
+        [object]$Value
+    )
+
+    if ($null -eq $Value) { return $null }
+
+    if ($Value -is [datetime]) {
+        return $Value.ToUniversalTime()
+    }
+
+    $text = $Value.ToString()
+    if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+
+    try {
+        $styles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+        $dt = [datetime]::Parse($text, [System.Globalization.CultureInfo]::InvariantCulture, $styles)
+        return $dt
+    } catch {
+        try {
+            $dt = [datetime]::Parse($text)
+            return $dt.ToUniversalTime()
+        } catch {
+            return $null
+        }
+    }
+}
 
 function Invoke-EventsHeuristics {
     param(
@@ -57,6 +102,123 @@ function Invoke-EventsHeuristics {
         }
     } else {
         Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Event log artifact missing, so noisy or unhealthy logs may be hidden.' -Subcategory 'Collection'
+    }
+
+    $deviceInstallArtifact = Get-AnalyzerArtifact -Context $Context -Name 'deviceinstall-events'
+    Write-HeuristicDebug -Source 'Events' -Message 'Resolved device install artifact' -Data ([ordered]@{
+        Found = [bool]$deviceInstallArtifact
+    })
+
+    if ($deviceInstallArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $deviceInstallArtifact)
+        Write-HeuristicDebug -Source 'Events' -Message 'Resolved device install payload' -Data ([ordered]@{
+            HasPayload = [bool]$payload
+        })
+
+        if ($payload) {
+            $windowDays = if ($payload.PSObject.Properties['WindowDays']) { [int]$payload.WindowDays } else { 7 }
+            $candidateEvents = [System.Collections.Generic.List[pscustomobject]]::new()
+            $errors = [System.Collections.Generic.List[string]]::new()
+
+            $sources = @(
+                [pscustomobject]@{ Property = 'UserPnpEvents'; Label = 'Microsoft-Windows-UserPnp/DeviceInstall' },
+                [pscustomobject]@{ Property = 'KernelPnPEvents'; Label = 'Microsoft-Windows-Kernel-PnP' }
+            )
+
+            foreach ($source in $sources) {
+                if (-not $payload.PSObject.Properties[$source.Property]) { continue }
+                $items = $payload.($source.Property)
+
+                $isEnumerable = $items -is [System.Collections.IEnumerable] -and -not ($items -is [string]) -and -not ($items -is [hashtable])
+                if ($isEnumerable) {
+                    foreach ($item in $items) {
+                        if (-not $item) { continue }
+
+                        if ($item.PSObject.Properties['Error'] -and $item.Error) {
+                            $errors.Add(("{0}: {1}" -f $source.Label, $item.Error)) | Out-Null
+                            continue
+                        }
+
+                        $tail = $null
+                        if ($item.PSObject.Properties['Message']) {
+                            $tail = Get-UsbDeviceIdTail -Value $item.Message
+                        }
+
+                        if (-not $tail -and $item.PSObject.Properties['Properties'] -and $item.Properties) {
+                            foreach ($value in $item.Properties) {
+                                $tail = Get-UsbDeviceIdTail -Value $value
+                                if ($tail) { break }
+                            }
+                        }
+
+                        if (-not $tail) { continue }
+
+                        $timestamp = $null
+                        if ($item.PSObject.Properties['TimeCreated']) {
+                            $timestamp = ConvertTo-UtcDateTime -Value $item.TimeCreated
+                        }
+
+                        $candidateEvents.Add([pscustomobject]@{
+                            Tail    = $tail
+                            Source  = $source.Label
+                            EventId = $item.Id
+                            TimeUtc = $timestamp
+                        }) | Out-Null
+                    }
+                } elseif ($items -and $items.PSObject.Properties['Error'] -and $items.Error) {
+                    $errors.Add(("{0}: {1}" -f $source.Label, $items.Error)) | Out-Null
+                }
+            }
+
+            $groupSummaries = [System.Collections.Generic.List[pscustomobject]]::new()
+            if ($candidateEvents.Count -gt 0) {
+                $grouped = $candidateEvents | Group-Object -Property Tail
+                foreach ($group in $grouped) {
+                    if (-not $group) { continue }
+                    $count = $group.Count
+                    if ($count -lt 3) { continue }
+
+                    $lastSeen = $null
+                    $timestamps = $group.Group | ForEach-Object { $_.TimeUtc } | Where-Object { $_ }
+                    if ($timestamps) {
+                        $lastSeen = ($timestamps | Sort-Object -Descending | Select-Object -First 1)
+                    }
+
+                    if (-not $lastSeen) { $lastSeen = [datetime]::UtcNow }
+
+                    $groupSummaries.Add([pscustomobject]@{
+                        deviceIdTail = $group.Name
+                        count        = $count
+                        lastUtc      = $lastSeen.ToString('o')
+                    }) | Out-Null
+                }
+            }
+
+            $severity = $null
+            if ($groupSummaries.Count -gt 0) {
+                $maxCount = ($groupSummaries | Measure-Object -Property count -Maximum).Maximum
+                $severity = if ($maxCount -ge 5) { 'medium' } else { 'low' }
+                $evidence = [ordered]@{
+                    windowDays = $windowDays
+                    devices    = $groupSummaries
+                }
+
+                Add-CategoryIssue -CategoryResult $result -Severity $severity -Title 'Repeated device install failures detected' -Evidence $evidence -Subcategory 'USB / Device Install'
+            }
+
+            Write-HeuristicDebug -Source 'Events' -Message 'Device install event evaluation summary' -Data ([ordered]@{
+                CandidateCount = $candidateEvents.Count
+                IssueCount     = $groupSummaries.Count
+                Severity       = if ($severity) { $severity } else { 'none' }
+                Errors         = if ($errors.Count -gt 0) { $errors.Count } else { 0 }
+            })
+
+            if ($errors.Count -gt 0) {
+                Write-HeuristicDebug -Source 'Events' -Message 'Device install event errors encountered' -Data ([ordered]@{
+                    Details = ($errors -join ' | ')
+                })
+            }
+        }
     }
 
     return $result

--- a/Collectors/System/Collect-DeviceInstallEvents.ps1
+++ b/Collectors/System/Collect-DeviceInstallEvents.ps1
@@ -1,0 +1,128 @@
+<#!
+.SYNOPSIS
+    Collects USB and device installation failure events plus SetupAPI diagnostics.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\CollectorCommon.ps1')
+
+function ConvertTo-EventRecord {
+    param(
+        [Parameter(Mandatory)]
+        $Event
+    )
+
+    $properties = @()
+    if ($Event -and $Event.PSObject.Properties['Properties'] -and $Event.Properties) {
+        $propValues = foreach ($prop in $Event.Properties) {
+            if ($null -eq $prop) { continue }
+            if ($prop.PSObject.Properties['Value']) {
+                if ($null -ne $prop.Value) {
+                    $prop.Value.ToString()
+                } else {
+                    $null
+                }
+            } else {
+                $prop.ToString()
+            }
+        }
+
+        $properties = @($propValues)
+    }
+
+    return [pscustomobject]@{
+        Id           = $Event.Id
+        ProviderName = $Event.ProviderName
+        Level        = $Event.LevelDisplayName
+        TimeCreated  = if ($Event.TimeCreated) { $Event.TimeCreated.ToString('o') } else { $null }
+        Message      = $Event.Message
+        Properties   = $properties
+    }
+}
+
+function Get-DeviceInstallEvents {
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogName,
+
+        [int[]]$EventIds = @(),
+
+        [string]$ProviderName,
+
+        [datetime]$StartTime,
+
+        [int]$MaxEvents = 500
+    )
+
+    $filter = @{ LogName = $LogName }
+    if ($EventIds -and $EventIds.Count -gt 0) { $filter['Id'] = $EventIds }
+    if ($PSBoundParameters.ContainsKey('ProviderName') -and -not [string]::IsNullOrWhiteSpace($ProviderName)) {
+        $filter['ProviderName'] = $ProviderName
+    }
+    if ($PSBoundParameters.ContainsKey('StartTime') -and $StartTime) {
+        $filter['StartTime'] = $StartTime
+    }
+
+    try {
+        $events = Get-WinEvent -FilterHashtable $filter -MaxEvents $MaxEvents -ErrorAction Stop
+    } catch {
+        return @([pscustomobject]@{
+            Source = "Get-WinEvent $LogName"
+            Error  = $_.Exception.Message
+        })
+    }
+
+    $records = [System.Collections.Generic.List[pscustomobject]]::new()
+    foreach ($event in $events) {
+        $records.Add((ConvertTo-EventRecord -Event $event)) | Out-Null
+    }
+
+    return $records.ToArray()
+}
+
+function Get-SetupApiLogTail {
+    param(
+        [string]$Path = 'C:\\Windows\\INF\\setupapi.dev.log',
+        [int]$Tail = 100
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return [pscustomobject]@{
+            Source = $Path
+            Error  = 'File not found'
+        }
+    }
+
+    try {
+        return Get-Content -LiteralPath $Path -Tail $Tail -ErrorAction Stop
+    } catch {
+        return [pscustomobject]@{
+            Source = $Path
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-Main {
+    $windowDays = 7
+    $startTime = (Get-Date).AddDays(-1 * $windowDays)
+
+    $payload = [ordered]@{
+        CapturedAtUtc     = (Get-Date).ToUniversalTime().ToString('o')
+        WindowDays        = $windowDays
+        StartTimeUtc      = $startTime.ToUniversalTime().ToString('o')
+        UserPnpEvents     = Get-DeviceInstallEvents -LogName 'Microsoft-Windows-UserPnp/DeviceInstall' -EventIds (20001..20007) -StartTime $startTime
+        KernelPnPEvents   = Get-DeviceInstallEvents -LogName 'System' -EventIds @(219) -ProviderName 'Microsoft-Windows-Kernel-PnP' -StartTime $startTime
+        SetupApiDevLogTail = Get-SetupApiLogTail
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'deviceinstall-events.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following sections list the analysis functions and issue card heuristics gro
 
 ## Services & Events Heuristics
 - **Services** – Issues adopt the per-service severity computed earlier (e.g., medium/high/critical for critical service failures) and explicitly raise high severity when legacy essentials like Dhcp or WinDefend are stopped.
-- **Events** – Adds informational issues for logs showing five or more errors and low-severity issues for logs with at least ten warnings in the sampled data.
+- **Events** – Adds informational issues for logs showing five or more errors and low-severity issues for logs with at least ten warnings in the sampled data, and highlights recurring USB/device installation failures when the same VID/PID pair is observed three or more times within a seven-day window (escalating to medium severity for noisy devices).
 - **Printing** – Flags high severity when the Spooler service is stopped/disabled or when print hosts are unreachable, raises medium/high issues for offline queues and long-running jobs, warns on WSD ports, SNMP "public" communities, and legacy drivers, enforces Point-and-Print hardening posture, surfaces PrintService event storms and recurring driver crashes, and records GOOD findings for healthy spooler state, reachable printer ports, packaged drivers, and quiet event logs.
 
 ## Hardware Heuristics


### PR DESCRIPTION
## Summary
- add a dedicated collector that gathers UserPnp and Kernel-PnP device installation failures plus the SetupAPI log tail
- extend the Events analyzer to normalize VID/PID pairs and raise issues when USB device installs repeatedly fail
- document the new Events heuristic in the project README

## Testing
- Not run (pwsh not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd2278f954832d9d5f362865f85485