### PR TITLE
Adjust Events good card for Kerberos pre-auth check

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -346,7 +346,7 @@ function Invoke-EventsAuthenticationChecks {
         $kerberosError = $kerberosData.Error
     }
 
-    if ($kdc18EventsAll.Count -eq 0 -and -not $kerberosError -and $w32tmStatus -and $w32tmStatus.Succeeded -and ($null -ne $offsetSeconds) -and ([math]::Abs($offsetSeconds) -le 60)) {
+    if ($kerberosSummary.PreAuthEvents -eq 0 -and -not $kerberosError -and $w32tmStatus -and $w32tmStatus.Succeeded -and ($null -ne $offsetSeconds) -and ([math]::Abs($offsetSeconds) -le 60)) {
         $evidenceParts = New-Object System.Collections.Generic.List[string]
         $evidenceParts.Add(('Clock offset: {0}s' -f $offsetSeconds)) | Out-Null
         if ($w32tmMetrics.Source) {


### PR DESCRIPTION
## Summary
- ensure the Events authentication good card requires that no Kerberos pre-authentication failures occurred in the last 14 days before reporting healthy time synchronization

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2737109c832d984e16e809102fb3