### PR TITLE
Add autorun policy collector and heuristic

### DIFF
--- a/Analyzers/Heuristics/Security.ps1
+++ b/Analyzers/Heuristics/Security.ps1
@@ -88,6 +88,81 @@ function Get-RegistryValueFromEntries {
     return $null
 }
 
+function ConvertTo-NullablePolicyInt {
+    param($Value)
+
+    if ($Value -is [int]) { return [int]$Value }
+    if ($null -eq $Value) { return $null }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+
+    $trimmed = $text.Trim()
+    if ($trimmed -match '^(?i)0x[0-9a-f]+$') {
+        try {
+            return [Convert]::ToInt32($trimmed.Substring(2), 16)
+        } catch {
+            return $null
+        }
+    }
+
+    $parsed = 0
+    if ([int]::TryParse($trimmed, [ref]$parsed)) {
+        return $parsed
+    }
+
+    return $null
+}
+
+function Get-AutorunPolicyValue {
+    param(
+        $Entries,
+        [string[]]$PreferredPaths,
+        [string]$Name
+    )
+
+    if (-not $Entries) { return $null }
+
+    foreach ($path in $PreferredPaths) {
+        foreach ($entry in (ConvertTo-List $Entries)) {
+            if (-not $entry) { continue }
+            if ($entry.Path -ne $path) { continue }
+            if ($entry.Error) { continue }
+            if ($entry.PSObject.Properties['Exists'] -and -not $entry.Exists) { continue }
+            if (-not $entry.Values) { continue }
+
+            $property = $entry.Values.PSObject.Properties[$Name]
+            if (-not $property) { continue }
+
+            $converted = ConvertTo-NullablePolicyInt $property.Value
+            return [pscustomobject]@{
+                Path    = $entry.Path
+                Value   = $converted
+                RawValue = $property.Value
+            }
+        }
+    }
+
+    foreach ($entry in (ConvertTo-List $Entries)) {
+        if (-not $entry) { continue }
+        if ($entry.Error) { continue }
+        if ($entry.PSObject.Properties['Exists'] -and -not $entry.Exists) { continue }
+        if (-not $entry.Values) { continue }
+
+        $property = $entry.Values.PSObject.Properties[$Name]
+        if (-not $property) { continue }
+
+        $converted = ConvertTo-NullablePolicyInt $property.Value
+        return [pscustomobject]@{
+            Path    = $entry.Path
+            Value   = $converted
+            RawValue = $property.Value
+        }
+    }
+
+    return $null
+}
+
 function Invoke-SecurityHeuristics {
     param(
         [Parameter(Mandatory)]
@@ -825,6 +900,134 @@ function Invoke-SecurityHeuristics {
         Add-CategoryNormal -CategoryResult $result -Title 'NTLM hardening policies enforced' -Evidence $ntlmEvidence -Subcategory 'NTLM Hardening'
     } else {
         Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'NTLM hardening policies are not configured, allowing credential relay attacks. Enforce RestrictSending/Audit NTLM settings.' -Evidence $ntlmEvidence -Subcategory 'NTLM Hardening'
+    }
+
+    $autorunArtifact = Get-AnalyzerArtifact -Context $Context -Name 'autorun'
+    Write-HeuristicDebug -Source 'Security' -Message 'Resolved autorun artifact' -Data ([ordered]@{
+        Found = [bool]$autorunArtifact
+    })
+    if ($autorunArtifact) {
+        $autorunPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $autorunArtifact)
+        Write-HeuristicDebug -Source 'Security' -Message 'Evaluating autorun payload' -Data ([ordered]@{
+            HasPayload = [bool]$autorunPayload
+        })
+
+        if ($autorunPayload -and $autorunPayload.ExplorerPolicies) {
+            $autorunEntries = ConvertTo-List $autorunPayload.ExplorerPolicies
+            Write-HeuristicDebug -Source 'Security' -Message 'Analyzing autorun policy entries' -Data ([ordered]@{
+                EntryCount = if ($autorunEntries) { $autorunEntries.Count } else { 0 }
+            })
+
+            $preferredPaths = @(
+                'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer',
+                'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+                'HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer',
+                'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+            )
+
+            $noDriveResult = Get-AutorunPolicyValue -Entries $autorunEntries -PreferredPaths $preferredPaths -Name 'NoDriveTypeAutoRun'
+            $noAutoResult = Get-AutorunPolicyValue -Entries $autorunEntries -PreferredPaths $preferredPaths -Name 'NoAutoRun'
+            $noDriveValue = if ($noDriveResult) { $noDriveResult.Value } else { $null }
+            $noAutoValue = if ($noAutoResult) { $noAutoResult.Value } else { $null }
+            $noDriveHardened = ($noDriveValue -eq 255)
+            $noAutoHardened = ($noAutoValue -eq 1)
+
+            $evidenceLines = [System.Collections.Generic.List[string]]::new()
+
+            if ($noDriveResult) {
+                if ($noDriveValue -ne $null) {
+                    $evidenceLines.Add(("Effective NoDriveTypeAutoRun: 0x{0:X2} ({0}) from {1}" -f $noDriveValue, $noDriveResult.Path)) | Out-Null
+                } elseif ($noDriveResult.RawValue) {
+                    $evidenceLines.Add(("Effective NoDriveTypeAutoRun: value '{0}' from {1} could not be parsed" -f $noDriveResult.RawValue, $noDriveResult.Path)) | Out-Null
+                } else {
+                    $evidenceLines.Add('Effective NoDriveTypeAutoRun: value present but unreadable') | Out-Null
+                }
+            } else {
+                $evidenceLines.Add('Effective NoDriveTypeAutoRun: not set (no applicable registry value found)') | Out-Null
+            }
+
+            if ($noAutoResult) {
+                if ($noAutoValue -ne $null) {
+                    $evidenceLines.Add(("Effective NoAutoRun: {0} from {1}" -f $noAutoValue, $noAutoResult.Path)) | Out-Null
+                } elseif ($noAutoResult.RawValue) {
+                    $evidenceLines.Add(("Effective NoAutoRun: value '{0}' from {1} could not be parsed" -f $noAutoResult.RawValue, $noAutoResult.Path)) | Out-Null
+                } else {
+                    $evidenceLines.Add('Effective NoAutoRun: value present but unreadable') | Out-Null
+                }
+            } else {
+                $evidenceLines.Add('Effective NoAutoRun: not set (no applicable registry value found)') | Out-Null
+            }
+
+            foreach ($entry in (ConvertTo-List $autorunEntries)) {
+                if (-not $entry) { continue }
+
+                $lineParts = [System.Collections.Generic.List[string]]::new()
+                if ($entry.Error) {
+                    $lineParts.Add(("error: {0}" -f $entry.Error)) | Out-Null
+                } elseif ($entry.PSObject.Properties['Exists'] -and -not $entry.Exists) {
+                    $lineParts.Add('missing') | Out-Null
+                } elseif (-not $entry.Values) {
+                    $lineParts.Add('no values captured') | Out-Null
+                } else {
+                    foreach ($primary in @(
+                        @{ Name = 'NoDriveTypeAutoRun'; Hex = $true },
+                        @{ Name = 'NoAutoRun'; Hex = $false }
+                    )) {
+                        $property = $entry.Values.PSObject.Properties[$primary.Name]
+                        if ($property) {
+                            $converted = ConvertTo-NullablePolicyInt $property.Value
+                            if ($primary.Hex -and $converted -ne $null) {
+                                $lineParts.Add(("{0}=0x{1:X2} ({1})" -f $primary.Name, $converted)) | Out-Null
+                            } elseif ($converted -ne $null) {
+                                $lineParts.Add(("{0}={1}" -f $primary.Name, $converted)) | Out-Null
+                            } else {
+                                $lineParts.Add(("{0}={1}" -f $primary.Name, $property.Value)) | Out-Null
+                            }
+                        } else {
+                            $lineParts.Add(("{0}=(not set)" -f $primary.Name)) | Out-Null
+                        }
+                    }
+
+                    foreach ($extra in @('DisableAutoplay', 'DisableAutorun', 'Autorunsc', 'HonorAutorunSetting')) {
+                        $extraProp = $entry.Values.PSObject.Properties[$extra]
+                        if ($extraProp) {
+                            $lineParts.Add(("{0}={1}" -f $extra, $extraProp.Value)) | Out-Null
+                        }
+                    }
+                }
+
+                $detail = if ($lineParts.Count -gt 0) { $lineParts -join '; ' } else { 'no relevant values' }
+                $evidenceLines.Add(("Path {0}: {1}" -f $entry.Path, $detail)) | Out-Null
+            }
+
+            $evidenceText = $evidenceLines.ToArray() -join "`n"
+            if ($noDriveHardened -and $noAutoHardened) {
+                Add-CategoryNormal -CategoryResult $result -Title 'Autorun/Autoplay policies hardened (NoDriveTypeAutoRun=0xFF; NoAutoRun=1).' -Evidence $evidenceText -Subcategory 'Autorun Policies' -CheckId 'Security/AutorunPolicies'
+            } else {
+                $statusParts = [System.Collections.Generic.List[string]]::new()
+                if (-not $noDriveHardened) {
+                    if ($noDriveValue -eq $null) {
+                        $statusParts.Add('NoDriveTypeAutoRun missing') | Out-Null
+                    } else {
+                        $statusParts.Add(("NoDriveTypeAutoRun=0x{0:X2}" -f ($noDriveValue -band 0xFFFFFFFF))) | Out-Null
+                    }
+                }
+                if (-not $noAutoHardened) {
+                    if ($noAutoValue -eq $null) {
+                        $statusParts.Add('NoAutoRun missing') | Out-Null
+                    } else {
+                        $statusParts.Add(("NoAutoRun={0}" -f $noAutoValue)) | Out-Null
+                    }
+                }
+                $detailText = if ($statusParts.Count -gt 0) { $statusParts -join '; ' } else { 'values not hardened' }
+                $title = "Autorun/Autoplay policies not hardened ({0}), allowing removable media autorun." -f $detailText
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title $title -Evidence $evidenceText -Subcategory 'Autorun Policies' -CheckId 'Security/AutorunPolicies'
+            }
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Autorun policy artifact missing expected structure, so removable media autorun defenses are unknown.' -Subcategory 'Autorun Policies'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Autorun policy artifact not collected, so removable media autorun defenses are unknown.' -Subcategory 'Autorun Policies'
     }
 
     return $result

--- a/Collectors/Security/Collect-Autorun.ps1
+++ b/Collectors/Security/Collect-Autorun.ps1
@@ -1,0 +1,63 @@
+<#!
+.SYNOPSIS
+    Collects autorun and autoplay policy configuration from registry.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-ExplorerPolicyValues {
+    param(
+        [string[]]$Paths
+    )
+
+    $result = [System.Collections.Generic.List[pscustomobject]]::new()
+
+    foreach ($path in $Paths) {
+        $entry = [ordered]@{
+            Path = $path
+        }
+
+        if (-not (Test-Path -Path $path)) {
+            $entry['Exists'] = $false
+            $result.Add([pscustomobject]$entry) | Out-Null
+            continue
+        }
+
+        $entry['Exists'] = $true
+
+        try {
+            $values = Get-ItemProperty -Path $path -ErrorAction Stop | Select-Object * -ExcludeProperty PS*, CIM*, PSEdition
+            $entry['Values'] = $values
+        } catch {
+            $entry['Error'] = $_.Exception.Message
+        }
+
+        $result.Add([pscustomobject]$entry) | Out-Null
+    }
+
+    return $result.ToArray()
+}
+
+function Invoke-Main {
+    $paths = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+        'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer',
+        'HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
+    )
+
+    $payload = [ordered]@{
+        ExplorerPolicies = Get-ExplorerPolicyValues -Paths $paths
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'autorun.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add a security collector that exports autorun and autoplay policy registry values into `autorun.json`
- teach the security analyzer to read the new artifact and flag missing or weak autorun hardening values

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de06aa2348832d9b299a6373dfe157