### PR TITLE
Fix Microsoft Store service evidence formatting

### DIFF
--- a/Analyzers/Heuristics/System/MicrosoftStore.ps1
+++ b/Analyzers/Heuristics/System/MicrosoftStore.ps1
@@ -193,9 +193,9 @@ function Invoke-SystemMicrosoftStoreChecks {
         if ($entry) {
             $startType = if ($entry.PSObject.Properties['startType']) { [string]$entry.startType } else { 'Unknown' }
             $status = if ($entry.PSObject.Properties['status']) { [string]$entry.status } else { 'Unknown' }
-            $evidenceLines.Add("$name: StartType=$startType; Status=$status") | Out-Null
+            $evidenceLines.Add("$($name): StartType=$startType; Status=$status") | Out-Null
         } else {
-            $evidenceLines.Add("$name: StartType=Unknown; Status=Unknown") | Out-Null
+            $evidenceLines.Add("$($name): StartType=Unknown; Status=Unknown") | Out-Null
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure service evidence lines in the Microsoft Store heuristic format the service name correctly when followed by a colon

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dde1cb4d8c832dbef39c540e037989