### PR TITLE
Add IPv6 routing collector and analyzer heuristics

### DIFF
--- a/Collectors/Network/Collect-IPv6Routing.ps1
+++ b/Collectors/Network/Collect-IPv6Routing.ps1
@@ -1,0 +1,87 @@
+<#!
+.SYNOPSIS
+    Collects IPv6 routing context including neighbor cache, router advertisements, and IPv6-focused ipconfig output.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$OutputDirectory = (Join-Path -Path (Split-Path -Parent $PSCommandPath) -ChildPath '..\\output')
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
+
+function Get-Ipv6Neighbors {
+    return Invoke-CollectorNativeCommand -FilePath 'netsh.exe' -ArgumentList @('interface', 'ipv6', 'show', 'neighbors') -SourceLabel 'netsh interface ipv6 show neighbors'
+}
+
+function Get-Ipv6Routers {
+    return Invoke-CollectorNativeCommand -FilePath 'netsh.exe' -ArgumentList @('interface', 'ipv6', 'show', 'routers') -SourceLabel 'netsh interface ipv6 show routers'
+}
+
+function Get-IpConfigIpv6Sections {
+    $output = Invoke-CollectorNativeCommand -FilePath 'ipconfig.exe' -ArgumentList '/all' -SourceLabel 'ipconfig.exe'
+    if (-not $output) { return $output }
+
+    $lines = @()
+    if ($output -is [string]) {
+        $lines = $output -split "`r?`n"
+    } elseif ($output -is [System.Collections.IEnumerable] -and -not ($output -is [string])) {
+        foreach ($item in $output) {
+            $lines += [string]$item
+        }
+    } else {
+        $lines = @([string]$output)
+    }
+
+    $ipv6Pattern = '(?i)([0-9A-F]{0,4}:){2,}[0-9A-F]{0,4}'
+    $results = New-Object System.Collections.Generic.List[string]
+    $currentHeader = $null
+    $headerEmitted = $false
+
+    foreach ($line in $lines) {
+        $text = if ($line -is [string]) { $line } else { [string]$line }
+        if ($null -eq $text) { continue }
+
+        $trimmed = $text.Trim()
+        if ($trimmed -match '^[^\s].*:$') {
+            $currentHeader = $trimmed
+            $headerEmitted = $false
+            continue
+        }
+
+        $containsIpv6 = $false
+        if ($text -match '(?i)IPv6' -or ($trimmed -and $trimmed -match $ipv6Pattern)) {
+            $containsIpv6 = $true
+        }
+
+        if ($containsIpv6) {
+            if ($currentHeader -and -not $headerEmitted) {
+                $results.Add($currentHeader) | Out-Null
+                $headerEmitted = $true
+            }
+            $results.Add($text) | Out-Null
+            continue
+        }
+
+        if ($headerEmitted -and [string]::IsNullOrWhiteSpace($trimmed)) {
+            $results.Add($text) | Out-Null
+            $headerEmitted = $false
+        }
+    }
+
+    return $results.ToArray()
+}
+
+function Invoke-Main {
+    $payload = [ordered]@{
+        Neighbors    = Get-Ipv6Neighbors
+        Routers      = Get-Ipv6Routers
+        IpConfigIpv6 = Get-IpConfigIpv6Sections
+    }
+
+    $result = New-CollectorMetadata -Payload $payload
+    $outputPath = Export-CollectorResult -OutputDirectory $OutputDirectory -FileName 'ipv6-routing.json' -Data $result -Depth 6
+    Write-Output $outputPath
+}
+
+Invoke-Main


### PR DESCRIPTION
## Summary
- add a dedicated IPv6 routing collector that captures netsh neighbor/router output and IPv6-focused ipconfig details
- extend network heuristics with IPv6 parsing helpers, IPv6 gateway tracking, and new findings for rogue router advertisements

## Testing
- not run (PowerShell unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de2c512ec8832d8339f7d9f0c30e2a