### PR TITLE
Document issue card plain English explanation requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository-wide agent instructions
+
+- Every issue card emitted by analyzers or report components must include a single, plain-English sentence summarizing the real-world impact for technicians or end users. Keep this line concise (one sentence) and ensure it clearly conveys the consequence of the issue.
+- When editing heuristics, analyzers, or report templates, verify that any new or updated issue cards follow this plain-English explanation requirement. If the collected data cannot supply enough context, note that in the explanation.
+- Refer to the "Issue card authoring conventions" section of `README.md` for additional background.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ All collector scripts use `CollectorCommon.ps1` helpers to enforce a consistent 
 
 HTML is produced by `HtmlComposer.ps1`, which receives category results from each heuristic module. The analyzer also returns flattened issue, normal, and check collections for programmatic consumption.
 
+### Issue card authoring conventions
+
+When adding or updating heuristics that emit issue cards, always include a single plain-English sentence in the card that explains the practical ramifications for the technician or end user. This one-line explanation should make the impact obvious without requiring deep protocol knowledge.
+
 ## Heuristic catalogue
 
 The following sections list the analysis functions and issue card heuristics grouped by their respective categories. Each heuristic summarizes the conditions that raise issues and the severity levels applied.


### PR DESCRIPTION
## Summary
- add repository-wide instructions ensuring each issue card contains a plain-English, one-line impact explanation
- document the new issue card authoring convention in the README for heuristic contributors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de0e223018832d80a251094304e157