### PR TITLE
Add Microsoft Store functional health heuristic

### DIFF
--- a/Analyzers/Heuristics/System.ps1
+++ b/Analyzers/Heuristics/System.ps1
@@ -13,6 +13,7 @@ $systemModuleRoot = Join-Path -Path $PSScriptRoot -ChildPath 'System'
 . (Join-Path -Path $systemModuleRoot -ChildPath 'Power.ps1')
 . (Join-Path -Path $systemModuleRoot -ChildPath 'Performance.ps1')
 . (Join-Path -Path $systemModuleRoot -ChildPath 'Startup.ps1')
+. (Join-Path -Path $systemModuleRoot -ChildPath 'MicrosoftStore.ps1')
 
 function Invoke-SystemHeuristics {
     param(
@@ -32,6 +33,7 @@ function Invoke-SystemHeuristics {
     Invoke-SystemPowerChecks -Context $Context -Result $result
     Invoke-SystemPerformanceChecks -Context $Context -Result $result
     Invoke-SystemStartupChecks -Context $Context -Result $result
+    Invoke-SystemMicrosoftStoreChecks -Context $Context -Result $result
 
     return $result
 }

--- a/Analyzers/Heuristics/System/MicrosoftStore.ps1
+++ b/Analyzers/Heuristics/System/MicrosoftStore.ps1
@@ -1,0 +1,244 @@
+function Invoke-SystemMicrosoftStoreChecks {
+    param(
+        [Parameter(Mandatory)]
+        $Context,
+        [Parameter(Mandatory)]
+        $Result
+    )
+
+    Write-HeuristicDebug -Source 'System/MicrosoftStore' -Message 'Starting Microsoft Store functional checks'
+
+    $artifact = Get-AnalyzerArtifact -Context $Context -Name 'store-functional'
+    Write-HeuristicDebug -Source 'System/MicrosoftStore' -Message 'Resolved store functional artifact' -Data ([ordered]@{
+        Found = [bool]$artifact
+    })
+    if (-not $artifact) { return }
+
+    $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $artifact)
+    Write-HeuristicDebug -Source 'System/MicrosoftStore' -Message 'Evaluating store payload' -Data ([ordered]@{
+        HasPayload = [bool]$payload
+    })
+    if (-not $payload) { return }
+
+    $propertyNames = $payload.PSObject.Properties | ForEach-Object { $_.Name }
+
+    $storePackagePresent = $null
+    if ($propertyNames -contains 'storePackagePresent') {
+        $storePackagePresent = [bool]$payload.storePackagePresent
+    }
+
+    $installedLocationOk = $null
+    if ($propertyNames -contains 'installedLocationOk') {
+        $installedLocationOk = [bool]$payload.installedLocationOk
+    }
+
+    $appxManifestFound = $null
+    if ($propertyNames -contains 'appxManifestFound') {
+        $appxManifestFound = $payload.appxManifestFound
+    }
+
+    $services = @()
+    if ($propertyNames -contains 'services') {
+        if ($payload.services -is [System.Collections.IEnumerable] -and -not ($payload.services -is [string])) {
+            $services = @($payload.services)
+        } elseif ($payload.services) {
+            $services = @($payload.services)
+        }
+    }
+
+    $serviceMap = New-Object 'System.Collections.Generic.Dictionary[string,object]' ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($service in $services) {
+        if (-not $service) { continue }
+        if (-not $service.PSObject.Properties['name']) { continue }
+        $serviceMap[$service.name] = $service
+    }
+
+    $proxy = $null
+    if ($propertyNames -contains 'proxy') {
+        $proxy = $payload.proxy
+    }
+
+    $reachability = @()
+    if ($propertyNames -contains 'reachability') {
+        if ($payload.reachability -is [System.Collections.IEnumerable] -and -not ($payload.reachability -is [string])) {
+            $reachability = @($payload.reachability)
+        } elseif ($payload.reachability) {
+            $reachability = @($payload.reachability)
+        }
+    }
+
+    $formatBool = {
+        param($value)
+        if ($value -eq $true) { return 'True' }
+        if ($value -eq $false) { return 'False' }
+        return 'Unknown'
+    }
+
+    $criticalServices = 'AppXSVC','ClipSVC','InstallService'
+    $pathServices = 'DoSvc','wuauserv'
+
+    $highReasons = New-Object System.Collections.Generic.List[string]
+    $mediumReasons = New-Object System.Collections.Generic.List[string]
+
+    $appxSvc = if ($serviceMap.ContainsKey('AppXSVC')) { $serviceMap['AppXSVC'] } else { $null }
+    $storeNotApplicable = ($storePackagePresent -eq $false) -and (-not $appxSvc -or ((-not $appxSvc.startType) -and (-not $appxSvc.status)))
+    if ($storeNotApplicable) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Store not applicable on this SKU' -Evidence 'Microsoft Store package absent and AppXSVC service missing.' -Subcategory 'Microsoft Store'
+        return
+    }
+
+    if ($storePackagePresent -eq $false) {
+        $highReasons.Add('Microsoft Store package missing or Get-AppxPackage returned no data.') | Out-Null
+    } elseif ($storePackagePresent -eq $true) {
+        if ($installedLocationOk -eq $false) {
+            $highReasons.Add('Microsoft Store package InstalledLocation is missing or inaccessible.') | Out-Null
+        }
+        if ($appxManifestFound -eq $false) {
+            $highReasons.Add('AppxManifest.xml for Microsoft Store was not found under C:\Program Files\WindowsApps.') | Out-Null
+        }
+    }
+
+    foreach ($name in $criticalServices) {
+        $entry = if ($serviceMap.ContainsKey($name)) { $serviceMap[$name] } else { $null }
+        if (-not $entry) {
+            $highReasons.Add("Critical service $name missing.") | Out-Null
+            continue
+        }
+
+        $startType = if ($entry.PSObject.Properties['startType']) { [string]$entry.startType } else { $null }
+        $status = if ($entry.PSObject.Properties['status']) { [string]$entry.status } else { $null }
+        $startTypeNormalized = if ($startType) { $startType.ToLowerInvariant() } else { $null }
+        $statusNormalized = if ($status) { $status.ToLowerInvariant() } else { $null }
+        $startTypePolicyOk = $false
+        if ($startTypeNormalized -in @('manual','auto','automatic')) { $startTypePolicyOk = $true }
+
+        if (-not $startType -and -not $status) {
+            $highReasons.Add("Critical service $name state unavailable.") | Out-Null
+            continue
+        }
+
+        if ($startTypeNormalized -eq 'disabled') {
+            $highReasons.Add("Critical service $name is disabled.") | Out-Null
+            continue
+        }
+
+        if ($statusNormalized -eq 'stopped' -and -not $startTypePolicyOk) {
+            $highReasons.Add("Critical service $name is stopped and not configured for Manual/Automatic start.") | Out-Null
+        }
+    }
+
+    foreach ($name in $pathServices) {
+        $entry = if ($serviceMap.ContainsKey($name)) { $serviceMap[$name] } else { $null }
+        if (-not $entry) {
+            $mediumReasons.Add("Service $name missing, delivery path unclear.") | Out-Null
+            continue
+        }
+
+        $startType = if ($entry.PSObject.Properties['startType']) { [string]$entry.startType } else { $null }
+        $status = if ($entry.PSObject.Properties['status']) { [string]$entry.status } else { $null }
+        $startTypeNormalized = if ($startType) { $startType.ToLowerInvariant() } else { $null }
+        $statusNormalized = if ($status) { $status.ToLowerInvariant() } else { $null }
+
+        if ($startTypeNormalized -eq 'disabled') {
+            $mediumReasons.Add("Service $name is disabled.") | Out-Null
+            continue
+        }
+
+        if ($statusNormalized -eq 'stopped') {
+            $mediumReasons.Add("Service $name is stopped.") | Out-Null
+        }
+    }
+
+    $proxyIsDirect = $null
+    $proxySummary = 'Unknown'
+    if ($proxy) {
+        if ($proxy.PSObject.Properties['isDirect']) { $proxyIsDirect = $proxy.isDirect }
+        if ($proxy.PSObject.Properties['winhttp']) { $proxySummary = [string]$proxy.winhttp }
+    }
+
+    $failedEndpoints = @()
+    $successfulTcp = 0
+    $knownEndpoints = 0
+    foreach ($entry in $reachability) {
+        if (-not $entry) { continue }
+        $dnsOk = if ($entry.PSObject.Properties['dnsOk']) { $entry.dnsOk } else { $null }
+        $tcpOk = if ($entry.PSObject.Properties['tcp443Ok']) { $entry.tcp443Ok } else { $null }
+        if ($tcpOk -eq $true) { $successfulTcp++ }
+        if ($dnsOk -ne $null -or $tcpOk -ne $null) { $knownEndpoints++ }
+        $dnsFailed = ($dnsOk -eq $false)
+        $tcpFailed = ($tcpOk -eq $false)
+        if ($dnsFailed -or $tcpFailed) {
+            $failedEndpoints += $entry
+        }
+    }
+
+    $failedCount = $failedEndpoints.Count
+    $proxyNonDirect = ($proxyIsDirect -eq $false) -or (($proxySummary -and $proxySummary -notin @('Direct','Unknown')))
+    if ($proxyNonDirect -and $failedCount -gt 0) {
+        $mediumReasons.Add('WinHTTP proxy is non-direct and Store endpoints show connectivity failures.') | Out-Null
+    }
+
+    if ($failedCount -ge 2) {
+        $mediumReasons.Add('At least two Microsoft Store endpoints failed DNS or TCP reachability checks.') | Out-Null
+    }
+
+    $evidenceLines = New-Object System.Collections.Generic.List[string]
+    $evidenceLines.Add("storePackagePresent={0}" -f (& $formatBool $storePackagePresent)) | Out-Null
+    $evidenceLines.Add("installedLocationOk={0}" -f (& $formatBool $installedLocationOk)) | Out-Null
+    $manifestStatus = if ($null -eq $appxManifestFound) { 'Unknown' } elseif ($appxManifestFound -eq $true) { 'True' } else { 'False' }
+    $evidenceLines.Add("appxManifestFound={0}" -f $manifestStatus) | Out-Null
+
+    foreach ($name in $criticalServices + $pathServices) {
+        $entry = if ($serviceMap.ContainsKey($name)) { $serviceMap[$name] } else { $null }
+        if ($entry) {
+            $startType = if ($entry.PSObject.Properties['startType']) { [string]$entry.startType } else { 'Unknown' }
+            $status = if ($entry.PSObject.Properties['status']) { [string]$entry.status } else { 'Unknown' }
+            $evidenceLines.Add("{0}: StartType={1}; Status={2}" -f $name, $startType, $status) | Out-Null
+        } else {
+            $evidenceLines.Add("{0}: StartType=Unknown; Status=Unknown" -f $name) | Out-Null
+        }
+    }
+
+    $evidenceLines.Add("proxy={0}" -f $proxySummary) | Out-Null
+
+    if ($reachability.Count -gt 0) {
+        foreach ($entry in $reachability) {
+            if (-not $entry -or -not $entry.PSObject.Properties['host']) { continue }
+            $dnsOk = if ($entry.PSObject.Properties['dnsOk']) { $entry.dnsOk } else { $null }
+            $tcpOk = if ($entry.PSObject.Properties['tcp443Ok']) { $entry.tcp443Ok } else { $null }
+            $evidenceLines.Add("{0}: DNS={1}; TCP443={2}" -f $entry.host, (& $formatBool $dnsOk), (& $formatBool $tcpOk)) | Out-Null
+        }
+    }
+
+    Add-CategoryCheck -CategoryResult $Result -Name 'Store package present' -Status (& $formatBool $storePackagePresent)
+    Add-CategoryCheck -CategoryResult $Result -Name 'Installed location OK' -Status (& $formatBool $installedLocationOk)
+    Add-CategoryCheck -CategoryResult $Result -Name 'AppxManifest located' -Status $manifestStatus
+    foreach ($name in $criticalServices + $pathServices) {
+        $entry = if ($serviceMap.ContainsKey($name)) { $serviceMap[$name] } else { $null }
+        $startType = if ($entry -and $entry.PSObject.Properties['startType']) { [string]$entry.startType } else { 'Unknown' }
+        $status = if ($entry -and $entry.PSObject.Properties['status']) { [string]$entry.status } else { 'Unknown' }
+        Add-CategoryCheck -CategoryResult $Result -Name ("Service {0}" -f $name) -Status ("{0} / {1}" -f $startType, $status)
+    }
+
+    if ($reachability.Count -gt 0) {
+        foreach ($entry in $reachability) {
+            if (-not $entry -or -not $entry.PSObject.Properties['host']) { continue }
+            $dnsOk = if ($entry.PSObject.Properties['dnsOk']) { $entry.dnsOk } else { $null }
+            $tcpOk = if ($entry.PSObject.Properties['tcp443Ok']) { $entry.tcp443Ok } else { $null }
+            Add-CategoryCheck -CategoryResult $Result -Name ("Reachability {0}" -f $entry.host) -Status ("DNS={0}; TCP443={1}" -f (& $formatBool $dnsOk), (& $formatBool $tcpOk))
+        }
+    }
+
+    $evidence = $evidenceLines -join "`n"
+
+    if ($highReasons.Count -gt 0) {
+        $reasonText = ($highReasons + $mediumReasons) -join "`n"
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Microsoft Store functional checks failing' -Evidence (($reasonText, '', $evidence) -join "`n") -Subcategory 'Microsoft Store'
+    } elseif ($mediumReasons.Count -gt 0) {
+        $reasonText = $mediumReasons -join "`n"
+        Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Microsoft Store functional checks failing' -Evidence (($reasonText, '', $evidence) -join "`n") -Subcategory 'Microsoft Store'
+    } else {
+        $successSummary = "storePackagePresent=true; services OK (AppXSVC/ClipSVC/InstallService Running or Manual); proxy={0}; endpoints reachable ({1}/3 TCP 443 OK)" -f $proxySummary, $successfulTcp
+        Add-CategoryNormal -CategoryResult $Result -Title 'Microsoft Store functional checks passed' -Evidence (($successSummary, '', $evidence) -join "`n") -Subcategory 'Microsoft Store'
+    }
+}

