### PR TITLE
Add DNS client event heuristic for intermittent DNS failures

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -5,6 +5,143 @@
 
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
 
+function ConvertTo-EventArray {
+    param($Value)
+
+    if ($null -eq $Value) { return @() }
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string]) -and -not ($Value -is [hashtable])) {
+        $items = @()
+        foreach ($item in $Value) {
+            if ($null -ne $item) { $items += $item }
+        }
+        return $items
+    }
+
+    return @($Value)
+}
+
+function ConvertTo-TrimmedStringArray {
+    param($Value)
+
+    if ($null -eq $Value) { return @() }
+
+    if ($Value -is [string]) {
+        $trimmed = $Value.Trim()
+        if ($trimmed) { return @($trimmed) }
+        return @()
+    }
+
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string])) {
+        $results = @()
+        foreach ($item in $Value) {
+            $results += ConvertTo-TrimmedStringArray $item
+        }
+        return $results | Where-Object { $_ -and $_.Trim() }
+    }
+
+    $text = [string]$Value
+    if ($text) {
+        $trimmed = $text.Trim()
+        if ($trimmed) { return @($trimmed) }
+    }
+
+    return @()
+}
+
+function Resolve-EventDateTime {
+    param($Value)
+
+    if ($null -eq $Value) { return $null }
+
+    if ($Value -is [datetime]) {
+        try { return $Value.ToUniversalTime() } catch { return $Value }
+    }
+
+    $text = [string]$Value
+    if (-not [string]::IsNullOrWhiteSpace($text)) {
+        $parsed = $null
+        if ([datetime]::TryParse($text, [ref]$parsed)) {
+            try { return $parsed.ToUniversalTime() } catch { return $parsed }
+        }
+    }
+
+    return $null
+}
+
+function Resolve-VpnBaselineState {
+    param($Context)
+
+    $artifactNames = @('vpn-baseline', 'vpn', 'network-baseline')
+    foreach ($name in $artifactNames) {
+        $artifact = Get-AnalyzerArtifact -Context $Context -Name $name
+        if (-not $artifact) { continue }
+
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $artifact)
+        if (-not $payload) { continue }
+
+        $candidates = ConvertTo-EventArray $payload
+        if ($payload.PSObject -and $payload.PSObject.Properties['Vpn']) {
+            $candidates += ConvertTo-EventArray $payload.Vpn
+        }
+        if ($payload.PSObject -and $payload.PSObject.Properties['Baseline']) {
+            $candidates += ConvertTo-EventArray $payload.Baseline
+        }
+
+        foreach ($candidate in $candidates) {
+            if (-not $candidate) { continue }
+
+            $propertyTable = @{}
+            if ($candidate -is [hashtable]) {
+                foreach ($key in $candidate.Keys) {
+                    if ($null -eq $key) { continue }
+                    $propertyTable[$key.ToString()] = $candidate[$key]
+                }
+            } elseif ($candidate.PSObject) {
+                foreach ($prop in $candidate.PSObject.Properties) {
+                    if (-not $prop) { continue }
+                    $propertyTable[$prop.Name] = $prop.Value
+                }
+            }
+
+            if ($propertyTable.Count -eq 0) { continue }
+
+            $connectedValue = $null
+            foreach ($key in @('Connected','IsConnected','Status')) {
+                if ($propertyTable.ContainsKey($key)) {
+                    $connectedValue = $propertyTable[$key]
+                    break
+                }
+            }
+
+            $corpServers = @()
+            foreach ($key in @('CorporateDnsServers','CorporateDns','ExpectedDnsServers','DnsServers','Servers')) {
+                if ($propertyTable.ContainsKey($key)) {
+                    $corpServers = ConvertTo-TrimmedStringArray $propertyTable[$key]
+                    if ($corpServers.Count -gt 0) { break }
+                }
+            }
+
+            $connectedBool = $null
+            if ($connectedValue -is [bool]) {
+                $connectedBool = [bool]$connectedValue
+            } elseif ($connectedValue -is [string]) {
+                $normalized = $connectedValue.Trim().ToLowerInvariant()
+                if ($normalized -in @('true','yes','connected','online','up')) { $connectedBool = $true }
+                elseif ($normalized -in @('false','no','disconnected','offline','down')) { $connectedBool = $false }
+            }
+
+            if ($connectedBool -ne $null -or ($corpServers -and $corpServers.Count -gt 0)) {
+                return [pscustomobject]@{
+                    Connected           = $connectedBool
+                    CorporateDnsServers = $corpServers
+                }
+            }
+        }
+    }
+
+    return $null
+}
+
 function Invoke-EventsHeuristics {
     param(
         [Parameter(Mandatory)]
@@ -27,6 +164,9 @@ function Invoke-EventsHeuristics {
             HasPayload = [bool]$payload
         })
         if ($payload) {
+            $vpnBaseline = $null
+            $vpnBaselineChecked = $false
+
             foreach ($logName in @('System','Application','GroupPolicy')) {
                 Write-HeuristicDebug -Source 'Events' -Message ('Inspecting {0} log entries' -f $logName)
                 if (-not $payload.PSObject.Properties[$logName]) { continue }
@@ -52,6 +192,143 @@ function Invoke-EventsHeuristics {
                 } elseif ($entries.Error) {
                     $logSubcategory = ("{0} Event Log" -f $logName)
                     Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Unable to read {0} event log, so noisy or unhealthy logs may be hidden." -f $logName) -Evidence $entries.Error -Subcategory $logSubcategory
+                }
+            }
+
+            if ($payload.PSObject.Properties['DnsClientOperational']) {
+                $dnsEntriesRaw = $payload.DnsClientOperational
+                $dnsError = $null
+                if ($dnsEntriesRaw -and $dnsEntriesRaw.PSObject -and $dnsEntriesRaw.PSObject.Properties['Error']) {
+                    $dnsError = $dnsEntriesRaw.Error
+                }
+
+                if ($dnsError) {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Unable to read Microsoft-Windows-DNS-Client/Operational log, so DNS resolution issues may be hidden.' -Evidence $dnsError -Subcategory 'DNS Client Events'
+                } else {
+                    $dnsEntries = ConvertTo-EventArray $dnsEntriesRaw
+                    $nowUtc = (Get-Date).ToUniversalTime()
+                    $cutoffUtc = $nowUtc.AddHours(-24)
+                    $recentEvents = @()
+
+                    foreach ($entry in $dnsEntries) {
+                        if (-not $entry) { continue }
+                        if ($entry.PSObject -and $entry.PSObject.Properties['Error'] -and $entry.Error) { continue }
+
+                        $timeUtc = $null
+                        if ($entry.PSObject -and $entry.PSObject.Properties['TimeCreated']) {
+                            $timeUtc = Resolve-EventDateTime $entry.TimeCreated
+                        } elseif ($entry.PSObject -and $entry.PSObject.Properties['Time']) {
+                            $timeUtc = Resolve-EventDateTime $entry.Time
+                        }
+
+                        if (-not $timeUtc) { continue }
+                        if ($timeUtc -lt $cutoffUtc -or $timeUtc -gt $nowUtc) { continue }
+
+                        $name = $null
+                        if ($entry.PSObject) {
+                            foreach ($nameProperty in @('QueryName','Name','MessageSnippet')) {
+                                if ($entry.PSObject.Properties[$nameProperty] -and $entry.$nameProperty) {
+                                    $candidateName = [string]$entry.$nameProperty
+                                    if ($candidateName) { $name = $candidateName.Trim() }
+                                    if ($name) { break }
+                                }
+                            }
+
+                            if (-not $name -and $entry.PSObject.Properties['Message'] -and $entry.Message) {
+                                $candidateName = [string]$entry.Message
+                                if ($candidateName) {
+                                    $candidateName = $candidateName.Trim()
+                                    if ($candidateName.Length -gt 150) { $candidateName = $candidateName.Substring(0,150) }
+                                    if ($candidateName) { $name = $candidateName }
+                                }
+                            }
+                        }
+
+                        if (-not $name) { $name = 'Unknown query' }
+
+                        $server = $null
+                        if ($entry.PSObject) {
+                            foreach ($serverProperty in @('ServerAddress','Server','ServerIp','ServerIPAddress')) {
+                                if ($entry.PSObject.Properties[$serverProperty] -and $entry.$serverProperty) {
+                                    $candidateServer = [string]$entry.$serverProperty
+                                    if ($candidateServer) { $server = $candidateServer.Trim() }
+                                    if ($server) { break }
+                                }
+                            }
+
+                            if (-not $server -and $entry.PSObject.Properties['Servers'] -and $entry.Servers) {
+                                $serverCandidates = ConvertTo-TrimmedStringArray $entry.Servers
+                                if ($serverCandidates.Count -gt 0) { $server = $serverCandidates[0] }
+                            }
+                        }
+
+                        if (-not $server) { $server = 'Unknown server' }
+
+                        $recentEvents += [pscustomobject]@{
+                            Name    = $name
+                            Server  = $server
+                            TimeUtc = $timeUtc
+                        }
+                    }
+
+                    if ($recentEvents.Count -ge 5) {
+                        $groups = $recentEvents | Group-Object -Property { '{0}|{1}' -f ($_.Name.ToLowerInvariant()), ($_.Server.ToLowerInvariant()) }
+                        $groupEvidence = @()
+                        foreach ($group in ($groups | Sort-Object Count -Descending)) {
+                            if (-not $group) { continue }
+                            $first = $group.Group | Select-Object -First 1
+                            if (-not $first) { continue }
+                            $groupEvidence += [ordered]@{
+                                name   = $first.Name
+                                server = $first.Server
+                                count  = $group.Count
+                            }
+                            if ($groupEvidence.Count -ge 5) { break }
+                        }
+
+                        $sampleNames = ($recentEvents | Select-Object -ExpandProperty Name -Unique | Select-Object -First 5)
+                        $servers = ($recentEvents | Select-Object -ExpandProperty Server -Unique | Select-Object -First 5)
+                        $lastEvent = ($recentEvents | Sort-Object TimeUtc -Descending | Select-Object -First 1)
+                        $lastUtcText = if ($lastEvent -and $lastEvent.TimeUtc) { $lastEvent.TimeUtc.ToString('u') } else { $null }
+
+                        $evidence = [ordered]@{
+                            occurrences24h = $recentEvents.Count
+                            sampleNames    = $sampleNames
+                            servers        = $servers
+                            lastUtc        = $lastUtcText
+                        }
+
+                        if ($groupEvidence.Count -gt 0) { $evidence['groups'] = $groupEvidence }
+
+                        if (-not $vpnBaselineChecked) {
+                            $vpnBaseline = Resolve-VpnBaselineState $Context
+                            $vpnBaselineChecked = $true
+                        }
+
+                        if ($vpnBaseline -and $vpnBaseline.Connected) {
+                            $corpServers = ConvertTo-TrimmedStringArray $vpnBaseline.CorporateDnsServers
+                            if ($corpServers.Count -gt 0) {
+                                $normalizedServers = $servers | ForEach-Object {
+                                    $candidate = if ($_ -is [string]) { $_ } else { [string]$_ }
+                                    if ($candidate) {
+                                        $trimmed = $candidate.Trim()
+                                        if ($trimmed) { $trimmed.ToLowerInvariant() }
+                                    }
+                                }
+                                $normalizedServers = $normalizedServers | Where-Object { $_ }
+                                $normalizedCorp = $corpServers | ForEach-Object { $_.ToLowerInvariant() }
+                                $overlap = $false
+                                foreach ($serverValue in $normalizedServers) {
+                                    if ($normalizedCorp -contains $serverValue) { $overlap = $true; break }
+                                }
+                                if (-not $overlap) {
+                                    $evidence['tags'] = @('Possible DNS leak')
+                                }
+                            }
+                        }
+
+                        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'DNS resolution timeouts observed' -Evidence $evidence -Subcategory 'DNS Client Events'
+                    }
                 }
             }
         }

--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -28,11 +28,114 @@ function Get-RecentEvents {
     }
 }
 
