### PR TITLE
Add DNS client timeout heuristic to events analyzer

### DIFF
--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -193,6 +193,11 @@ function Get-TimeServiceEvents {
     return Get-EventRecords -LogName 'Microsoft-Windows-Time-Service/Operational' -EventIds @(29, 36, 47, 50) -StartTime $startTime -MaxEvents 400
 }
 
+function Get-DnsClientEvents {
+    $startTime = (Get-Date).AddDays(-14)
+    return Get-EventRecords -LogName 'Microsoft-Windows-DNS-Client/Operational' -EventIds @(1014) -StartTime $startTime -MaxEvents 800
+}
+
 function Get-W32tmStatus {
     $result = [ordered]@{
         CommandPath = $null
@@ -242,6 +247,9 @@ function Invoke-Main {
             TimeServiceEvents       = Get-TimeServiceEvents
             W32tmStatus             = Get-W32tmStatus
             AccountLockouts         = Get-AccountLockoutEvents
+        }
+        Networking = [ordered]@{
+            DnsClient = Get-DnsClientEvents
         }
     }
 


### PR DESCRIPTION
## Summary
- collect DNS client timeout events from the DNS client operational log during collection
- add an Events category heuristic that aggregates 1014 timeouts, surfaces evidence, and tags possible VPN DNS leaks

## Testing
- ⚠️ `pwsh -NoLogo -Command "Set-StrictMode -Version Latest; . 'Analyzers/Heuristics/Events.ps1'"` *(PowerShell not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd31f173f8832d8fd1664b428a8207