### PR TITLE
Add heuristic for user profile unload conflicts

### DIFF
--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -139,6 +139,11 @@ function Get-EventRecords {
     return [pscustomobject]$result
 }
 
+function Get-UserProfileServiceEvents {
+    $startTime = (Get-Date).AddDays(-7)
+    return Get-EventRecords -LogName 'Microsoft-Windows-User Profile Service/Operational' -EventIds @(1530, 1533) -StartTime $startTime -MaxEvents 400
+}
+
 function Get-AccountLockoutEvents {
     $startTime = (Get-Date).AddDays(-7)
 
@@ -237,6 +242,7 @@ function Invoke-Main {
         System      = Get-RecentEvents -LogName 'System'
         Application = Get-RecentEvents -LogName 'Application'
         GroupPolicy = Get-RecentEvents -LogName 'Microsoft-Windows-GroupPolicy/Operational' -MaxEvents 200
+        UserProfileService = Get-UserProfileServiceEvents
         Authentication = [ordered]@{
             KerberosPreAuthFailures = Get-KerberosPreAuthFailures
             TimeServiceEvents       = Get-TimeServiceEvents


### PR DESCRIPTION
## Summary
- extend the events collector to capture User Profile Service operational events 1530 and 1533 for heuristic analysis
- add an Events category heuristic that flags repeated profile unload conflicts with supporting evidence and a triage recommendation

## Testing
- Not run (PowerShell unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd31fe8930832d8a7e6c5fdf87b12a