### PR TITLE
Add Task Scheduler misfire detection to Events analyzer

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -5,6 +5,51 @@
 
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
 
+function Get-TaskSchedulerMaskedName {
+    param([string]$TaskName)
+
+    if ([string]::IsNullOrWhiteSpace($TaskName)) { return $null }
+
+    $hashAlgorithm = $null
+    try {
+        $hashAlgorithm = [System.Security.Cryptography.SHA256]::Create()
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($TaskName)
+        $hash = $hashAlgorithm.ComputeHash($bytes)
+        return ([System.BitConverter]::ToString($hash)).Replace('-', '').ToLowerInvariant()
+    } catch {
+        return $null
+    } finally {
+        if ($hashAlgorithm) { $hashAlgorithm.Dispose() }
+    }
+}
+
+function ConvertTo-EventDateTime {
+    param($Value)
+
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [datetime]) { return [datetime]$Value }
+
+    $text = $Value.ToString()
+    if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+
+    $parsed = [datetime]::MinValue
+    $styles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+    if ([datetime]::TryParse($text, [System.Globalization.CultureInfo]::InvariantCulture, $styles, [ref]$parsed)) {
+        return $parsed
+    }
+
+    $styles = [System.Globalization.DateTimeStyles]::AssumeLocal
+    if ([datetime]::TryParse($text, [System.Globalization.CultureInfo]::InvariantCulture, $styles, [ref]$parsed)) {
+        return $parsed
+    }
+
+    try {
+        return [datetime]::Parse($text)
+    } catch {
+        return $null
+    }
+}
+
 function Invoke-EventsHeuristics {
     param(
         [Parameter(Mandatory)]
@@ -52,6 +97,75 @@ function Invoke-EventsHeuristics {
                 } elseif ($entries.Error) {
                     $logSubcategory = ("{0} Event Log" -f $logName)
                     Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Unable to read {0} event log, so noisy or unhealthy logs may be hidden." -f $logName) -Evidence $entries.Error -Subcategory $logSubcategory
+                }
+            }
+
+            if ($payload.PSObject.Properties['TaskScheduler']) {
+                $schedulerEntries = $payload.TaskScheduler
+                if ($schedulerEntries -and -not $schedulerEntries.Error) {
+                    $monitoredIds = @(101, 107, 414)
+                    $windowUtc = (Get-Date).ToUniversalTime().AddDays(-7)
+                    $normalized = foreach ($entry in $schedulerEntries) {
+                        if (-not $entry) { continue }
+                        if (-not $entry.PSObject.Properties['TaskName']) { continue }
+                        $taskName = [string]$entry.TaskName
+                        if ([string]::IsNullOrWhiteSpace($taskName)) { continue }
+
+                        $eventId = $null
+                        if ($entry.PSObject.Properties['Id']) {
+                            try { $eventId = [int]$entry.Id } catch { $eventId = $null }
+                        }
+                        if ($null -eq $eventId -or ($monitoredIds -notcontains $eventId)) { continue }
+
+                        $timeValue = $null
+                        if ($entry.PSObject.Properties['TimeCreated']) {
+                            $timeValue = ConvertTo-EventDateTime -Value $entry.TimeCreated
+                        }
+                        if (-not $timeValue) { continue }
+                        $timeUtc = $timeValue.ToUniversalTime()
+                        if ($timeUtc -lt $windowUtc) { continue }
+
+                        [pscustomobject]@{
+                            TaskName = $taskName
+                            EventId  = $eventId
+                            TimeUtc  = $timeUtc
+                        }
+                    }
+
+                    if ($normalized) {
+                        $groups = $normalized | Group-Object -Property TaskName -CaseSensitive:$false
+                        $findings = New-Object System.Collections.Generic.List[object]
+
+                        foreach ($group in $groups) {
+                            if (-not $group -or -not $group.Group) { continue }
+                            $eventCount = $group.Count
+                            if ($eventCount -lt 3) { continue }
+
+                            $representative = $group.Group | Select-Object -First 1
+                            $taskName = if ($representative) { [string]$representative.TaskName } else { $group.Name }
+
+                            $lastUtc = $group.Group | Sort-Object -Property TimeUtc -Descending | Select-Object -First 1
+                            $lastUtcText = $null
+                            if ($lastUtc -and $lastUtc.TimeUtc) {
+                                $lastUtcText = $lastUtc.TimeUtc.ToString('yyyy-MM-ddTHH:mm:ssZ')
+                            }
+
+                            $maskedName = Get-TaskSchedulerMaskedName -TaskName $taskName
+
+                            $findings.Add([ordered]@{
+                                taskNameMasked = $maskedName
+                                count          = $eventCount
+                                lastUtc        = $lastUtcText
+                            }) | Out-Null
+                        }
+
+                        if ($findings.Count -gt 0) {
+                            $evidence = $findings | Sort-Object -Property count, lastUtc -Descending
+                            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Scheduled task failures detected' -Evidence $evidence -Subcategory 'Task Scheduler'
+                        }
+                    }
+                } elseif ($schedulerEntries.Error) {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Unable to read Task Scheduler operational log, so scheduled task failures may be hidden.' -Evidence $schedulerEntries.Error -Subcategory 'Task Scheduler'
                 }
             }
         }

