### PR TITLE
Add Netlogon secure channel heuristic to events analyzer

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -279,6 +279,182 @@ function Get-EventsCurrentDeviceName {
     return $null
 }
 
+function Test-EventsHasAuthenticationFailuresElsewhere {
+    param($Authentication)
+
+    if (-not $Authentication) { return $false }
+
+    try {
+        if ($Authentication.PSObject.Properties['KerberosPreAuthFailures']) {
+            $kerberos = $Authentication.KerberosPreAuthFailures
+            if ($kerberos -and -not $kerberos.Error -and $kerberos.PSObject.Properties['Events']) {
+                $kerberosEvents = @($kerberos.Events | Where-Object { $_ })
+                if ($kerberosEvents.Count -gt 0) { return $true }
+            }
+        }
+
+        if ($Authentication.PSObject.Properties['AccountLockouts']) {
+            $accountData = $Authentication.AccountLockouts
+            if ($accountData) {
+                foreach ($propertyName in @('Lockouts','FailedLogons','NetworkLogons')) {
+                    if (-not $accountData.PSObject.Properties[$propertyName]) { continue }
+                    $subData = $accountData.$propertyName
+                    if (-not $subData -or $subData.Error) { continue }
+                    if (-not $subData.PSObject.Properties['Events']) { continue }
+                    $events = @($subData.Events | Where-Object { $_ })
+                    if ($events.Count -gt 0) { return $true }
+                }
+            }
+        }
+    } catch {
+        Write-HeuristicDebug -Source 'Events/Auth' -Message 'Failed to evaluate authentication failure signals' -Data ([ordered]@{ Error = $_.Exception.Message })
+    }
+
+    return $false
+}
+
+function Invoke-EventsNetlogonTrustChecks {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+
+        $SystemEntries,
+
+        $Authentication
+    )
+
+    Write-HeuristicDebug -Source 'Events/Netlogon' -Message 'Evaluating Netlogon/LSA secure channel events'
+
+    if (-not $SystemEntries) { return }
+
+    $entries = @()
+    if ($SystemEntries -is [System.Collections.IEnumerable] -and -not ($SystemEntries -is [string])) {
+        foreach ($entry in $SystemEntries) {
+            if (-not $entry) { continue }
+            $entries += ,$entry
+        }
+    } else {
+        $entries = @($SystemEntries)
+    }
+
+    if ($entries.Count -eq 0) { return }
+
+    $nowUtc = (Get-Date).ToUniversalTime()
+    $recentCutoff = $nowUtc.AddDays(-7)
+    $extendedCutoff = $nowUtc.AddDays(-14)
+
+    $matches = New-Object System.Collections.Generic.List[pscustomobject]
+
+    foreach ($entry in $entries) {
+        if (-not $entry) { continue }
+        if ($entry.PSObject.Properties['Error'] -and -not $entry.PSObject.Properties['Id']) { continue }
+
+        $timeUtc = $null
+        if ($entry.PSObject.Properties['TimeCreated']) {
+            $timeUtc = ConvertTo-EventsDateTimeUtc -Value $entry.TimeCreated
+        }
+
+        if (-not $timeUtc) { continue }
+        if ($timeUtc -lt $extendedCutoff) { continue }
+
+        $id = $null
+        if ($entry.PSObject.Properties['Id']) {
+            try {
+                $id = [int]$entry.Id
+            } catch {
+                $id = $entry.Id
+            }
+        }
+
+        $provider = $null
+        if ($entry.PSObject.Properties['ProviderName']) {
+            $provider = [string]$entry.ProviderName
+        }
+
+        $message = $null
+        if ($entry.PSObject.Properties['Message']) {
+            $message = [string]$entry.Message
+        }
+
+        $level = $null
+        if ($entry.PSObject.Properties['LevelDisplayName']) {
+            $level = [string]$entry.LevelDisplayName
+        }
+
+        if ($level -and -not ($level -match '(?i)(error|warning|critical)')) {
+            continue
+        }
+
+        $providerNormalized = $null
+        if ($provider) {
+            $providerNormalized = $provider.Trim()
+        }
+
+        $isNetlogonEvent = $false
+        if ($id -eq 5719) {
+            if (-not $providerNormalized -or $providerNormalized -match '(?i)NETLOGON') {
+                $isNetlogonEvent = $true
+            }
+        }
+
+        $isLsasrvEvent = $false
+        if ($providerNormalized) {
+            if ($providerNormalized -match '(?i)LSASRV') {
+                $isLsasrvEvent = $true
+            } elseif ($providerNormalized -match '(?i)Microsoft-Windows-Security-Kerberos') {
+                $isLsasrvEvent = $true
+            }
+        }
+
+        if (-not $isLsasrvEvent -and $message) {
+            if ($message -match '(?i)LSASRV') {
+                $isLsasrvEvent = $true
+            }
+        }
+
+        if (-not $isNetlogonEvent -and -not $isLsasrvEvent) { continue }
+
+        $matches.Add([pscustomobject]@{
+            Id       = $id
+            TimeUtc  = $timeUtc
+            Provider = $providerNormalized
+        }) | Out-Null
+    }
+
+    if ($matches.Count -eq 0) { return }
+
+    $recentMatches = @($matches | Where-Object { $_.TimeUtc -ge $recentCutoff })
+    if ($recentMatches.Count -lt 3) { return }
+
+    $olderMatches = @($matches | Where-Object { $_.TimeUtc -lt $recentCutoff })
+
+    $eventIdSet = $recentMatches | ForEach-Object { $_.Id } | Where-Object { $_ } | Sort-Object -Unique
+    $lastEvent = $recentMatches | Sort-Object TimeUtc -Descending | Select-Object -First 1
+
+    $evidence = [ordered]@{
+        eventIdSet = @($eventIdSet)
+        count      = $recentMatches.Count
+        lastUtc    = if ($lastEvent -and $lastEvent.TimeUtc) { $lastEvent.TimeUtc.ToString('o') } else { $null }
+    }
+
+    $severity = 'medium'
+    $hasAuthFailures = Test-EventsHasAuthenticationFailuresElsewhere -Authentication $Authentication
+    if ($olderMatches.Count -gt 0 -and $hasAuthFailures) {
+        $severity = 'high'
+    }
+
+    Write-HeuristicDebug -Source 'Events/Netlogon' -Message 'Netlogon/LSA issues detected' -Data ([ordered]@{
+        RecentCount = $recentMatches.Count
+        OlderCount  = $olderMatches.Count
+        Severity    = $severity
+        EventIds    = @($eventIdSet)
+    })
+
+    $evidenceJson = $evidence | ConvertTo-Json -Depth 4 -Compress
+
+    Add-CategoryIssue -CategoryResult $Result -Severity $severity -Title 'Netlogon secure channel / domain reachability issues' -Evidence $evidenceJson -Subcategory 'Netlogon/LSA (Domain Join)'
+}
+
 function Invoke-EventsAuthenticationChecks {
     param(
         [Parameter(Mandatory)]
@@ -763,6 +939,10 @@ function Invoke-EventsHeuristics {
                     $logSubcategory = ("{0} Event Log" -f $logName)
                     Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Unable to read {0} event log, so noisy or unhealthy logs may be hidden." -f $logName) -Evidence $entries.Error -Subcategory $logSubcategory
                 }
+            }
+
+            if ($payload.PSObject.Properties['System']) {
+                Invoke-EventsNetlogonTrustChecks -Result $result -SystemEntries $payload.System -Authentication $payload.Authentication
             }
 
             if ($payload.PSObject.Properties['Authentication']) {


### PR DESCRIPTION
## Summary
- add a helper to detect existing authentication failures in event artifacts
- implement a Netlogon/LSA secure channel heuristic that aggregates repeated NETLOGON 5719 and LSASRV errors
- wire the new heuristic into the events analyzer so the issue surfaces with severity escalation when persistent alongside other auth failures

## Testing
- Not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd322e0e84832d88f65b1fcb48d5ee