+function Get-DnsClientTimeoutEvents {
+    param(
+        [datetime]$StartTime = (Get-Date).AddDays(-14),
+
+        [int]$MaxEvents = 400
+    )
+
+    $filter = @{ LogName = 'Microsoft-Windows-DNS-Client/Operational'; Id = 1014 }
+    if ($StartTime) { $filter['StartTime'] = $StartTime }
+
+    try {
+        $events = Get-WinEvent -FilterHashtable $filter -ErrorAction Stop | Sort-Object TimeCreated -Descending
+        if ($MaxEvents -gt 0) {
+            $events = $events | Select-Object -First $MaxEvents
+        }
+    } catch {
+        return [PSCustomObject]@{
+            LogName = 'Microsoft-Windows-DNS-Client/Operational'
+            Error   = $_.Exception.Message
+        }
+    }
+
+    $results = New-Object System.Collections.Generic.List[pscustomobject]
+    foreach ($event in $events) {
+        if (-not $event) { continue }
+
+        $queryName = $null
+        $serverAddress = $null
+
+        try {
+            $xml = [xml]$event.ToXml()
+        } catch {
+            $xml = $null
+        }
+
+        if ($xml -and $xml.Event -and $xml.Event.EventData) {
+            foreach ($dataNode in $xml.Event.EventData.Data) {
+                if (-not $dataNode) { continue }
+
+                $nameAttr = $null
+                if ($dataNode.PSObject.Properties['Name']) {
+                    $nameAttr = [string]$dataNode.Name
+                }
+
+                $textValue = $null
+                if ($dataNode.PSObject.Properties['#text']) {
+                    $textValue = [string]$dataNode.'#text'
+                } elseif ($dataNode.PSObject.Properties['InnerText']) {
+                    $textValue = [string]$dataNode.InnerText
+                } else {
+                    $textValue = [string]$dataNode
+                }
+
+                if ($textValue) {
+                    $textValue = $textValue.Trim()
+                }
+
+                if (-not $nameAttr) { continue }
+
+                switch -Regex ($nameAttr) {
+                    '^Query(Name)?$' {
+                        if (-not $queryName -and $textValue) { $queryName = $textValue }
+                        continue
+                    }
+                    '^Name$' {
+                        if (-not $queryName -and $textValue) { $queryName = $textValue }
+                        continue
+                    }
+                    'Server(Address|IP|IPAddress)?$' {
+                        if (-not $serverAddress -and $textValue) { $serverAddress = $textValue }
+                        continue
+                    }
+                }
+            }
+        }
+
+        $messageSnippet = $null
+        if ($event.Message) {
+            $messageSnippet = [string]$event.Message
+            if ($messageSnippet) {
+                $messageSnippet = $messageSnippet.Trim()
+                if ($messageSnippet.Length -gt 150) {
+                    $messageSnippet = $messageSnippet.Substring(0, 150)
+                }
+            }
+        }
+
+        $results.Add([PSCustomObject]@{
+            TimeCreated    = $event.TimeCreated
+            Id             = $event.Id
+            LevelDisplayName = $event.LevelDisplayName
+            ProviderName   = $event.ProviderName
+            Message        = $event.Message
+            QueryName      = $queryName
+            ServerAddress  = $serverAddress
+            MessageSnippet = $messageSnippet
+        }) | Out-Null
+    }
+
+    return $results.ToArray()
+}
+
 function Invoke-Main {
     $payload = [ordered]@{
         System      = Get-RecentEvents -LogName 'System'
         Application = Get-RecentEvents -LogName 'Application'
         GroupPolicy = Get-RecentEvents -LogName 'Microsoft-Windows-GroupPolicy/Operational' -MaxEvents 200
+        DnsClientOperational = Get-DnsClientTimeoutEvents
     }
 
     $result = New-CollectorMetadata -Payload $payload


### PR DESCRIPTION
## Summary
- collect Microsoft-Windows-DNS-Client/Operational 1014 events including query and server context
- analyze DNS client failures to emit a medium severity issue with tagging when repeated timeouts suggest a possible DNS leak

## Testing
- not run (PowerShell is unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd2205017c832dbd22b0a278821ae4