### PR TITLE
Enhance network diagnostics for captive portal detection

### DIFF
--- a/Analyzers/Heuristics/Network/Network-BaselineHelper.ps1
+++ b/Analyzers/Heuristics/Network/Network-BaselineHelper.ps1
@@ -1,0 +1,350 @@
+<#!
+.SYNOPSIS
+    Shared helper functions for resolving corporate network baseline expectations.
+#>
+
+function ConvertTo-NetworkBaselineArray {
+    param($Value)
+
+    if ($null -eq $Value) { return @() }
+    if ($Value -is [string]) { return @($Value) }
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [hashtable])) {
+        $items = @()
+        foreach ($item in $Value) { $items += $item }
+        return $items
+    }
+
+    return @($Value)
+}
+
+function ConvertTo-NetworkBaselineStringList {
+    param($Value)
+
+    $results = New-Object System.Collections.Generic.List[string]
+    foreach ($item in (ConvertTo-NetworkBaselineArray $Value)) {
+        if ($null -eq $item) { continue }
+        try {
+            $text = [string]$item
+        } catch {
+            $text = $item.ToString()
+        }
+
+        if ([string]::IsNullOrWhiteSpace($text)) { continue }
+        $trimmed = $text.Trim()
+        if (-not $results.Contains($trimmed)) {
+            $results.Add($trimmed) | Out-Null
+        }
+    }
+
+    return $results.ToArray()
+}
+
+function ConvertTo-NetworkBaselineIpv4Int {
+    param([string]$Address)
+
+    if ([string]::IsNullOrWhiteSpace($Address)) { return $null }
+
+    $candidate = $Address.Trim()
+    if (-not $candidate) { return $null }
+
+    $candidate = $candidate.Split('%')[0]
+
+    $ip = $null
+    if (-not [System.Net.IPAddress]::TryParse($candidate, [ref]$ip)) { return $null }
+    if ($ip.AddressFamily -ne [System.Net.Sockets.AddressFamily]::InterNetwork) { return $null }
+
+    $bytes = $ip.GetAddressBytes()
+    if ([System.BitConverter]::IsLittleEndian) { [Array]::Reverse($bytes) }
+
+    return [System.BitConverter]::ToUInt32($bytes, 0)
+}
+
+function ConvertTo-NetworkBaselineSubnetSpec {
+    param($Value)
+
+    if ($null -eq $Value) { return $null }
+
+    if ($Value -is [string]) {
+        $text = $Value.Trim()
+        if (-not $text) { return $null }
+
+        if ($text -match '^\d+\.\d+\.\d+\.\d+/\d{1,2}$') {
+            $parts = $text.Split('/')
+            if ($parts.Count -ne 2) { return $null }
+            $networkInt = ConvertTo-NetworkBaselineIpv4Int $parts[0]
+            if ($null -eq $networkInt) { return $null }
+            $prefix = [int]$parts[1]
+            if ($prefix -lt 0 -or $prefix -gt 32) { return $null }
+
+            return [pscustomobject]@{
+                Type       = 'cidr'
+                Text       = $text
+                Network    = $parts[0]
+                NetworkInt = $networkInt
+                Prefix     = $prefix
+            }
+        }
+
+        if ($text -match '^\d+\.\d+\.\d+\.\d+\s*-\s*\d+\.\d+\.\d+\.\d+$') {
+            $rangeParts = $text -split '\s*-\s*'
+            if ($rangeParts.Count -ne 2) { return $null }
+            $startInt = ConvertTo-NetworkBaselineIpv4Int $rangeParts[0]
+            $endInt = ConvertTo-NetworkBaselineIpv4Int $rangeParts[1]
+            if ($null -eq $startInt -or $null -eq $endInt) { return $null }
+            if ($endInt -lt $startInt) {
+                $temp = $startInt
+                $startInt = $endInt
+                $endInt = $temp
+            }
+
+            return [pscustomobject]@{
+                Type    = 'range'
+                Text    = $text
+                Start   = $rangeParts[0]
+                End     = $rangeParts[1]
+                StartInt = $startInt
+                EndInt   = $endInt
+            }
+        }
+
+        $ipInt = ConvertTo-NetworkBaselineIpv4Int $text
+        if ($null -eq $ipInt) { return $null }
+
+        return [pscustomobject]@{
+            Type      = 'exact'
+            Text      = $text
+            Address   = $text
+            AddressInt = $ipInt
+        }
+    }
+
+    if ($Value.PSObject -and $Value.PSObject.Properties['Cidr'] -and $Value.Cidr) {
+        return ConvertTo-NetworkBaselineSubnetSpec ([string]$Value.Cidr)
+    }
+
+    if ($Value.PSObject -and $Value.PSObject.Properties['Network'] -and $Value.PSObject.Properties['Prefix']) {
+        $network = [string]$Value.Network
+        $prefix = [int]$Value.Prefix
+        if ([string]::IsNullOrWhiteSpace($network)) { return $null }
+        return ConvertTo-NetworkBaselineSubnetSpec ("{0}/{1}" -f $network, $prefix)
+    }
+
+    $startProperty = $null
+    foreach ($candidate in @('Start', 'StartAddress', 'RangeStart')) {
+        if ($Value.PSObject.Properties[$candidate] -and $Value.$candidate) {
+            $startProperty = $candidate
+            break
+        }
+    }
+
+    $endProperty = $null
+    foreach ($candidate in @('End', 'EndAddress', 'RangeEnd')) {
+        if ($Value.PSObject.Properties[$candidate] -and $Value.$candidate) {
+            $endProperty = $candidate
+            break
+        }
+    }
+
+    if ($startProperty -and $endProperty) {
+        $start = [string]$Value.$startProperty
+        $end = [string]$Value.$endProperty
+        if (-not [string]::IsNullOrWhiteSpace($start) -and -not [string]::IsNullOrWhiteSpace($end)) {
+            return ConvertTo-NetworkBaselineSubnetSpec ("{0}-{1}" -f $start.Trim(), $end.Trim())
+        }
+    }
+
+    if ($Value.PSObject -and $Value.PSObject.Properties['Address'] -and $Value.Address) {
+        return ConvertTo-NetworkBaselineSubnetSpec ([string]$Value.Address)
+    }
+
+    return $null
+}
+
+function Test-NetworkBaselineIpv4Match {
+    param(
+        [string]$Address,
+        $Subnets
+    )
+
+    $addressInt = ConvertTo-NetworkBaselineIpv4Int $Address
+    if ($null -eq $addressInt) { return $false }
+
+    foreach ($candidate in (ConvertTo-NetworkBaselineArray $Subnets)) {
+        if (-not $candidate) { continue }
+        $spec = if ($candidate.PSObject -and $candidate.PSObject.Properties['Type']) {
+            $candidate
+        } else {
+            ConvertTo-NetworkBaselineSubnetSpec $candidate
+        }
+
+        if (-not $spec) { continue }
+
+        switch ($spec.Type) {
+            'cidr' {
+                $prefix = [int]$spec.Prefix
+                $networkInt = $spec.NetworkInt
+                if ($null -eq $networkInt) { $networkInt = ConvertTo-NetworkBaselineIpv4Int $spec.Network }
+                if ($null -eq $networkInt) { continue }
+
+                if ($prefix -le 0) {
+                    return $true
+                } elseif ($prefix -ge 32) {
+                    if ($addressInt -eq $networkInt) { return $true }
+                } else {
+                    $mask = ([uint32]0xFFFFFFFF -shl (32 - $prefix))
+                    if (($addressInt -band $mask) -eq ($networkInt -band $mask)) { return $true }
+                }
+                continue
+            }
+            'range' {
+                $startInt = $spec.StartInt
+                if ($null -eq $startInt) { $startInt = ConvertTo-NetworkBaselineIpv4Int $spec.Start }
+                $endInt = $spec.EndInt
+                if ($null -eq $endInt) { $endInt = ConvertTo-NetworkBaselineIpv4Int $spec.End }
+                if ($null -eq $startInt -or $null -eq $endInt) { continue }
+                if ($startInt -le $addressInt -and $addressInt -le $endInt) { return $true }
+                continue
+            }
+            'exact' {
+                $expectedInt = $spec.AddressInt
+                if ($null -eq $expectedInt) { $expectedInt = ConvertTo-NetworkBaselineIpv4Int $spec.Address }
+                if ($null -eq $expectedInt) { continue }
+                if ($expectedInt -eq $addressInt) { return $true }
+                continue
+            }
+            default {
+                $converted = ConvertTo-NetworkBaselineSubnetSpec $spec
+                if ($converted -and (Test-NetworkBaselineIpv4Match -Address $Address -Subnets @($converted))) {
+                    return $true
+                }
+            }
+        }
+    }
+
+    return $false
+}
+
+function Test-NetworkBaselineHostMatch {
+    param(
+        [string]$Candidate,
+        $Expected
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Candidate)) { return $false }
+
+    $normalizedCandidate = $Candidate.Trim().Split('%')[0]
+    if (-not $normalizedCandidate) { return $false }
+    $normalizedCandidate = $normalizedCandidate.ToLowerInvariant()
+
+    foreach ($item in (ConvertTo-NetworkBaselineArray $Expected)) {
+        if ($null -eq $item) { continue }
+        $text = [string]$item
+        if ([string]::IsNullOrWhiteSpace($text)) { continue }
+        $normalizedExpected = $text.Trim().Split('%')[0].ToLowerInvariant()
+        if ($normalizedExpected -eq $normalizedCandidate) { return $true }
+    }
+
+    return $false
+}
+
+function Get-NetworkBaselinePayload {
+    param($Context)
+
+    if (-not $Context -or -not $Context.Artifacts) { return $null }
+
+    $candidates = @('network-baseline', 'corporate-network', 'dhcp-baseline', 'corporate-network-baseline')
+    foreach ($candidate in $candidates) {
+        foreach ($suffix in @('', '.json')) {
+            $key = ($candidate + $suffix).ToLowerInvariant()
+            if (-not $Context.Artifacts.ContainsKey($key)) { continue }
+
+            $entries = $Context.Artifacts[$key]
+            $list = @()
+            if ($entries -is [System.Collections.IEnumerable] -and -not ($entries -is [string])) {
+                foreach ($entry in $entries) { $list += $entry }
+            } else {
+                $list = @($entries)
+            }
+
+            foreach ($entry in $list) {
+                if (-not $entry) { continue }
+                if ($entry.PSObject.Properties['Data'] -and $entry.Data) {
+                    $data = $entry.Data
+                    if ($data.PSObject -and $data.PSObject.Properties['Error']) { continue }
+                    if ($data.PSObject -and $data.PSObject.Properties['Payload'] -and $data.Payload) {
+                        $payloadData = $data.Payload
+                    } else {
+                        $payloadData = $data
+                    }
+
+                    return [pscustomobject]@{
+                        Data   = $payloadData
+                        Source = if ($entry.PSObject.Properties['Path']) { [string]$entry.Path } else { $null }
+                    }
+                }
+            }
+        }
+    }
+
+    return $null
+}
+
+function Get-NetworkCorporateExpectations {
+    param($Context)
+
+    $baseline = Get-NetworkBaselinePayload -Context $Context
+    if (-not $baseline -or -not $baseline.Data) { return $null }
+
+    $node = $baseline.Data
+    if ($node.PSObject -and $node.PSObject.Properties['Payload'] -and $node.Payload) {
+        $node = $node.Payload
+    }
+
+    if ($node.PSObject -and $node.PSObject.Properties['CorporateNetworks'] -and $node.CorporateNetworks) {
+        $node = $node.CorporateNetworks
+    }
+
+    $subnetSpecs = New-Object System.Collections.Generic.List[object]
+    $serverList = New-Object System.Collections.Generic.List[string]
+    $gatewayList = New-Object System.Collections.Generic.List[string]
+
+    $nodesToProcess = @($node)
+    if ($node.PSObject -and $node.PSObject.Properties['Dhcp'] -and $node.Dhcp) {
+        $nodesToProcess += $node.Dhcp
+    }
+
+    foreach ($current in $nodesToProcess) {
+        if (-not $current) { continue }
+
+        foreach ($propertyName in @('CorporateSubnets','Subnets','Networks','DhcpScopes','Scopes','Ipv4Subnets','IPv4Subnets','Ranges')) {
+            if (-not $current.PSObject.Properties[$propertyName]) { continue }
+            foreach ($value in (ConvertTo-NetworkBaselineArray $current.$propertyName)) {
+                $spec = ConvertTo-NetworkBaselineSubnetSpec $value
+                if ($spec) { $subnetSpecs.Add($spec) | Out-Null }
+            }
+        }
+
+        foreach ($propertyName in @('DhcpServers','Servers','CorporateDhcpServers','ServerAddresses')) {
+            if (-not $current.PSObject.Properties[$propertyName]) { continue }
+            foreach ($value in (ConvertTo-NetworkBaselineStringList $current.$propertyName)) {
+                if (-not $serverList.Contains($value)) { $serverList.Add($value) | Out-Null }
+            }
+        }
+
+        foreach ($propertyName in @('Gateways','DefaultGateways','CorporateGateways')) {
+            if (-not $current.PSObject.Properties[$propertyName]) { continue }
+            foreach ($value in (ConvertTo-NetworkBaselineStringList $current.$propertyName)) {
+                if (-not $gatewayList.Contains($value)) { $gatewayList.Add($value) | Out-Null }
+            }
+        }
+    }
+
+    if ($subnetSpecs.Count -eq 0 -and $serverList.Count -eq 0 -and $gatewayList.Count -eq 0) { return $null }
+
+    return [pscustomobject]@{
+        Subnets     = $subnetSpecs.ToArray()
+        DhcpServers = $serverList.ToArray()
+        Gateways    = $gatewayList.ToArray()
+        Source      = $baseline.Source
+    }
+}

