### PR TITLE
Add outbound SMB firewall heuristic and rule metadata

### DIFF
--- a/Collectors/Security/Collect-Firewall.ps1
+++ b/Collectors/Security/Collect-Firewall.ps1
@@ -32,10 +32,26 @@ function Get-FirewallProfiles {
     }
 }
 
+function ConvertTo-StringArray {
+    param($Value)
+
+    if ($null -eq $Value) { return @() }
+    if ($Value -is [string]) { return @($Value) }
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string])) {
+        $items = [System.Collections.Generic.List[string]]::new()
+        foreach ($item in $Value) {
+            if ($null -eq $item) { continue }
+            $items.Add([string]$item) | Out-Null
+        }
+        return $items.ToArray()
+    }
+
+    return @([string]$Value)
+}
+
 function Get-FirewallRules {
     try {
-        return Get-NetFirewallRule -All -ErrorAction Stop |
-            Select-Object DisplayName, Direction, Action, Enabled, Profile, @{Name='PolicyStore';Expression={$_.PolicyStoreSourceType}}, Program, Service, Group, Description
+        $rules = Get-NetFirewallRule -All -ErrorAction Stop
     } catch {
         Write-Verbose "Get-NetFirewallRule failed: $($_.Exception.Message)"
         return [PSCustomObject]@{
@@ -43,6 +59,70 @@ function Get-FirewallRules {
             Error  = $_.Exception.Message
         }
     }
+
+    $results = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($rule in $rules) {
+        if (-not $rule) { continue }
+
+        $record = [ordered]@{
+            DisplayName = $rule.DisplayName
+            Direction   = $rule.Direction
+            Action      = $rule.Action
+            Enabled     = $rule.Enabled
+            Profile     = $rule.Profile
+            PolicyStore = $rule.PolicyStoreSourceType
+            Program     = $rule.Program
+            Service     = $rule.Service
+            Group       = $rule.Group
+            Description = $rule.Description
+        }
+
+        try {
+            $portFilters = Get-NetFirewallPortFilter -AssociatedNetFirewallRule $rule -ErrorAction Stop
+            if ($portFilters) {
+                $serialized = [System.Collections.Generic.List[object]]::new()
+                foreach ($filter in $portFilters) {
+                    if (-not $filter) { continue }
+                    $serialized.Add([ordered]@{
+                        Protocol    = $filter.Protocol
+                        LocalPort   = ConvertTo-StringArray $filter.LocalPort
+                        RemotePort  = ConvertTo-StringArray $filter.RemotePort
+                        IcmpType    = ConvertTo-StringArray $filter.IcmpType
+                        DynamicTarget = $filter.DynamicTarget
+                    }) | Out-Null
+                }
+                if ($serialized.Count -gt 0) {
+                    $record['PortFilters'] = $serialized.ToArray()
+                }
+            }
+        } catch {
+            $record['PortFilterError'] = $_.Exception.Message
+        }
+
+        try {
+            $addressFilters = Get-NetFirewallAddressFilter -AssociatedNetFirewallRule $rule -ErrorAction Stop
+            if ($addressFilters) {
+                $serialized = [System.Collections.Generic.List[object]]::new()
+                foreach ($filter in $addressFilters) {
+                    if (-not $filter) { continue }
+                    $serialized.Add([ordered]@{
+                        LocalAddress  = ConvertTo-StringArray $filter.LocalAddress
+                        RemoteAddress = ConvertTo-StringArray $filter.RemoteAddress
+                    }) | Out-Null
+                }
+                if ($serialized.Count -gt 0) {
+                    $record['AddressFilters'] = $serialized.ToArray()
+                }
+            }
+        } catch {
+            $record['AddressFilterError'] = $_.Exception.Message
+        }
+
+        $results.Add([PSCustomObject]$record) | Out-Null
+    }
+
+    return $results.ToArray()
 }
 
 function Invoke-Main {


### PR DESCRIPTION
## Summary
- extend the firewall collector to capture port and address filters for every rule entry
- add a security heuristic that flags enabled outbound TCP 445 allow rules targeting any remote address and reports the matching rules

## Testing
- not run (PowerShell tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de4ae22fc4832dafa726c027ac185d