--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -28,11 +28,69 @@ function Get-RecentEvents {
     }
 }
 
+function Get-TaskSchedulerTaskName {
+    param(
+        [Parameter(Mandatory)]
+        [System.Diagnostics.Eventing.Reader.EventRecord]$EventRecord
+    )
+
+    try {
+        $xml = [xml]$EventRecord.ToXml()
+        $taskNode = $xml.Event.EventData.Data | Where-Object { $_.Name -eq 'TaskName' } | Select-Object -First 1
+        if ($taskNode -and $taskNode.'#text') { return [string]$taskNode.'#text' }
+    } catch {
+        return $null
+    }
+
+    return $null
+}
+
+function Get-TaskSchedulerEvents {
+    param(
+        [int]$WindowDays = 7
+    )
+
+    $filter = @{
+        LogName   = 'Microsoft-Windows-TaskScheduler/Operational'
+        Id        = @(101, 107, 414)
+        StartTime = (Get-Date).AddDays(-1 * $WindowDays)
+    }
+
+    try {
+        $events = Get-WinEvent -FilterHashtable $filter -ErrorAction Stop
+    } catch {
+        return [PSCustomObject]@{
+            LogName = $filter.LogName
+            Error   = $_.Exception.Message
+        }
+    }
+
+    $results = New-Object System.Collections.Generic.List[object]
+
+    foreach ($event in $events) {
+        if (-not $event) { continue }
+        $taskName = $null
+        try { $taskName = Get-TaskSchedulerTaskName -EventRecord $event } catch { $taskName = $null }
+
+        $results.Add([PSCustomObject]@{
+            TimeCreated     = $event.TimeCreated
+            Id              = $event.Id
+            LevelDisplayName = $event.LevelDisplayName
+            ProviderName    = $event.ProviderName
+            Message         = $event.Message
+            TaskName        = $taskName
+        }) | Out-Null
+    }
+
+    return $results.ToArray()
+}
+
 function Invoke-Main {
     $payload = [ordered]@{
         System      = Get-RecentEvents -LogName 'System'
         Application = Get-RecentEvents -LogName 'Application'
         GroupPolicy = Get-RecentEvents -LogName 'Microsoft-Windows-GroupPolicy/Operational' -MaxEvents 200
+        TaskScheduler = Get-TaskSchedulerEvents -WindowDays 7
     }
 
     $result = New-CollectorMetadata -Payload $payload

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following sections list the analysis functions and issue card heuristics gro
 
 ## Services & Events Heuristics
 - **Services** – Issues adopt the per-service severity computed earlier (e.g., medium/high/critical for critical service failures) and explicitly raise high severity when legacy essentials like Dhcp or WinDefend are stopped.
-- **Events** – Adds informational issues for logs showing five or more errors and low-severity issues for logs with at least ten warnings in the sampled data.
+- **Events** – Adds informational issues for logs showing five or more errors and low-severity issues for logs with at least ten warnings in the sampled data, and raises medium severity when Task Scheduler misfire events (IDs 101/107/414) repeat three or more times for the same task within seven days.
 - **Printing** – Flags high severity when the Spooler service is stopped/disabled or when print hosts are unreachable, raises medium/high issues for offline queues and long-running jobs, warns on WSD ports, SNMP "public" communities, and legacy drivers, enforces Point-and-Print hardening posture, surfaces PrintService event storms and recurring driver crashes, and records GOOD findings for healthy spooler state, reachable printer ports, packaged drivers, and quiet event logs.
 
 ## Hardware Heuristics


### PR DESCRIPTION
## Summary
- extend the events collector to gather Task Scheduler operational log entries and expose task names
- add an Events heuristic that groups Task Scheduler misfire events, masks task identities, and raises a medium-severity issue when repeated
- document the new Task Scheduler heuristic in the Services & Events catalogue

## Testing
- ⚠️ `pwsh -NoLogo -Command ". '$PWD/Analyzers/Heuristics/Events.ps1'"` *(failed: `pwsh` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2284e484832da8cc1bde50db95f0