### PR TITLE
Add autorun policy collector and heuristic check

### DIFF
--- a/Collectors/Security/Collect-Autorun.ps1
+++ b/Collectors/Security/Collect-Autorun.ps1
@@ -1,0 +1,50 @@
+<#!
+.SYNOPSIS
+    Collects Autorun and Autoplay policy configuration from Explorer policy keys.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\CollectorCommon.ps1')
+
+function Get-AutorunExplorerPolicies {
+    $paths = @(
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer',
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+        'HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+    )
+
+    $result = [System.Collections.Generic.List[pscustomobject]]::new()
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $result.Add([pscustomobject]@{
+                Path   = $path
+                Values = $values
+            })
+        } catch {
+            $result.Add([pscustomobject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            })
+        }
+    }
+
+    return $result.ToArray()
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        ExplorerPolicies = Get-AutorunExplorerPolicies
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'autorun.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add a security collector that exports Explorer autorun policy values into autorun.json
- update the hardware heuristics to load the autorun artifact and flag missing or weak configurations

## Testing
- not run (pwsh not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddd237d8bc832d807a33238e09c000