### PR TITLE
Add WMI activity heuristic to events analysis

### DIFF
--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -28,11 +28,51 @@ function Get-RecentEvents {
     }
 }
 
+function Get-WmiActivityEvents {
+    param(
+        [int]$WindowDays = 7
+    )
+
+    $logName = 'Microsoft-Windows-WMI-Activity/Operational'
+    $startTime = (Get-Date).AddDays(-[math]::Abs($WindowDays))
+
+    try {
+        $filter = @{
+            LogName   = $logName
+            Id        = @(10, 5858, 5859)
+            StartTime = $startTime
+        }
+
+        return Get-WinEvent -FilterHashtable $filter -ErrorAction Stop |
+            Sort-Object -Property TimeCreated -Descending |
+            ForEach-Object {
+                $message = $_.Message
+                if ($message -and $message.Length -gt 200) {
+                    $message = $message.Substring(0, 200)
+                }
+
+                [pscustomobject]@{
+                    TimeCreated      = $_.TimeCreated
+                    Id               = $_.Id
+                    LevelDisplayName = $_.LevelDisplayName
+                    ProviderName     = $_.ProviderName
+                    Message          = $message
+                }
+            }
+    } catch {
+        return [PSCustomObject]@{
+            LogName = $logName
+            Error   = $_.Exception.Message
+        }
+    }
+}
+
 function Invoke-Main {
     $payload = [ordered]@{
         System      = Get-RecentEvents -LogName 'System'
         Application = Get-RecentEvents -LogName 'Application'
         GroupPolicy = Get-RecentEvents -LogName 'Microsoft-Windows-GroupPolicy/Operational' -MaxEvents 200
+        WmiActivity = Get-WmiActivityEvents
     }
 
     $result = New-CollectorMetadata -Payload $payload


### PR DESCRIPTION
## Summary
- collect Microsoft-Windows-WMI-Activity Operational events for common failure IDs within a seven day window
- surface a medium severity issue in the Events category when repeated WMI operation errors are detected, including contextual evidence

## Testing
- `pwsh -NoLogo -Command "Set-StrictMode -Version Latest; . '$PWD/Analyzers/AnalyzerCommon.ps1'; . '$PWD/Analyzers/Heuristics/Events.ps1'"` *(fails: pwsh not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd22872f9c832dbad4c96928b76c05