### PR TITLE
Add heuristic for Netlogon and LSASRV secure channel issues

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -54,6 +54,83 @@ function Invoke-EventsHeuristics {
                     Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Unable to read {0} event log, so noisy or unhealthy logs may be hidden." -f $logName) -Evidence $entries.Error -Subcategory $logSubcategory
                 }
             }
+
+            if ($payload.PSObject.Properties['System']) {
+                $systemEntries = @($payload.System)
+                $systemErrors = @($systemEntries | Where-Object { $_ -and $_.PSObject.Properties['Error'] })
+                if ($systemEntries.Count -gt 0 -and $systemErrors.Count -eq 0) {
+                    Write-HeuristicDebug -Source 'Events' -Message 'Analyzing System log for Netlogon/LSA issues'
+
+                    $now = Get-Date
+                    $recentThreshold = $now.AddDays(-7)
+                    $windowThreshold = $now.AddDays(-14)
+
+                    $windowEvents = New-Object System.Collections.Generic.List[pscustomobject]
+
+                    foreach ($entry in $systemEntries) {
+                        if (-not $entry) { continue }
+
+                        $timeValue = $null
+                        if ($entry.PSObject.Properties['TimeCreated']) {
+                            $rawTime = $entry.TimeCreated
+                            if ($rawTime -is [datetime]) {
+                                $timeValue = [datetime]$rawTime
+                            } else {
+                                [datetime]::TryParse([string]$rawTime, [ref]$timeValue) | Out-Null
+                            }
+                        }
+
+                        if (-not $timeValue) { continue }
+                        if ($timeValue -lt $windowThreshold) { continue }
+
+                        $provider = if ($entry.PSObject.Properties['ProviderName']) { [string]$entry.ProviderName } else { '' }
+                        $message = if ($entry.PSObject.Properties['Message']) { [string]$entry.Message } else { '' }
+                        $level = if ($entry.PSObject.Properties['LevelDisplayName']) { [string]$entry.LevelDisplayName } else { '' }
+                        $eventId = if ($entry.PSObject.Properties['Id']) { $entry.Id } else { $null }
+
+                        $isErrorLevel = ([string]::IsNullOrWhiteSpace($level) -or $level.Equals('Error', 'InvariantCultureIgnoreCase'))
+                        $isNetlogon = ($eventId -eq 5719 -and $provider -and ($provider -match '(?i)netlogon'))
+                        $lsaProviderMatch = ($provider -match '(?i)lsasrv' -or $provider -match '(?i)microsoft-windows-security-kerberos')
+                        $messageContainsLsa = ($message -match '(?i)\bLSASRV\b')
+                        $isLsa = ($isErrorLevel -and ($lsaProviderMatch -or $messageContainsLsa))
+
+                        if (-not $isNetlogon -and -not $isLsa) { continue }
+
+                        $windowEvents.Add([pscustomobject]@{
+                            Id            = if ($eventId -ne $null) { [int]$eventId } else { $null }
+                            TimeCreated   = $timeValue
+                            ProviderName  = $provider
+                            Level         = $level
+                            Type          = if ($isNetlogon) { 'NETLOGON' } else { 'LSASRV' }
+                        }) | Out-Null
+                    }
+
+                    if ($windowEvents.Count -gt 0) {
+                        $recentEvents = @($windowEvents | Where-Object { $_.TimeCreated -ge $recentThreshold })
+                        if ($recentEvents.Count -ge 3) {
+                            $olderEvents = @($windowEvents | Where-Object { $_.TimeCreated -lt $recentThreshold })
+                            $lsaEvents = @($windowEvents | Where-Object { $_.Type -eq 'LSASRV' })
+
+                            $eventIdSet = @($recentEvents | Where-Object { $_.Id -ne $null } | ForEach-Object { $_.Id } | Sort-Object -Unique)
+                            $lastEvent = $recentEvents | Sort-Object TimeCreated -Descending | Select-Object -First 1
+                            $lastUtc = if ($lastEvent -and $lastEvent.TimeCreated) { $lastEvent.TimeCreated.ToUniversalTime().ToString('o') } else { $null }
+
+                            $severity = 'medium'
+                            if ($olderEvents.Count -gt 0 -and $lsaEvents.Count -gt 0) {
+                                $severity = 'high'
+                            }
+
+                            $evidence = [ordered]@{
+                                eventIdSet = $eventIdSet
+                                count      = $recentEvents.Count
+                                lastUtc    = $lastUtc
+                            }
+
+                            Add-CategoryIssue -CategoryResult $result -Severity $severity -Title 'Netlogon secure channel / domain reachability issues' -Evidence $evidence -Subcategory 'Netlogon/LSA (Domain Join)'
+                        }
+                    }
+                }
+            }
         }
     } else {
         Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Event log artifact missing, so noisy or unhealthy logs may be hidden.' -Subcategory 'Collection'


### PR DESCRIPTION
## Summary
- add event-log heuristic to flag repeated NETLOGON 5719 and LSASRV authentication issues
- capture evidence metadata for event ids, counts, and most recent occurrence
- raise severity when LSASRV errors persist across the collection window

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd228cf9a4832d8a9c415407578ece