--- a/Collectors/Network/Collect-Network.ps1
+++ b/Collectors/Network/Collect-Network.ps1
@@ -26,13 +26,588 @@ function Get-ArpCache {
     return Invoke-CollectorNativeCommand -FilePath 'arp.exe' -ArgumentList '-a' -SourceLabel 'arp.exe'
 }
 
+function ConvertTo-NetworkCollectorArray {
+    param($Value)
+
+    if ($null -eq $Value) { return @() }
+    if ($Value -is [string]) { return @($Value) }
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [hashtable])) {
+        $items = @()
+        foreach ($item in $Value) { $items += $item }
+        return $items
+    }
+
+    return @($Value)
+}
+
+function ConvertTo-NetworkProbeStringArray {
+    param($Value)
+
+    $items = New-Object System.Collections.Generic.List[string]
+    foreach ($entry in (ConvertTo-NetworkCollectorArray $Value)) {
+        if ($null -eq $entry) { continue }
+        $text = [string]$entry
+        if ([string]::IsNullOrWhiteSpace($text)) { continue }
+        $candidate = $text.Trim()
+        if (-not $items.Contains($candidate)) { $items.Add($candidate) | Out-Null }
+    }
+
+    return $items.ToArray()
+}
+
+function New-NetworkProbeDefinition {
+    param(
+        $Entry,
+        [string]$DefaultType
+    )
+
+    if ($null -eq $Entry) { return $null }
+
+    if ($Entry -is [string]) {
+        $text = $Entry.Trim()
+        if (-not $text) { return $null }
+        if ($text -match '^(?i)https?://') {
+            try { $uri = [System.Uri]$text } catch { $uri = $null }
+            $host = if ($uri) { $uri.Host } else { $null }
+            $allowed = if ($host) { @($host) } else { @() }
+            return [pscustomobject]@{
+                Name                 = $text
+                Type                 = 'http'
+                Url                  = $text
+                ExpectHost           = $host
+                AllowedRedirectHosts = $allowed
+                TimeoutSeconds       = 5
+            }
+        }
+
+        return [pscustomobject]@{
+            Name       = $text
+            Type       = 'dns'
+            Query      = $text
+            RecordType = 'A'
+        }
+    }
+
+    $type = $null
+    if ($Entry.PSObject -and $Entry.PSObject.Properties['Type'] -and $Entry.Type) {
+        $type = [string]$Entry.Type
+    } elseif ($DefaultType) {
+        $type = $DefaultType
+    }
+
+    $normalizedType = $null
+    if ($type) {
+        $normalizedType = $type.Trim().ToLowerInvariant()
+    }
+
+    switch ($normalizedType) {
+        'dns' {
+            $query = $null
+            if ($Entry.PSObject.Properties['Query'] -and $Entry.Query) {
+                $query = [string]$Entry.Query
+            } elseif ($Entry.PSObject.Properties['Target'] -and $Entry.Target) {
+                $query = [string]$Entry.Target
+            } elseif ($Entry.PSObject.Properties['Name'] -and $Entry.Name) {
+                $query = [string]$Entry.Name
+            }
+
+            if ([string]::IsNullOrWhiteSpace($query)) { return $null }
+
+            $recordType = 'A'
+            if ($Entry.PSObject.Properties['RecordType'] -and $Entry.RecordType) {
+                $recordType = [string]$Entry.RecordType
+            }
+
+            $definition = [ordered]@{
+                Name       = if ($Entry.PSObject.Properties['Name'] -and $Entry.Name) { [string]$Entry.Name } else { $query }
+                Type       = 'dns'
+                Query      = $query
+                RecordType = $recordType
+            }
+
+            if ($Entry.PSObject.Properties['Server'] -and $Entry.Server) {
+                $definition['Server'] = [string]$Entry.Server
+            }
+
+            if ($Entry.PSObject.Properties['ExpectedSubnets'] -and $Entry.ExpectedSubnets) {
+                $definition['ExpectedSubnets'] = ConvertTo-NetworkProbeStringArray $Entry.ExpectedSubnets
+            } elseif ($Entry.PSObject.Properties['ExpectSubnets'] -and $Entry.ExpectSubnets) {
+                $definition['ExpectedSubnets'] = ConvertTo-NetworkProbeStringArray $Entry.ExpectSubnets
+            }
+
+            if ($Entry.PSObject.Properties['ExpectedAddresses'] -and $Entry.ExpectedAddresses) {
+                $definition['ExpectedAddresses'] = ConvertTo-NetworkProbeStringArray $Entry.ExpectedAddresses
+            }
+
+            return [pscustomobject]$definition
+        }
+        default {
+            $url = $null
+            if ($Entry.PSObject.Properties['Url'] -and $Entry.Url) {
+                $url = [string]$Entry.Url
+            } elseif ($Entry.PSObject.Properties['Target'] -and $Entry.Target) {
+                $url = [string]$Entry.Target
+            }
+
+            if ([string]::IsNullOrWhiteSpace($url)) { return $null }
+
+            $timeout = 5
+            if ($Entry.PSObject.Properties['TimeoutSeconds'] -and $Entry.TimeoutSeconds) {
+                try { $timeout = [int]$Entry.TimeoutSeconds } catch { $timeout = 5 }
+            }
+
+            $expectHost = $null
+            foreach ($property in @('ExpectedHost','ExpectHost')) {
+                if ($Entry.PSObject.Properties[$property] -and $Entry.$property) {
+                    $expectHost = [string]$Entry.$property
+                    break
+                }
+            }
+
+            if (-not $expectHost) {
+                try { $expectHost = ([System.Uri]$url).Host } catch { $expectHost = $null }
+            }
+
+            $allowed = @()
+            foreach ($property in @('AllowedRedirectHosts','AllowRedirectHosts')) {
+                if ($Entry.PSObject.Properties[$property] -and $Entry.$property) {
+                    $allowed = ConvertTo-NetworkProbeStringArray $Entry.$property
+                    break
+                }
+            }
+
+            if (($allowed.Count -eq 0) -and $expectHost) { $allowed = @($expectHost) }
+
+            $definition = [ordered]@{
+                Name                 = if ($Entry.PSObject.Properties['Name'] -and $Entry.Name) { [string]$Entry.Name } else { $url }
+                Type                 = 'http'
+                Url                  = $url
+                ExpectHost           = $expectHost
+                AllowedRedirectHosts = $allowed
+                TimeoutSeconds       = $timeout
+            }
+
+            foreach ($property in @('ExpectedStatus','ExpectStatus')) {
+                if ($Entry.PSObject.Properties[$property] -and $Entry.$property) {
+                    try { $definition['ExpectedStatus'] = [int]$Entry.$property } catch { }
+                    break
+                }
+            }
+
+            foreach ($property in @('ExpectContentPattern','ExpectedContentPattern')) {
+                if ($Entry.PSObject.Properties[$property] -and $Entry.$property) {
+                    $definition['ExpectContentPattern'] = [string]$Entry.$property
+                    break
+                }
+            }
+
+            return [pscustomobject]$definition
+        }
+    }
+}
+
+function ConvertTo-NetworkProbeDefinitionList {
+    param(
+        $Value,
+        [string]$DefaultType
+    )
+
+    $definitions = New-Object System.Collections.Generic.List[object]
+    foreach ($entry in (ConvertTo-NetworkCollectorArray $Value)) {
+        $definition = New-NetworkProbeDefinition -Entry $entry -DefaultType $DefaultType
+        if ($definition) { $definitions.Add($definition) | Out-Null }
+    }
+
+    return $definitions.ToArray()
+}
+
+function Get-NetworkProbeDefinitions {
+    $candidatePaths = New-Object System.Collections.Generic.List[string]
+
+    if ($env:AUTOHELPDESK_NETWORK_PROBES) {
+        foreach ($part in ($env:AUTOHELPDESK_NETWORK_PROBES -split ';')) {
+            if (-not [string]::IsNullOrWhiteSpace($part)) {
+                $candidatePaths.Add($part.Trim()) | Out-Null
+            }
+        }
+    }
+
+    $candidatePaths.Add((Join-Path -Path $PSScriptRoot -ChildPath 'NetworkProbes.json')) | Out-Null
+    $parent = Split-Path -Path $PSScriptRoot -Parent
+    if ($parent) {
+        $candidatePaths.Add((Join-Path -Path $parent -ChildPath 'NetworkProbes.json')) | Out-Null
+    }
+
+    $uniquePaths = $candidatePaths | Where-Object { $_ } | Select-Object -Unique
+    foreach ($path in $uniquePaths) {
+        if (-not (Test-Path -LiteralPath $path)) { continue }
+
+        try {
+            $content = Get-Content -Path $path -Raw -ErrorAction Stop
+            if ([string]::IsNullOrWhiteSpace($content)) { continue }
+            $json = $content | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            return [pscustomobject]@{
+                Source = $path
+                Error  = $_.Exception.Message
+            }
+        }
+
+        $definitions = New-Object System.Collections.Generic.List[object]
+
+        if ($json.PSObject -and $json.PSObject.Properties['Http']) {
+            foreach ($item in (ConvertTo-NetworkProbeDefinitionList -Value $json.Http -DefaultType 'http')) {
+                $definitions.Add($item) | Out-Null
+            }
+        }
+
+        if ($json.PSObject -and $json.PSObject.Properties['Dns']) {
+            foreach ($item in (ConvertTo-NetworkProbeDefinitionList -Value $json.Dns -DefaultType 'dns')) {
+                $definitions.Add($item) | Out-Null
+            }
+        }
+
+        if ($definitions.Count -eq 0) {
+            foreach ($item in (ConvertTo-NetworkProbeDefinitionList -Value $json -DefaultType $null)) {
+                $definitions.Add($item) | Out-Null
+            }
+        }
+
+        return [pscustomobject]@{
+            Source      = $path
+            Definitions = $definitions.ToArray()
+        }
+    }
+
+    return $null
+}
+
+function Get-DhcpOptionDetails {
+    try {
+        $adapters = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled = True" -ErrorAction Stop
+    } catch {
+        return @([pscustomobject]@{
+            Source = 'Get-CimInstance Win32_NetworkAdapterConfiguration'
+            Error  = $_.Exception.Message
+        })
+    }
+
+    $results = New-Object System.Collections.Generic.List[object]
+
+    foreach ($adapter in $adapters) {
+        if (-not $adapter) { continue }
+
+        $settingId = if ($adapter.PSObject.Properties['SettingID']) { [string]$adapter.SettingID } else { $null }
+        $leaseObtained = $null
+        if ($adapter.PSObject.Properties['DHCPLeaseObtained'] -and $adapter.DHCPLeaseObtained) {
+            try { $leaseObtained = ([datetime]$adapter.DHCPLeaseObtained).ToString('o') } catch { $leaseObtained = [string]$adapter.DHCPLeaseObtained }
+        }
+        $leaseExpires = $null
+        if ($adapter.PSObject.Properties['DHCPLeaseExpires'] -and $adapter.DHCPLeaseExpires) {
+            try { $leaseExpires = ([datetime]$adapter.DHCPLeaseExpires).ToString('o') } catch { $leaseExpires = [string]$adapter.DHCPLeaseExpires }
+        }
+
+        $entry = [ordered]@{
+            Description    = if ($adapter.PSObject.Properties['Description']) { [string]$adapter.Description } else { $null }
+            Caption        = if ($adapter.PSObject.Properties['Caption']) { [string]$adapter.Caption } else { $null }
+            InterfaceIndex = if ($adapter.PSObject.Properties['InterfaceIndex']) { $adapter.InterfaceIndex } else { $null }
+            Index          = if ($adapter.PSObject.Properties['Index']) { $adapter.Index } else { $null }
+            SettingId      = $settingId
+            DhcpServer     = if ($adapter.PSObject.Properties['DHCPServer']) { [string]$adapter.DHCPServer } else { $null }
+            LeaseObtained  = $leaseObtained
+            LeaseExpires   = $leaseExpires
+            DhcpOptions    = @{}
+        }
+
+        $options = [ordered]@{}
+        if ($settingId) {
+            $registryPath = "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces\\$settingId"
+            if (Test-Path -LiteralPath $registryPath) {
+                try {
+                    $values = Get-ItemProperty -Path $registryPath -ErrorAction Stop
+                    if ($values.PSObject.Properties['DhcpServer'] -and $values.DhcpServer) {
+                        $options['ServerIdentifier'] = [string]$values.DhcpServer
+                    }
+                    if ($values.PSObject.Properties['DhcpDomain'] -and $values.DhcpDomain) {
+                        $options['Domain'] = [string]$values.DhcpDomain
+                    }
+                    if ($values.PSObject.Properties['DhcpClassId'] -and $values.DhcpClassId) {
+                        $options['VendorClass'] = [string]$values.DhcpClassId
+                    }
+                    if ($values.PSObject.Properties['DhcpIPAddress'] -and $values.DhcpIPAddress) {
+                        $options['Address'] = [string]$values.DhcpIPAddress
+                    }
+                    if ($values.PSObject.Properties['DhcpDefaultGateway'] -and $values.DhcpDefaultGateway) {
+                        $rawGateway = $values.DhcpDefaultGateway
+                        if ($rawGateway -is [System.Collections.IEnumerable] -and -not ($rawGateway -is [string])) {
+                            $options['Gateway'] = @($rawGateway | ForEach-Object { [string]$_ })
+                        } else {
+                            $options['Gateway'] = @([string]$rawGateway)
+                        }
+                    }
+                } catch {
+                    $options['ReadError'] = $_.Exception.Message
+                }
+            } else {
+                $options['RegistryMissing'] = $true
+            }
+        }
+
+        $entry.DhcpOptions = $options
+        $results.Add([pscustomobject]$entry) | Out-Null
+    }
+
+    return $results.ToArray()
+}
+
+function Invoke-NetworkDnsProbe {
+    param(
+        $Definition
+    )
+
+    if (-not $Definition -or -not $Definition.PSObject.Properties['Query']) { return $null }
+
+    $recordType = if ($Definition.PSObject.Properties['RecordType'] -and $Definition.RecordType) { [string]$Definition.RecordType } else { 'A' }
+    $result = [ordered]@{
+        Name       = if ($Definition.PSObject.Properties['Name'] -and $Definition.Name) { [string]$Definition.Name } else { [string]$Definition.Query }
+        Type       = 'dns'
+        Query      = [string]$Definition.Query
+        RecordType = $recordType
+        Definition = [pscustomobject]$Definition
+        StartedAt  = (Get-Date).ToString('o')
+    }
+
+    if ($Definition.PSObject.Properties['Server'] -and $Definition.Server) {
+        $result['Server'] = [string]$Definition.Server
+    }
+
+    $addresses = New-Object System.Collections.Generic.List[string]
+    $cnames = New-Object System.Collections.Generic.List[string]
+    $records = New-Object System.Collections.Generic.List[object]
+    $success = $false
+    $errorMessage = $null
+    $lookupMethod = 'Resolve-DnsName'
+
+    try {
+        $parameters = @{ Name = $Definition.Query; ErrorAction = 'Stop' }
+        if ($Definition.PSObject.Properties['RecordType'] -and $Definition.RecordType) { $parameters['Type'] = $Definition.RecordType }
+        if ($Definition.PSObject.Properties['Server'] -and $Definition.Server) { $parameters['Server'] = $Definition.Server }
+        $rawRecords = Resolve-DnsName @parameters
+
+        foreach ($record in $rawRecords) {
+            if (-not $record) { continue }
+            $entry = [ordered]@{
+                Name = if ($record.PSObject.Properties['Name']) { [string]$record.Name } else { $Definition.Query }
+                Type = if ($record.PSObject.Properties['QueryType']) { [string]$record.QueryType } elseif ($record.PSObject.Properties['Type']) { [string]$record.Type } else { $recordType }
+            }
+            if ($record.PSObject.Properties['TTL']) { $entry['TTL'] = $record.TTL }
+            if ($record.PSObject.Properties['IPAddress'] -and $record.IPAddress) {
+                $ipText = [string]$record.IPAddress
+                $entry['IPAddress'] = $ipText
+                if (-not $addresses.Contains($ipText)) { $addresses.Add($ipText) | Out-Null }
+            }
+            if ($record.PSObject.Properties['NameHost'] -and $record.NameHost) {
+                $hostText = [string]$record.NameHost
+                $entry['NameHost'] = $hostText
+                if (-not $cnames.Contains($hostText)) { $cnames.Add($hostText) | Out-Null }
+            }
+            $records.Add([pscustomobject]$entry) | Out-Null
+        }
+
+        $success = $true
+    } catch {
+        $errorMessage = $_.Exception.Message
+        $lookupMethod = 'System.Net.Dns'
+
+        try {
+            $fallbackAddresses = [System.Net.Dns]::GetHostAddresses($Definition.Query)
+            foreach ($address in $fallbackAddresses) {
+                if (-not $address) { continue }
+                $text = $address.ToString()
+                if ([string]::IsNullOrWhiteSpace($text)) { continue }
+                if (-not $addresses.Contains($text)) { $addresses.Add($text) | Out-Null }
+            }
+            if ($addresses.Count -gt 0) { $success = $true; $errorMessage = $null }
+        } catch {
+            if (-not $errorMessage) { $errorMessage = $_.Exception.Message }
+        }
+    }
+
+    $result['LookupMethod'] = $lookupMethod
+    $result['CompletedAt'] = (Get-Date).ToString('o')
+    $result['Success'] = $success
+    $result['Addresses'] = $addresses.ToArray()
+    if ($cnames.Count -gt 0) { $result['CanonicalNames'] = $cnames.ToArray() }
+    if ($records.Count -gt 0) { $result['Records'] = $records.ToArray() }
+    if ($errorMessage) { $result['Error'] = $errorMessage }
+
+    return [pscustomobject]$result
+}
+
+function Invoke-NetworkHttpProbe {
+    param(
+        $Definition
+    )
+
+    if (-not $Definition -or -not $Definition.PSObject.Properties['Url']) { return $null }
+
+    $timeout = if ($Definition.PSObject.Properties['TimeoutSeconds'] -and $Definition.TimeoutSeconds) { [int]$Definition.TimeoutSeconds } else { 5 }
+    $result = [ordered]@{
+        Name                 = if ($Definition.PSObject.Properties['Name'] -and $Definition.Name) { [string]$Definition.Name } else { [string]$Definition.Url }
+        Type                 = 'http'
+        Url                  = [string]$Definition.Url
+        ExpectHost           = if ($Definition.PSObject.Properties['ExpectHost'] -and $Definition.ExpectHost) { [string]$Definition.ExpectHost } else { $null }
+        AllowedRedirectHosts = if ($Definition.PSObject.Properties['AllowedRedirectHosts'] -and $Definition.AllowedRedirectHosts) { ConvertTo-NetworkProbeStringArray $Definition.AllowedRedirectHosts } else { @() }
+        Definition           = [pscustomobject]$Definition
+        TimeoutSeconds       = $timeout
+        StartedAt            = (Get-Date).ToString('o')
+    }
+
+    if (-not $result.ExpectHost) {
+        try { $result.ExpectHost = ([System.Uri]$result.Url).Host } catch { }
+    }
+
+    if (($result.AllowedRedirectHosts.Count -eq 0) -and $result.ExpectHost) {
+        $result.AllowedRedirectHosts = @($result.ExpectHost)
+    }
+
+    if ($Definition.PSObject.Properties['ExpectedStatus'] -and $Definition.ExpectedStatus) {
+        try { $result['ExpectedStatus'] = [int]$Definition.ExpectedStatus } catch { }
+    }
+
+    if ($Definition.PSObject.Properties['ExpectContentPattern'] -and $Definition.ExpectContentPattern) {
+        $result['ExpectContentPattern'] = [string]$Definition.ExpectContentPattern
+    }
+
+    $statusCode = $null
+    $finalUrl = $null
+    $bodyPreview = $null
+    $headers = [ordered]@{}
+    $success = $false
+    $errorMessage = $null
+
+    try {
+        $invokeParameters = @{
+            Uri                = $result.Url
+            MaximumRedirection = 5
+            TimeoutSec         = $timeout
+            ErrorAction        = 'Stop'
+        }
+
+        try {
+            $invokeCommand = Get-Command -Name Invoke-WebRequest -ErrorAction SilentlyContinue
+            if ($invokeCommand -and $invokeCommand.Parameters.ContainsKey('UseBasicParsing')) {
+                $invokeParameters['UseBasicParsing'] = $true
+            }
+        } catch { }
+
+        $response = Invoke-WebRequest @invokeParameters
+        if ($response.StatusCode) { $statusCode = [int]$response.StatusCode }
+
+        if ($response.BaseResponse -and $response.BaseResponse.ResponseUri) {
+            $finalUrl = $response.BaseResponse.ResponseUri.AbsoluteUri
+        } elseif ($response.Headers -and $response.Headers['Location']) {
+            $finalUrl = [string]$response.Headers['Location']
+        }
+
+        if ($response.Headers) {
+            foreach ($key in $response.Headers.Keys) {
+                if (-not $key) { continue }
+                $headers[$key] = ($response.Headers[$key] -join ', ')
+            }
+        }
+
+        if ($response.Content) {
+            $text = [string]$response.Content
+            if ($text.Length -gt 0) {
+                $bodyPreview = if ($text.Length -gt 256) { $text.Substring(0,256) } else { $text }
+            }
+        }
+
+        $success = $true
+    } catch {
+        $errorMessage = $_.Exception.Message
+        if ($_.Exception.Response) {
+            $resp = $_.Exception.Response
+            try { $statusCode = [int]$resp.StatusCode } catch { }
+            try {
+                if ($resp.ResponseUri) {
+                    $finalUrl = $resp.ResponseUri.AbsoluteUri
+                }
+            } catch { }
+        }
+    }
+
+    if ($statusCode) { $result['StatusCode'] = $statusCode }
+    if ($finalUrl) { $result['FinalUrl'] = $finalUrl }
+    if ($result.FinalUrl) {
+        try { $result['FinalHost'] = ([System.Uri]$result.FinalUrl).Host } catch { }
+    }
+    if ($headers.Count -gt 0) { $result['Headers'] = $headers }
+    if ($bodyPreview) { $result['BodyPreview'] = $bodyPreview }
+    if ($errorMessage) { $result['Error'] = $errorMessage }
+
+    $result['Success'] = $success
+    $result['CompletedAt'] = (Get-Date).ToString('o')
+
+    return [pscustomobject]$result
+}
+
+function Invoke-NetworkProbes {
+    $probeResult = [ordered]@{
+        CapturedAt    = (Get-Date).ToString('o')
+        Http          = @()
+        Dns           = @()
+        Errors        = @()
+        Configuration = $null
+    }
+
+    $definitions = Get-NetworkProbeDefinitions
+    if ($definitions -and $definitions.PSObject.Properties['Error']) {
+        $probeResult.Errors = @([ordered]@{ Source = $definitions.Source; Error = $definitions.Error })
+        return [pscustomobject]$probeResult
+    }
+
+    if ($definitions -and $definitions.Definitions -and $definitions.Definitions.Count -gt 0) {
+        $probeResult.Configuration = [ordered]@{
+            Source = $definitions.Source
+            Targets = $definitions.Definitions
+        }
+
+        $httpResults = New-Object System.Collections.Generic.List[object]
+        $dnsResults = New-Object System.Collections.Generic.List[object]
+
+        foreach ($definition in $definitions.Definitions) {
+            if (-not $definition) { continue }
+            switch ($definition.Type) {
+                'http' { $httpResults.Add((Invoke-NetworkHttpProbe -Definition $definition)) | Out-Null; continue }
+                'dns'  { $dnsResults.Add((Invoke-NetworkDnsProbe -Definition $definition)) | Out-Null; continue }
+            }
+        }
+
+        if ($httpResults.Count -gt 0) { $probeResult.Http = $httpResults.ToArray() }
+        if ($dnsResults.Count -gt 0) { $probeResult.Dns = $dnsResults.ToArray() }
+
+        if (($probeResult.Http.Count + $probeResult.Dns.Count) -eq 0) {
+            $probeResult.Errors = @([ordered]@{ Source = $definitions.Source; Message = 'No probe definitions executed.' })
+        }
+    } else {
+        $probeResult.Errors = @([ordered]@{ Source = 'Collect-Network'; Message = 'No network probe configuration discovered.' })
+    }
+
+    return [pscustomobject]$probeResult
+}
+
 function Invoke-Main {
     $payload = [ordered]@{
         IpConfig = Get-IpConfiguration
         Route    = Get-RoutingTable
         Netstat  = Get-NetstatSnapshot
         Arp      = Get-ArpCache
+        DhcpOptions = Get-DhcpOptionDetails
     }
+
+    $payload['ConnectivityProbes'] = Invoke-NetworkProbes
 
     $result = New-CollectorMetadata -Payload $payload
     $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'network.json' -Data $result -Depth 6


### PR DESCRIPTION
## Summary
- extend the network collector with DHCP option metadata capture and configurable HTTP/DNS probe execution
- add a shared helper for interpreting corporate subnet, gateway, and DHCP scope baselines
- update network and DHCP heuristics to raise captive portal and guest VLAN findings using the collected probe results

## Testing
- not run (requires Windows network tooling)


------
https://chatgpt.com/codex/tasks/task_e_68de13b580a4832db000a68b486de70d