### PR TITLE
Add autorun collector and heuristic for removable media hardening

### DIFF
--- a/Analyzers/Heuristics/Hardware/InvokeHardware.ps1
+++ b/Analyzers/Heuristics/Hardware/InvokeHardware.ps1
@@ -1,3 +1,97 @@
+function ConvertTo-HardwareAutorunInt {
+    param($Value)
+
+    if ($null -eq $Value) { return $null }
+
+    if ($Value -is [int] -or $Value -is [long]) { return [int]$Value }
+    if ($Value -is [uint32] -or $Value -is [uint64]) { return [int]$Value }
+
+    if ($Value -is [string]) {
+        $text = $Value.Trim()
+        if (-not $text) { return $null }
+
+        if ($text -match '^0x([0-9a-f]+)$') {
+            try { return [Convert]::ToInt32($matches[1], 16) } catch { return $null }
+        }
+
+        $parsed = 0
+        if ([int]::TryParse($text, [ref]$parsed)) { return $parsed }
+
+        $decimalMatch = [regex]::Match($text, '([0-9]+)')
+        if ($decimalMatch.Success) {
+            try { return [int]$decimalMatch.Groups[1].Value } catch { return $null }
+        }
+    }
+
+    return $null
+}
+
+function Get-HardwareAutorunEntry {
+    param(
+        $Entries,
+        [string]$Path
+    )
+
+    if (-not $Entries -or -not $Path) { return $null }
+
+    $normalizedTarget = $Path.TrimEnd('\').ToLowerInvariant()
+
+    foreach ($entry in $Entries) {
+        if (-not $entry) { continue }
+        if (-not $entry.Path) { continue }
+        $entryPath = $entry.Path.TrimEnd('\').ToLowerInvariant()
+        if ($entryPath -eq $normalizedTarget) { return $entry }
+    }
+
+    return $null
+}
+
+function Get-HardwareAutorunValue {
+    param(
+        $Entry,
+        [string]$Name
+    )
+
+    if (-not $Entry -or -not $Name) { return $null }
+    if (-not $Entry.Values) { return $null }
+
+    $property = $Entry.Values.PSObject.Properties[$Name]
+    if (-not $property) { return $null }
+
+    return $property.Value
+}
+
+function Format-HardwareAutorunValue {
+    param($Value)
+
+    if ($null -eq $Value) { return 'missing' }
+
+    $intValue = ConvertTo-HardwareAutorunInt $Value
+    if ($null -ne $intValue) {
+        return ('0x{0:X2} ({1})' -f ($intValue -band 0xFF), $intValue)
+    }
+
+    return [string]$Value
+}
+
+function Format-HardwareAutorunEntry {
+    param(
+        [string]$Label,
+        $Entry
+    )
+
+    $noDriveType = Format-HardwareAutorunValue (Get-HardwareAutorunValue -Entry $Entry -Name 'NoDriveTypeAutoRun')
+    $noAutoRun = Format-HardwareAutorunValue (Get-HardwareAutorunValue -Entry $Entry -Name 'NoAutoRun')
+    $noDriveAuto = Format-HardwareAutorunValue (Get-HardwareAutorunValue -Entry $Entry -Name 'NoDriveAutoRun')
+
+    $parts = [System.Collections.Generic.List[string]]::new()
+    $parts.Add("NoDriveTypeAutoRun=$noDriveType") | Out-Null
+    $parts.Add("NoAutoRun=$noAutoRun") | Out-Null
+    $parts.Add("NoDriveAutoRun=$noDriveAuto") | Out-Null
+
+    return ('{0}: {1}' -f $Label, ($parts.ToArray() -join '; '))
+}
+
 function Invoke-HardwareHeuristics {
     param(
         [Parameter(Mandatory)]
@@ -9,6 +103,115 @@ function Invoke-HardwareHeuristics {
     })
 
     $result = New-CategoryResult -Name 'Hardware'
+
+    $autorunArtifact = Get-AnalyzerArtifact -Context $Context -Name 'autorun'
+    Write-HeuristicDebug -Source 'Hardware' -Message 'Resolved autorun artifact' -Data ([ordered]@{
+        Found = [bool]$autorunArtifact
+    })
+
+    $autorunEntries = @()
+    if ($autorunArtifact) {
+        $autorunPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $autorunArtifact)
+        $autorunEntries = @()
+        if ($autorunPayload -and $autorunPayload.Registry) {
+            if ($autorunPayload.Registry -is [System.Collections.IEnumerable] -and -not ($autorunPayload.Registry -is [string])) {
+                foreach ($item in $autorunPayload.Registry) { $autorunEntries += ,$item }
+            } else {
+                $autorunEntries = @($autorunPayload.Registry)
+            }
+        }
+
+        Write-HeuristicDebug -Source 'Hardware' -Message 'Evaluating autorun payload' -Data ([ordered]@{
+            HasRegistry = ($autorunEntries.Count -gt 0)
+        })
+    }
+
+    if (-not $autorunArtifact) {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Autorun/Autoplay artifact missing, so removable media autorun posture is unknown.' -Subcategory 'Removable Media'
+    } elseif ($autorunEntries.Count -eq 0) {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Autorun/Autoplay registry data unavailable, so removable media autorun posture is unknown.' -Subcategory 'Removable Media'
+    } else {
+        $machinePolicyEntry = Get-HardwareAutorunEntry -Entries $autorunEntries -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
+        $machineLegacyEntry = Get-HardwareAutorunEntry -Entries $autorunEntries -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+        $userPolicyEntry = Get-HardwareAutorunEntry -Entries $autorunEntries -Path 'HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
+        $userLegacyEntry = Get-HardwareAutorunEntry -Entries $autorunEntries -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+
+        $machineNoDrive = $null
+        $machineNoDriveSource = $null
+        foreach ($entry in @($machinePolicyEntry, $machineLegacyEntry)) {
+            if (-not $entry) { continue }
+            $value = ConvertTo-HardwareAutorunInt (Get-HardwareAutorunValue -Entry $entry -Name 'NoDriveTypeAutoRun')
+            if ($null -ne $value) {
+                $machineNoDrive = $value
+                $machineNoDriveSource = $entry.Path
+                break
+            }
+        }
+
+        $machineNoAutoRun = $null
+        $machineNoAutoSource = $null
+        foreach ($entry in @($machinePolicyEntry, $machineLegacyEntry)) {
+            if (-not $entry) { continue }
+            $value = ConvertTo-HardwareAutorunInt (Get-HardwareAutorunValue -Entry $entry -Name 'NoAutoRun')
+            if ($null -ne $value) {
+                $machineNoAutoRun = $value
+                $machineNoAutoSource = $entry.Path
+                break
+            }
+        }
+
+        $userNoDrive = $null
+        foreach ($entry in @($userPolicyEntry, $userLegacyEntry)) {
+            if (-not $entry) { continue }
+            $value = ConvertTo-HardwareAutorunInt (Get-HardwareAutorunValue -Entry $entry -Name 'NoDriveTypeAutoRun')
+            if ($null -ne $value) { $userNoDrive = $value; break }
+        }
+
+        $userNoAutoRun = $null
+        foreach ($entry in @($userPolicyEntry, $userLegacyEntry)) {
+            if (-not $entry) { continue }
+            $value = ConvertTo-HardwareAutorunInt (Get-HardwareAutorunValue -Entry $entry -Name 'NoAutoRun')
+            if ($null -ne $value) { $userNoAutoRun = $value; break }
+        }
+
+        $expectedNoDriveType = 0xFF
+        $expectedNoAutoRun = 1
+
+        $machineHardened = ($machineNoDrive -eq $expectedNoDriveType) -and ($machineNoAutoRun -eq $expectedNoAutoRun)
+        $userOverridesPresent = ($null -ne $userNoDrive) -or ($null -ne $userNoAutoRun)
+        $userHardened = $true
+        if ($userOverridesPresent) {
+            $userHardened = ($userNoDrive -eq $expectedNoDriveType) -and ($userNoAutoRun -eq $expectedNoAutoRun)
+        }
+
+        $evidenceLines = [System.Collections.Generic.List[string]]::new()
+        $evidenceLines.Add(Format-HardwareAutorunEntry -Label 'HKLM Policies\\Explorer' -Entry $machinePolicyEntry) | Out-Null
+        $evidenceLines.Add(Format-HardwareAutorunEntry -Label 'HKLM\\...\\Policies\\Explorer' -Entry $machineLegacyEntry) | Out-Null
+        $evidenceLines.Add(Format-HardwareAutorunEntry -Label 'HKCU Policies\\Explorer' -Entry $userPolicyEntry) | Out-Null
+        $evidenceLines.Add(Format-HardwareAutorunEntry -Label 'HKCU\\...\\Policies\\Explorer' -Entry $userLegacyEntry) | Out-Null
+
+        $evidence = $evidenceLines.ToArray() -join "`n"
+
+        Write-HeuristicDebug -Source 'Hardware' -Message 'Autorun hardening evaluated' -Data ([ordered]@{
+            MachineNoDrive      = $machineNoDrive
+            MachineNoDrivePath  = $machineNoDriveSource
+            MachineNoAutoRun    = $machineNoAutoRun
+            MachineNoAutoPath   = $machineNoAutoSource
+            UserNoDrive         = $userNoDrive
+            UserNoAutoRun       = $userNoAutoRun
+            MachineHardened     = $machineHardened
+            UserOverrides       = $userOverridesPresent
+            UserHardened        = $userHardened
+        })
+
+        if (-not $machineHardened -or -not $userHardened) {
+            $title = 'Autorun/Autoplay remains enabled because NoDriveTypeAutoRun/NoAutoRun are not set to hardened values (0xFF/1), allowing removable media to auto-execute.'
+            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title $title -Evidence $evidence -Subcategory 'Removable Media'
+        } else {
+            $title = 'Autorun/Autoplay disabled via NoDriveTypeAutoRun = 0xFF and NoAutoRun = 1.'
+            Add-CategoryNormal -CategoryResult $result -Title $title -Evidence $evidence -Subcategory 'Removable Media'
+        }
+    }
 
     $driversArtifact = Get-AnalyzerArtifact -Context $Context -Name 'drivers'
     Write-HeuristicDebug -Source 'Hardware' -Message 'Resolved driver artifact' -Data ([ordered]@{

--- a/Collectors/Security/Collect-Autorun.ps1
+++ b/Collectors/Security/Collect-Autorun.ps1
@@ -1,0 +1,51 @@
+<#!
+.SYNOPSIS
+    Collects Autorun and Autoplay hardening policy values.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-AutorunRegistryValues {
+    $paths = @(
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer',
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+        'HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+    )
+
+    $results = [System.Collections.Generic.List[pscustomobject]]::new()
+
+    foreach ($path in $paths) {
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $results.Add([pscustomobject]@{
+                Path   = $path
+                Values = $values
+            }) | Out-Null
+        } catch {
+            $results.Add([pscustomobject]@{
+                Path  = $path
+                Error = $_.Exception.Message
+            }) | Out-Null
+        }
+    }
+
+    return $results.ToArray()
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Registry = Get-AutorunRegistryValues
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'autorun.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add a security collector that exports Autorun/Autoplay policy values into an `autorun` artifact
- extend the hardware heuristics to load the new artifact, evaluate hardened values, and surface issues when Autorun remains enabled

## Testing
- not run (pwsh is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ddd461765c832d882433fbb1039688