### PR TITLE
Add user profile temporary profile heuristic

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -59,5 +59,154 @@ function Invoke-EventsHeuristics {
         Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Event log artifact missing, so noisy or unhealthy logs may be hidden.' -Subcategory 'Collection'
     }
 
+    if ($payload -and $payload.PSObject.Properties['UserProfileService']) {
+        $userProfile = $payload.UserProfileService
+        $rawEvents = @()
+        if ($userProfile -and $userProfile.PSObject.Properties['Events']) {
+            $rawEvents = @($userProfile.Events)
+        }
+
+        $eventCount = $rawEvents.Count
+        $logName = if ($userProfile -and $userProfile.PSObject.Properties['LogName']) { [string]$userProfile.LogName } else { 'Unknown' }
+        Add-CategoryCheck -CategoryResult $result -Name 'User profile events (14d)' -Status ([string]$eventCount) -Details ("Log: {0}" -f $logName)
+
+        $parsedEvents = [System.Collections.Generic.List[pscustomobject]]::new()
+        foreach ($evt in $rawEvents) {
+            if (-not $evt) { continue }
+
+            $id = $null
+            if ($evt.PSObject.Properties['Id'] -and $evt.Id) {
+                try { $id = [int]$evt.Id } catch { $id = $null }
+            }
+
+            $timeUtc = $null
+            if ($evt.PSObject.Properties['TimeCreated'] -and $evt.TimeCreated) {
+                $rawTime = $evt.TimeCreated
+                if ($rawTime -is [datetime]) {
+                    try { $timeUtc = $rawTime.ToUniversalTime() } catch { $timeUtc = $rawTime }
+                } elseif ($rawTime -is [string]) {
+                    try {
+                        $parsed = [datetime]::Parse($rawTime)
+                        $timeUtc = $parsed.ToUniversalTime()
+                    } catch {
+                    }
+                }
+            }
+
+            $sidTail = $null
+            if ($evt.PSObject.Properties['SidTail']) { $sidTail = [string]$evt.SidTail }
+
+            $profilePath = $null
+            if ($evt.PSObject.Properties['ProfilePath']) { $profilePath = [string]$evt.ProfilePath }
+
+            $recordId = $null
+            if ($evt.PSObject.Properties['RecordId']) { $recordId = $evt.RecordId }
+
+            $parsedEvents.Add([pscustomobject]@{
+                Id          = $id
+                TimeUtc     = $timeUtc
+                SidTail     = $sidTail
+                ProfilePath = $profilePath
+                RecordId    = $recordId
+            }) | Out-Null
+        }
+
+        $nowUtc = (Get-Date).ToUniversalTime()
+        $sevenDaysAgo = $nowUtc.AddDays(-7)
+        $fourteenDaysAgo = $nowUtc.AddDays(-14)
+        $tempProfileIds = @(1511, 1515)
+        $trackedEventIds = @(1511, 1515, 1518, 1530, 1533)
+
+        $recentTempProfiles = $parsedEvents | Where-Object { $_.Id -in $tempProfileIds -and (-not $_.TimeUtc -or $_.TimeUtc -ge $sevenDaysAgo) }
+        if ($recentTempProfiles.Count -gt 0) {
+            $aggregated = @{}
+            $index = 0
+            foreach ($entry in $recentTempProfiles) {
+                $keyParts = [System.Collections.Generic.List[string]]::new()
+                if ($entry.SidTail) { $null = $keyParts.Add(('sid:{0}' -f $entry.SidTail)) }
+                if ($entry.ProfilePath) { $null = $keyParts.Add(('path:{0}' -f $entry.ProfilePath)) }
+                if ($keyParts.Count -eq 0) {
+                    if ($entry.RecordId) {
+                        $null = $keyParts.Add(('record:{0}' -f $entry.RecordId))
+                    } elseif ($entry.TimeUtc) {
+                        $null = $keyParts.Add(('time:{0:O}' -f $entry.TimeUtc))
+                    } else {
+                        $null = $keyParts.Add(('index:{0}' -f $index))
+                    }
+                }
+
+                $key = ($keyParts -join '|')
+                if (-not $aggregated.ContainsKey($key)) {
+                    $aggregated[$key] = [ordered]@{
+                        SidTail     = $entry.SidTail
+                        ProfilePath = $entry.ProfilePath
+                        LastUtc     = $entry.TimeUtc
+                    }
+                } else {
+                    if (-not $aggregated[$key].SidTail -and $entry.SidTail) { $aggregated[$key].SidTail = $entry.SidTail }
+                    if (-not $aggregated[$key].ProfilePath -and $entry.ProfilePath) { $aggregated[$key].ProfilePath = $entry.ProfilePath }
+                    if ($entry.TimeUtc -and ($null -eq $aggregated[$key].LastUtc -or $entry.TimeUtc -gt $aggregated[$key].LastUtc)) {
+                        $aggregated[$key].LastUtc = $entry.TimeUtc
+                    }
+                }
+
+                $index++
+            }
+
+            $evidenceLines = [System.Collections.Generic.List[string]]::new()
+            foreach ($aggregateEntry in $aggregated.GetEnumerator()) {
+                $details = $aggregateEntry.Value
+                $parts = [System.Collections.Generic.List[string]]::new()
+                if ($details.SidTail) { $null = $parts.Add(('sidTail={0}' -f $details.SidTail)) }
+                if ($details.ProfilePath) { $null = $parts.Add(('profilePath={0}' -f $details.ProfilePath)) }
+                if ($details.LastUtc) { $null = $parts.Add(('lastUtc={0}' -f $details.LastUtc.ToString('u'))) }
+                if ($parts.Count -eq 0) { $null = $parts.Add('details=unavailable') }
+                $null = $evidenceLines.Add($parts -join '; ')
+            }
+
+            $evidence = if ($evidenceLines.Count -gt 0) { $evidenceLines -join "`n" } else { 'No additional evidence captured.' }
+            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Temporary profile loaded' -Evidence $evidence -Subcategory 'User Profile'
+        }
+
+        $profileEntries = @()
+        $profileListError = $null
+        if ($userProfile -and $userProfile.PSObject.Properties['ProfileList']) {
+            $profileList = $userProfile.ProfileList
+            if ($profileList -and $profileList.PSObject.Properties['Entries']) {
+                $profileEntries = @($profileList.Entries)
+            }
+            if ($profileList -and $profileList.PSObject.Properties['Error']) {
+                $profileListError = $profileList.Error
+            }
+        }
+
+        $abnormalStates = [System.Collections.Generic.List[object]]::new()
+        foreach ($profile in $profileEntries) {
+            if (-not $profile) { continue }
+            if (-not $profile.PSObject.Properties['State']) { continue }
+            $rawState = $profile.State
+            if ($null -eq $rawState) { continue }
+            $stateValue = $null
+            try {
+                $stateValue = [int]$rawState
+            } catch {
+                continue
+            }
+            if ($stateValue -ne 0) {
+                $abnormalStates.Add($profile) | Out-Null
+            }
+        }
+
+        $recentTrackedEvents = $parsedEvents | Where-Object { $_.Id -in $trackedEventIds -and $_.TimeUtc -and $_.TimeUtc -ge $fourteenDaysAgo }
+
+        if (-not $profileListError -and $profileEntries.Count -gt 0 -and $abnormalStates.Count -eq 0 -and $recentTrackedEvents.Count -eq 0 -and $recentTempProfiles.Count -eq 0) {
+            Add-CategoryNormal -CategoryResult $result -Title 'Profiles healthy — no 1511/1515/1518/1530/1533 in last 14 days and ProfileList states normal.' -Subcategory 'User Profile'
+        }
+
+        if ($profileListError) {
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'ProfileList registry capture failed, so profile health is unknown.' -Evidence $profileListError -Subcategory 'User Profile'
+        }
+    }
+
     return $result
 }

