### PR TITLE
Add measured boot collector and heuristics

### DIFF
--- a/Analyzers/Heuristics/Security.ps1
+++ b/Analyzers/Heuristics/Security.ps1
@@ -489,6 +489,165 @@ function Invoke-SecurityHeuristics {
         Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'BitLocker artifact not collected, so the encryption state and data exposure risk are unknown.' -Subcategory 'BitLocker'
     }
 
+    $measuredBootArtifact = Get-AnalyzerArtifact -Context $Context -Name 'measured-boot'
+    Write-HeuristicDebug -Source 'Security' -Message 'Resolved measured boot artifact' -Data ([ordered]@{
+        Found = [bool]$measuredBootArtifact
+    })
+    if ($measuredBootArtifact) {
+        $measuredPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $measuredBootArtifact)
+        Write-HeuristicDebug -Source 'Security' -Message 'Evaluating measured boot payload' -Data ([ordered]@{
+            HasPayload = [bool]$measuredPayload
+        })
+
+        if ($measuredPayload) {
+            $bitlockerSection = $null
+            if ($measuredPayload.PSObject.Properties['BitLocker']) { $bitlockerSection = $measuredPayload.BitLocker }
+
+            $pcrHandled = $false
+            if ($bitlockerSection -and $bitlockerSection.PSObject.Properties['Volumes']) {
+                $pcrHandled = $true
+                $volumeData = $bitlockerSection.Volumes
+                if ($volumeData -and $volumeData.PSObject -and $volumeData.PSObject.Properties['Error'] -and $volumeData.Error) {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'BitLocker PCR binding query failed, so boot integrity attestation cannot be confirmed.' -Evidence $volumeData.Error -Subcategory 'Measured Boot'
+                } else {
+                    $volumes = ConvertTo-List $volumeData
+                    $pcrEvidence = [System.Collections.Generic.List[string]]::new()
+                    foreach ($volume in $volumes) {
+                        if (-not $volume) { continue }
+                        $mount = $null
+                        if ($volume.PSObject.Properties['MountPoint'] -and $volume.MountPoint) {
+                            $mount = [string]$volume.MountPoint
+                        }
+                        if (-not $mount) { $mount = 'Unknown volume' }
+
+                        $protectors = @()
+                        if ($volume.PSObject.Properties['KeyProtectors']) {
+                            $protectors = ConvertTo-List $volume.KeyProtectors
+                        } elseif ($volume.PSObject.Properties['KeyProtector']) {
+                            $protectors = ConvertTo-List $volume.KeyProtector
+                        }
+
+                        foreach ($protector in $protectors) {
+                            if (-not $protector) { continue }
+                            $bindingValues = @()
+                            if ($protector.PSObject.Properties['PcrBinding'] -and $protector.PcrBinding) {
+                                $bindingValues = ConvertTo-List $protector.PcrBinding
+                            }
+                            if (-not $bindingValues -or $bindingValues.Count -eq 0) { continue }
+
+                            $protectorType = $null
+                            if ($protector.PSObject.Properties['KeyProtectorType'] -and $protector.KeyProtectorType) {
+                                $protectorType = [string]$protector.KeyProtectorType
+                            }
+                            if (-not $protectorType) { $protectorType = 'Unknown protector' }
+
+                            $hashAlgorithm = $null
+                            if ($protector.PSObject.Properties['PcrHashAlgorithm'] -and $protector.PcrHashAlgorithm) {
+                                $hashAlgorithm = [string]$protector.PcrHashAlgorithm
+                            }
+
+                            $line = [System.Text.StringBuilder]::new()
+                            $null = $line.AppendFormat('Mount {0}: {1} bound to PCRs {2}', $mount, $protectorType, ($bindingValues -join ', '))
+                            if ($hashAlgorithm) {
+                                $null = $line.AppendFormat(' (Hash={0})', $hashAlgorithm)
+                            }
+
+                            $pcrEvidence.Add($line.ToString()) | Out-Null
+                        }
+                    }
+
+                    if ($pcrEvidence.Count -gt 0) {
+                        Add-CategoryNormal -CategoryResult $result -Title 'BitLocker PCR bindings captured for TPM-protected volumes.' -Evidence ($pcrEvidence.ToArray() -join "`n") -Subcategory 'Measured Boot'
+                    } else {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'BitLocker PCR binding data unavailable, so boot integrity attestation cannot be confirmed.' -Subcategory 'Measured Boot'
+                    }
+                }
+            }
+
+            if (-not $pcrHandled) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'BitLocker PCR binding data unavailable, so boot integrity attestation cannot be confirmed.' -Subcategory 'Measured Boot'
+            }
+
+            $attestationHandled = $false
+            if ($measuredPayload.PSObject.Properties['Attestation']) {
+                $attestationHandled = $true
+                $attestation = $measuredPayload.Attestation
+                if ($attestation -and $attestation.PSObject.Properties['Error'] -and $attestation.Error) {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Measured boot attestation query failed (MDM required), so remote health attestations cannot be confirmed.' -Evidence $attestation.Error -Subcategory 'Measured Boot'
+                } else {
+                    $events = @()
+                    if ($attestation -and $attestation.PSObject.Properties['Events']) {
+                        $events = ConvertTo-List $attestation.Events
+                    }
+
+                    $validEvents = @($events | Where-Object { $_ })
+                    if ($validEvents.Count -gt 0) {
+                        $sampleEvents = $validEvents | Select-Object -First 3
+                        $eventLines = [System.Collections.Generic.List[string]]::new()
+                        foreach ($evt in $sampleEvents) {
+                            $idText = 'ID ?'
+                            if ($evt.PSObject.Properties['Id'] -and $evt.Id -ne $null) { $idText = 'ID ' + $evt.Id }
+                            $timeText = 'Unknown time'
+                            if ($evt.PSObject.Properties['TimeCreated'] -and $evt.TimeCreated) { $timeText = [string]$evt.TimeCreated }
+                            $levelText = 'Unknown level'
+                            if ($evt.PSObject.Properties['Level'] -and $evt.Level) { $levelText = [string]$evt.Level }
+                            $eventLines.Add(('{0} at {1} ({2})' -f $idText, $timeText, $levelText)) | Out-Null
+                        }
+
+                        $evidence = [System.Collections.Generic.List[string]]::new()
+                        if ($attestation -and $attestation.PSObject.Properties['LogName'] -and $attestation.LogName) {
+                            $evidence.Add('Log: ' + [string]$attestation.LogName) | Out-Null
+                        }
+                        foreach ($line in $eventLines) { $evidence.Add($line) | Out-Null }
+
+                        Add-CategoryNormal -CategoryResult $result -Title 'Measured boot attestation events captured from TPM WMI log.' -Evidence ($evidence.ToArray() -join "`n") -Subcategory 'Measured Boot'
+                    } else {
+                        $noEventEvidence = 'No attestation events were returned by the collector.'
+                        if ($attestation -and $attestation.PSObject.Properties['LogName'] -and $attestation.LogName) {
+                            $noEventEvidence = 'Log: ' + [string]$attestation.LogName + ' returned 0 events.'
+                        }
+
+                        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Measured boot attestation events missing (MDM required), so remote health attestations cannot be confirmed.' -Evidence $noEventEvidence -Subcategory 'Measured Boot'
+                    }
+                }
+            }
+
+            if (-not $attestationHandled) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Measured boot attestation events missing (MDM required), so remote health attestations cannot be confirmed.' -Subcategory 'Measured Boot'
+            }
+
+            $secureBootHandled = $false
+            if ($measuredPayload.PSObject.Properties['SecureBoot']) {
+                $secureBootHandled = $true
+                $secureBoot = $measuredPayload.SecureBoot
+                if ($secureBoot -and $secureBoot.PSObject.Properties['Error'] -and $secureBoot.Error) {
+                    Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Secure Boot confirmation unavailable, so firmware integrity checks cannot be verified.' -Evidence $secureBoot.Error -Subcategory 'Measured Boot'
+                } else {
+                    $enabled = $null
+                    if ($secureBoot -and $secureBoot.PSObject.Properties['Enabled']) {
+                        $enabled = ConvertTo-NullableBool $secureBoot.Enabled
+                    }
+
+                    if ($enabled -eq $true) {
+                        Add-CategoryNormal -CategoryResult $result -Title 'Secure Boot confirmed by firmware.' -Evidence 'Confirm-SecureBootUEFI returned True.' -Subcategory 'Measured Boot'
+                    } elseif ($enabled -eq $false) {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Secure Boot reported disabled, so firmware integrity checks are bypassed.' -Evidence 'Confirm-SecureBootUEFI returned False.' -Subcategory 'Measured Boot'
+                    } else {
+                        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Secure Boot confirmation unavailable, so firmware integrity checks cannot be verified.' -Subcategory 'Measured Boot'
+                    }
+                }
+            }
+
+            if (-not $secureBootHandled) {
+                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Secure Boot confirmation unavailable, so firmware integrity checks cannot be verified.' -Subcategory 'Measured Boot'
+            }
+        } else {
+            Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Measured boot artifact missing expected structure, so boot integrity attestation cannot be confirmed.' -Subcategory 'Measured Boot'
+        }
+    } else {
+        Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Measured boot artifact not collected (MDM required), so boot integrity attestation cannot be confirmed.' -Subcategory 'Measured Boot'
+    }
+
     $tpmArtifact = Get-AnalyzerArtifact -Context $Context -Name 'tpm'
     Write-HeuristicDebug -Source 'Security' -Message 'Resolved TPM artifact' -Data ([ordered]@{
         Found = [bool]$tpmArtifact

--- a/Collectors/Security/Collect-MeasuredBoot.ps1
+++ b/Collectors/Security/Collect-MeasuredBoot.ps1
@@ -1,0 +1,168 @@
+<#!
+.SYNOPSIS
+    Collects measured boot evidence including PCR bindings, Secure Boot status, and TPM attestation events.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\CollectorCommon.ps1')
+
+function ConvertTo-Array {
+    param($Value)
+
+    if ($null -eq $Value) { return @() }
+    if ($Value -is [string]) { return @($Value) }
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string])) {
+        $list = [System.Collections.Generic.List[object]]::new()
+        foreach ($item in $Value) { $null = $list.Add($item) }
+        return $list.ToArray()
+    }
+
+    return @($Value)
+}
+
+function Get-BitLockerPcrBindings {
+    try {
+        $volumes = Get-BitLockerVolume -ErrorAction Stop
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Get-BitLockerVolume'
+            Error  = $_.Exception.Message
+        }
+    }
+
+    $volumeResults = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($volume in $volumes) {
+        if (-not $volume) { continue }
+
+        $volumeEntry = [ordered]@{}
+        if ($volume.PSObject.Properties['MountPoint']) { $volumeEntry['MountPoint'] = $volume.MountPoint }
+        if ($volume.PSObject.Properties['VolumeType']) { $volumeEntry['VolumeType'] = $volume.VolumeType }
+        if ($volume.PSObject.Properties['CapacityGB']) { $volumeEntry['CapacityGB'] = $volume.CapacityGB }
+        if ($volume.PSObject.Properties['EncryptionMethod']) { $volumeEntry['EncryptionMethod'] = $volume.EncryptionMethod }
+
+        $protectorList = [System.Collections.Generic.List[object]]::new()
+        foreach ($protector in (ConvertTo-Array $volume.KeyProtector)) {
+            if (-not $protector) { continue }
+
+            $protectorEntry = [ordered]@{}
+            if ($protector.PSObject.Properties['KeyProtectorId']) { $protectorEntry['KeyProtectorId'] = $protector.KeyProtectorId }
+            if ($protector.PSObject.Properties['KeyProtectorType']) { $protectorEntry['KeyProtectorType'] = $protector.KeyProtectorType }
+            if ($protector.PSObject.Properties['AutoUnlockEnabled']) { $protectorEntry['AutoUnlockEnabled'] = $protector.AutoUnlockEnabled }
+            if ($protector.PSObject.Properties['PcrBinding']) {
+                $bindingValues = ConvertTo-Array $protector.PcrBinding
+                if ($bindingValues.Count -gt 0) {
+                    $protectorEntry['PcrBinding'] = $bindingValues
+                }
+            }
+            if ($protector.PSObject.Properties['PcrHashAlgorithm']) {
+                $protectorEntry['PcrHashAlgorithm'] = $protector.PcrHashAlgorithm
+            } elseif ($protector.PSObject.Properties['PcrAlgorithmId']) {
+                $protectorEntry['PcrHashAlgorithm'] = $protector.PcrAlgorithmId
+            }
+            if ($protector.PSObject.Properties['TpmKeyId']) { $protectorEntry['TpmKeyId'] = $protector.TpmKeyId }
+            if ($protector.PSObject.Properties['RecoveryPasswordId']) { $protectorEntry['RecoveryPasswordId'] = $protector.RecoveryPasswordId }
+
+            $protectorList.Add([PSCustomObject]$protectorEntry) | Out-Null
+        }
+
+        $volumeEntry['KeyProtectors'] = $protectorList.ToArray()
+        $volumeResults.Add([PSCustomObject]$volumeEntry) | Out-Null
+    }
+
+    return $volumeResults.ToArray()
+}
+
+function Get-SecureBootVerification {
+    $cmd = Get-Command -Name 'Confirm-SecureBootUEFI' -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        return [PSCustomObject]@{
+            Source = 'Confirm-SecureBootUEFI'
+            Error  = 'Confirm-SecureBootUEFI not available on this system.'
+        }
+    }
+
+    try {
+        $enabled = Confirm-SecureBootUEFI -ErrorAction Stop
+        return [PSCustomObject]@{
+            Source  = 'Confirm-SecureBootUEFI'
+            Enabled = [bool]$enabled
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Source = 'Confirm-SecureBootUEFI'
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Get-MeasuredBootAttestation {
+    $logName = 'Microsoft-Windows-TPM-WMI/Operational'
+
+    try {
+        $null = Get-WinEvent -ListLog $logName -ErrorAction Stop
+    } catch {
+        return [PSCustomObject]@{
+            Source  = 'Get-WinEvent'
+            LogName = $logName
+            Error   = $_.Exception.Message
+        }
+    }
+
+    try {
+        $events = Get-WinEvent -LogName $logName -MaxEvents 50 -ErrorAction Stop
+    } catch {
+        return [PSCustomObject]@{
+            Source  = 'Get-WinEvent'
+            LogName = $logName
+            Error   = $_.Exception.Message
+        }
+    }
+
+    $eventSummaries = [System.Collections.Generic.List[object]]::new()
+    foreach ($event in $events) {
+        if (-not $event) { continue }
+
+        $entry = [ordered]@{}
+        if ($event.Id) { $entry['Id'] = [int]$event.Id }
+        if ($event.RecordId) { $entry['RecordId'] = [long]$event.RecordId }
+        if ($event.TimeCreated) { $entry['TimeCreated'] = $event.TimeCreated.ToString('o') }
+        if ($event.LevelDisplayName) { $entry['Level'] = [string]$event.LevelDisplayName }
+        if ($event.ProviderName) { $entry['Provider'] = [string]$event.ProviderName }
+        $message = $null
+        try {
+            if ($event.Message) {
+                $message = [string]$event.Message
+                if ($message) { $message = $message.Trim() }
+            }
+        } catch {
+            $message = $null
+        }
+        if ($message) { $entry['Message'] = $message }
+
+        $eventSummaries.Add([PSCustomObject]$entry) | Out-Null
+    }
+
+    return [PSCustomObject]@{
+        LogName = $logName
+        Events  = $eventSummaries.ToArray()
+    }
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        BitLocker  = [ordered]@{ Volumes = Get-BitLockerPcrBindings }
+        SecureBoot = Get-SecureBootVerification
+        Attestation = Get-MeasuredBootAttestation
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'measured-boot.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This README documents how the system fits together and enumerates the available 
   ```powershell
   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
   ```
+- Devices must be enrolled with Microsoft Intune or another MDM that enables health attestation if you want the measured boot collector to retrieve TPM attestation logs; without MDM integration those events are not written for remote collection.
 
 ## Quick start
 
@@ -95,6 +96,7 @@ The following sections list the analysis functions and issue card heuristics gro
 ## Security Heuristics
 - **Security (Microsoft Defender)** – Surfaces high severity when real-time protection is off, escalates signature age (medium/high/critical tiers), and reports high issues for missing engine/platform updates or informational gaps when Defender data is absent.
 - **Security/BitLocker** – Covers missing cmdlets (low), query failures (low), OS volumes without protection (critical), incomplete encryption (high), unclear state (low), no protected volumes (high), unparsed output (low), empty files (low), and missing recovery passwords (high).
+- **Security/Measured Boot** – Records healthy findings when PCR bindings, Secure Boot confirmation, and TPM attestation events are present, and raises informational issues when those signals are missing (flagging MDM requirements for attestation data gaps).
 - **Security/TPM** – Issues medium severity when a TPM exists but is not ready and high severity when no TPM is detected on hardware that should have one.
 - **Security/HVCI** – Marks medium issues when virtualization-based memory integrity is available but off or when Device Guard data is missing.
 - **Security/Credential Guard** – Raises a high-severity item if Credential Guard or RunAsPPL is not enforced.


### PR DESCRIPTION
## Summary
- add a measured boot security collector that exports BitLocker PCR bindings, Secure Boot status, and TPM attestation events
- extend the security heuristics to surface measured boot normals and informational issues, including MDM-required gaps
- document the MDM attestation prerequisite and measured boot heuristic in the README

## Testing
- `pwsh -NoLogo -Command "Set-Location '/workspace/AutoHelpDesk'; . './Analyzers/Heuristics/Security.ps1'"` *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_68de1187b08c832d836294a851a4a185