### PR TITLE
Add AppLocker audit heuristic to Events analyzer

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -196,11 +196,12 @@ function New-CategoryResult {
     $source = Get-HeuristicSourceMetadata
 
     return [pscustomobject]@{
-        Name    = $Name
-        Issues  = New-Object System.Collections.Generic.List[pscustomobject]
-        Normals = New-Object System.Collections.Generic.List[pscustomobject]
-        Checks  = New-Object System.Collections.Generic.List[pscustomobject]
-        Source  = $source
+        Name        = $Name
+        Issues      = New-Object System.Collections.Generic.List[pscustomobject]
+        Normals     = New-Object System.Collections.Generic.List[pscustomobject]
+        Checks      = New-Object System.Collections.Generic.List[pscustomobject]
+        Source      = $source
+        Visibility  = 'full'
     }
 }
 
@@ -238,6 +239,42 @@ function Add-CategoryIssue {
     if ($source) { $entry['Source'] = $source }
 
     $CategoryResult.Issues.Add([pscustomobject]$entry) | Out-Null
+}
+
+function Set-CategoryVisibility {
+    param(
+        [Parameter(Mandatory)]
+        $CategoryResult,
+
+        [Parameter(Mandatory)]
+        [string]$Visibility
+    )
+
+    if (-not $CategoryResult) { return }
+
+    $normalized = $Visibility
+    if ($normalized) {
+        $normalized = $normalized.Trim().ToLowerInvariant()
+    }
+
+    switch ($normalized) {
+        'full'     { $normalized = 'full' }
+        'partial'  { $normalized = 'partial' }
+        'none'     { $normalized = 'none' }
+        default    {
+            if (-not [string]::IsNullOrWhiteSpace($Visibility)) {
+                $normalized = $Visibility
+            } else {
+                $normalized = 'full'
+            }
+        }
+    }
+
+    if ($CategoryResult.PSObject.Properties['Visibility']) {
+        $CategoryResult.Visibility = $normalized
+    } else {
+        $CategoryResult | Add-Member -MemberType NoteProperty -Name 'Visibility' -Value $normalized
+    }
 }
 
 function Add-CategoryNormal {


### PR DESCRIPTION
## Summary
- collect AppLocker EXE/DLL and MSI/Script channels for the events artifact to enable application control analysis
- add an Events-category heuristic that flags repeated AppLocker denials/audits, masks evidence, and marks partial visibility when channels are missing
- extend the analyzer framework with category visibility metadata and helpers for application control evidence masking

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -Command ". ./Analyzers/AnalyzerCommon.ps1; . ./Analyzers/Heuristics/Events.ps1"` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd321d5f50832db6dbde6cfaeb4a1d