--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -28,15 +28,189 @@ function Get-RecentEvents {
     }
 }
 
+function Get-ProfileListSnapshot {
+    $profileRoot = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList'
+
+    if (-not (Test-Path -LiteralPath $profileRoot)) {
+        return [ordered]@{
+            Entries = @()
+            Error   = $null
+        }
+    }
+
+    try {
+        $entries = Get-ChildItem -LiteralPath $profileRoot -ErrorAction Stop | ForEach-Object {
+            $item = $_
+            $properties = $null
+            try {
+                $properties = Get-ItemProperty -LiteralPath $item.PSPath -ErrorAction Stop
+            } catch {
+            }
+
+            $sid = $item.PSChildName
+            $profilePath = $null
+            $state = $null
+            $flags = $null
+
+            if ($properties) {
+                if ($properties.PSObject.Properties['ProfileImagePath']) {
+                    $profilePath = [string]$properties.ProfileImagePath
+                }
+                if ($properties.PSObject.Properties['State']) {
+                    $state = [int64]$properties.State
+                }
+                if ($properties.PSObject.Properties['Flags']) {
+                    $flags = [int64]$properties.Flags
+                }
+            }
+
+            [pscustomobject]@{
+                Sid              = $sid
+                SidTail          = if ($sid) { ($sid -split '-')[-1] } else { $null }
+                ProfileImagePath = $profilePath
+                State            = $state
+                Flags            = $flags
+                LastWriteTimeUtc = $item.LastWriteTime.ToUniversalTime().ToString('o')
+            }
+        }
+
+        return [ordered]@{
+            Entries = $entries
+            Error   = $null
+        }
+    } catch {
+        return [ordered]@{
+            Entries = @()
+            Error   = $_.Exception.Message
+        }
+    }
+}
+
+function Get-UserProfileServiceEvents {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$ProfileMap,
+
+        [int]$CollectionWindowDays = 14
+    )
+
+    $eventIds = @(1511, 1515, 1518, 1530, 1533)
+    $windowStart = (Get-Date).AddDays(-1 * [double]$CollectionWindowDays)
+    $logCandidates = @('Microsoft-Windows-User Profile Service/Operational', 'System')
+    $errors = New-Object System.Collections.Generic.List[pscustomobject]
+    $selectedLog = $null
+    $collectedEvents = @()
+
+    foreach ($logName in $logCandidates) {
+        try {
+            $filter = @{
+                LogName   = $logName
+                Id        = $eventIds
+                StartTime = $windowStart
+            }
+
+            $events = @(Get-WinEvent -FilterHashtable $filter -ErrorAction Stop | Sort-Object -Property TimeCreated -Descending)
+            $selectedLog = $logName
+
+            if ($events.Count -eq 0) {
+                $collectedEvents = @()
+            } else {
+                $collectedEvents = foreach ($evt in $events) {
+                    $sid = $null
+
+                    if ($evt.PSObject.Properties['UserId'] -and $evt.UserId) {
+                        try {
+                            $sid = $evt.UserId.Value
+                        } catch {
+                            $sid = [string]$evt.UserId
+                        }
+                    }
+
+                    if (-not $sid -and $evt.Properties) {
+                        foreach ($prop in $evt.Properties) {
+                            if ($null -eq $prop) { continue }
+                            $value = $prop.Value
+                            if ($value -is [System.Security.Principal.SecurityIdentifier]) {
+                                $sid = $value.Value
+                                break
+                            }
+                            if ($value -is [string] -and $value -match '^S-1-5-') {
+                                $sid = $value
+                                break
+                            }
+                        }
+                    }
+
+                    $profilePath = $null
+                    if ($sid -and $ProfileMap.ContainsKey($sid)) {
+                        $profilePath = $ProfileMap[$sid].ProfileImagePath
+                    }
+
+                    [pscustomobject]@{
+                        TimeCreated       = $evt.TimeCreated
+                        Id                = $evt.Id
+                        LevelDisplayName  = $evt.LevelDisplayName
+                        ProviderName      = if ($evt.PSObject.Properties['ProviderName']) { $evt.ProviderName } else { $null }
+                        Message           = $evt.Message
+                        RecordId          = if ($evt.PSObject.Properties['RecordId']) { $evt.RecordId } else { $null }
+                        Sid               = $sid
+                        SidTail           = if ($sid) { ($sid -split '-')[-1] } else { $null }
+                        ProfilePath       = $profilePath
+                    }
+                }
+            }
+
+            if ($errors.Count -gt 0) {
+                $errors.Clear()
+            }
+
+            break
+        } catch {
+            $errors.Add([pscustomobject]@{
+                LogName = $logName
+                Error   = $_.Exception.Message
+            }) | Out-Null
+        }
+    }
+
+    if (-not $selectedLog) {
+        $selectedLog = $logCandidates[-1]
+    }
+
+    return [ordered]@{
+        LogName              = $selectedLog
+        Events               = $collectedEvents
+        CollectionWindowDays = $CollectionWindowDays
+        Errors               = if ($errors.Count -gt 0) { $errors } else { $null }
+    }
+}
+
 function Invoke-Main {
+    $profileSnapshot = Get-ProfileListSnapshot
+    $profileMap = @{}
+    foreach ($entry in $profileSnapshot.Entries) {
+        if ($entry.Sid) {
+            $profileMap[$entry.Sid] = $entry
+        }
+    }
+
+    $userProfileEvents = Get-UserProfileServiceEvents -ProfileMap $profileMap
+
     $payload = [ordered]@{
-        System      = Get-RecentEvents -LogName 'System'
-        Application = Get-RecentEvents -LogName 'Application'
-        GroupPolicy = Get-RecentEvents -LogName 'Microsoft-Windows-GroupPolicy/Operational' -MaxEvents 200
+        System            = Get-RecentEvents -LogName 'System'
+        Application       = Get-RecentEvents -LogName 'Application'
+        GroupPolicy       = Get-RecentEvents -LogName 'Microsoft-Windows-GroupPolicy/Operational' -MaxEvents 200
+        UserProfileService = [ordered]@{
+            Events               = $userProfileEvents.Events
+            LogName              = $userProfileEvents.LogName
+            CollectionWindowDays = $userProfileEvents.CollectionWindowDays
+            Errors               = $userProfileEvents.Errors
+            ProfileList          = $profileSnapshot
+        }
     }
 
     $result = New-CollectorMetadata -Payload $payload
-    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'events.json' -Data $result -Depth 6
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'events.json' -Data $result -Depth 8
     Write-Output $outputPath
 }
 


### PR DESCRIPTION
## Summary
- extend the events collector to capture User Profile Service temporary profile activity and related ProfileList registry data
- surface a new Events category heuristic that flags recent temporary profile usage and reports healthy profile states when no issues are detected

## Testing
- Not run (pwsh unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd220f0924832db52265955e4177af