--- a/Collectors/System/Collect-MicrosoftStoreFunctional.ps1
+++ b/Collectors/System/Collect-MicrosoftStoreFunctional.ps1
@@ -1,0 +1,198 @@
+<#!
+.SYNOPSIS
+    Collects Microsoft Store operational signals for analyzer heuristics.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-StorePackageState {
+    $package = $null
+    try {
+        $package = Get-AppxPackage -Name 'Microsoft.WindowsStore' -ErrorAction SilentlyContinue
+    } catch {
+        $package = $null
+    }
+
+    $present = [bool]$package
+    $locationOk = $false
+    if ($present -and $package.PSObject.Properties['InstalledLocation']) {
+        $installedLocation = $package.InstalledLocation
+        if ($installedLocation) {
+            try {
+                $locationOk = Test-Path -LiteralPath $installedLocation -ErrorAction Stop
+            } catch {
+                $locationOk = $false
+            }
+        }
+    }
+
+    $manifestFound = $false
+    if ($present) {
+        try {
+            $storeRoot = 'C:\\Program Files\\WindowsApps'
+            $storeFolders = Get-ChildItem -LiteralPath $storeRoot -ErrorAction Stop |
+                Where-Object { $_.Name -like 'Microsoft.WindowsStore_*' }
+
+            foreach ($folder in $storeFolders) {
+                try {
+                    $manifest = Get-ChildItem -LiteralPath $folder.FullName -Filter 'AppxManifest.xml' -ErrorAction Stop |
+                        Select-Object -First 1
+                    if ($manifest) {
+                        $manifestFound = $true
+                        break
+                    }
+                } catch [System.UnauthorizedAccessException] {
+                    throw
+                } catch {
+                    # Ignore other per-folder errors and continue scanning.
+                }
+            }
+        } catch [System.UnauthorizedAccessException] {
+            $manifestFound = $null
+        } catch {
+            $manifestFound = $false
+        }
+    }
+
+    return [ordered]@{
+        storePackagePresent = $present
+        installedLocationOk = if ($present) { [bool]$locationOk } else { $false }
+        appxManifestFound   = if ($present) { $manifestFound } else { $false }
+    }
+}
+
+function Get-ServiceSnapshot {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Names
+    )
+
+    $snapshot = New-Object System.Collections.Generic.List[object]
+    foreach ($name in $Names) {
+        $status = $null
+        $startType = $null
+        try {
+            $service = Get-Service -Name $name -ErrorAction Stop
+            $status = [string]$service.Status
+        } catch {
+            $status = $null
+        }
+
+        try {
+            $cim = Get-CimInstance -ClassName Win32_Service -Filter "Name='$name'" -ErrorAction Stop
+            if ($cim -and $cim.PSObject.Properties['StartMode']) {
+                $startType = [string]$cim.StartMode
+            }
+        } catch {
+        }
+
+        $snapshot.Add([pscustomobject]@{
+            name      = $name
+            startType = $startType
+            status    = $status
+        }) | Out-Null
+    }
+
+    return $snapshot
+}
+
+function Get-WinHttpProxySummary {
+    $summary = 'Unknown'
+    $isDirect = $null
+
+    try {
+        $output = & netsh winhttp show proxy 2>$null
+        if ($output) {
+            $directMatch = $output -match 'Direct access \(no proxy server\)' -or $output -match 'Direct access'
+            if ($directMatch) {
+                $summary = 'Direct'
+                $isDirect = $true
+            } else {
+                $summary = 'Non-Direct'
+                $isDirect = $false
+            }
+        }
+    } catch {
+        $summary = 'Unknown'
+        $isDirect = $null
+    }
+
+    return [pscustomobject]@{
+        winhttp  = $summary
+        isDirect = $isDirect
+    }
+}
+
+function Test-StoreEndpointReachability {
+    $hosts = 'storeedgefd.dsx.mp.microsoft.com','login.live.com','dl.delivery.mp.microsoft.com'
+    $results = New-Object System.Collections.Generic.List[object]
+
+    foreach ($host in $hosts) {
+        $dnsOk = $false
+        $tcpOk = $false
+        $rttMs = $null
+
+        try {
+            $null = Resolve-DnsName -Name $host -ErrorAction Stop
+            $dnsOk = $true
+        } catch [System.Management.Automation.CommandNotFoundException] {
+            $dnsOk = $null
+        } catch {
+            $dnsOk = $false
+        }
+
+        try {
+            $test = Test-NetConnection -ComputerName $host -Port 443 -InformationLevel Detailed -WarningAction SilentlyContinue -ErrorAction Stop
+            if ($test) {
+                if ($test.PSObject.Properties['TcpTestSucceeded']) {
+                    $tcpOk = [bool]$test.TcpTestSucceeded
+                }
+                if ($test.PSObject.Properties['PingSucceeded'] -and $test.PingSucceeded -and $test.PSObject.Properties['PingReplyDetails']) {
+                    $rttMs = [int]$test.PingReplyDetails.RoundtripTime
+                } elseif ($test.PSObject.Properties['Latency']) {
+                    $rttMs = [int]$test.Latency
+                }
+            }
+        } catch [System.Management.Automation.CommandNotFoundException] {
+            $tcpOk = $null
+        } catch {
+            $tcpOk = $false
+        }
+
+        $results.Add([pscustomobject]@{
+            host    = $host
+            dnsOk   = $dnsOk
+            tcp443Ok = $tcpOk
+            rttMs   = $rttMs
+        }) | Out-Null
+    }
+
+    return $results
+}
+
+function Invoke-Main {
+    $packageState = Get-StorePackageState
+    $services = Get-ServiceSnapshot -Names @('AppXSVC','ClipSVC','InstallService','DoSvc','wuauserv')
+    $proxy = Get-WinHttpProxySummary
+    $reachability = Test-StoreEndpointReachability
+
+    $payload = [ordered]@{
+        storePackagePresent = $packageState.storePackagePresent
+        installedLocationOk = $packageState.installedLocationOk
+        appxManifestFound   = $packageState.appxManifestFound
+        services            = $services
+        proxy               = $proxy
+        reachability        = $reachability
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'store-functional.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add a System collector that captures Microsoft Store package, service, proxy, and reachability telemetry
- surface a Microsoft Store heuristic that scores the collected data, handles not-applicable SKUs, and reports success/issue states
- wire the new heuristic into the System category so Microsoft Store health is reported alongside existing checks

## Testing
- not run (PowerShell-based collectors require Windows-specific cmdlets)


------
https://chatgpt.com/codex/tasks/task_e_68ddcdccc460832d922fa9ee3a7b9a1b