### PR TITLE
Refactor AD heuristics into modular scripts

### DIFF
--- a/Analyzers/Heuristics/AD.ps1
+++ b/Analyzers/Heuristics/AD.ps1
@@ -5,100 +5,15 @@
 
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
 
-function Get-FirstPayloadProperty {
-    param(
-        $Payload,
-        [string]$Name
-    )
-
-    if (-not $Payload) { return $null }
-    if ($Payload.PSObject.Properties[$Name]) { return $Payload.$Name }
-    return $null
-}
-
-function Get-ArtifactPayloadValue {
-    param(
-        $Artifact,
-        [string]$Property
-    )
-
-    $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $Artifact)
-    if (-not $payload) { return $null }
-    if ($Property) { return Get-FirstPayloadProperty -Payload $payload -Name $Property }
-    return $payload
-}
-
-function Add-StringFragment {
-    param(
-        [Parameter(Mandatory)]
-        [System.Text.StringBuilder]$Builder,
-        [Parameter(Mandatory)]
-        [string]$Fragment,
-        [string]$Separator = '; '
-    )
-
-    if ([string]::IsNullOrWhiteSpace($Fragment)) { return }
-    if ($Builder.Length -gt 0 -and $Separator) {
-        $null = $Builder.Append($Separator)
-    }
-    $null = $Builder.Append($Fragment)
-}
-
-function Get-CleanTimePeerName {
-    param(
-        [string]$Value
-    )
-
-    if ([string]::IsNullOrWhiteSpace($Value)) { return $null }
-
-    $clean = $Value.Trim()
-    $clean = $clean -replace ',0x[0-9a-fA-F]+', ''
-    $clean = $clean.Trim()
-
-    if ($clean -match '^(?<host>[^\s\(]+)\s*\(') {
-        $clean = $matches['host']
-    }
-
-    return $clean.TrimEnd('.')
-}
-
-function Test-IsDomainTimePeer {
-    param(
-        [string]$Peer,
-        [string[]]$CandidateHosts,
-        [string[]]$CandidateAddresses,
-        [string]$DomainName
-    )
-
-    if ([string]::IsNullOrWhiteSpace($Peer)) { return $false }
-
-    $peerLower = $Peer.ToLowerInvariant().TrimEnd('.')
-
-    if ($DomainName) {
-        $domainLower = $DomainName.ToLowerInvariant().TrimStart('.').TrimEnd('.')
-        if ($peerLower -eq $domainLower) { return $true }
-        if ($peerLower.EndsWith(".$domainLower")) { return $true }
-    }
-
-    if ($CandidateHosts) {
-        foreach ($host in $CandidateHosts) {
-            if ([string]::IsNullOrWhiteSpace($host)) { continue }
-            $hostLower = $host.ToLowerInvariant().TrimEnd('.')
-            if ($peerLower -eq $hostLower) { return $true }
-            $short = ($hostLower -split '\.')[0]
-            if ($short -and $peerLower -eq $short) { return $true }
-        }
-    }
-
-    if ($CandidateAddresses) {
-        foreach ($address in $CandidateAddresses) {
-            if ([string]::IsNullOrWhiteSpace($address)) { continue }
-            if ($peerLower -eq $address.ToLowerInvariant()) { return $true }
-        }
-    }
-
-    return $false
-}
+$adModuleRoot = Join-Path -Path $PSScriptRoot -ChildPath 'AD'
+. (Join-Path -Path $adModuleRoot -ChildPath 'Common.ps1')
+. (Join-Path -Path $adModuleRoot -ChildPath 'DomainStatus.ps1')
+. (Join-Path -Path $adModuleRoot -ChildPath 'DiscoveryConnectivity.ps1')
+. (Join-Path -Path $adModuleRoot -ChildPath 'Time.ps1')
+. (Join-Path -Path $adModuleRoot -ChildPath 'SecureChannel.ps1')
+. (Join-Path -Path $adModuleRoot -ChildPath 'Kerberos.ps1')
+. (Join-Path -Path $adModuleRoot -ChildPath 'GroupPolicy.ps1')
+. (Join-Path -Path $adModuleRoot -ChildPath 'Identity.ps1')
 
 function Invoke-ADHeuristics {
     param(
@@ -118,476 +33,50 @@ function Invoke-ADHeuristics {
     })
     $adPayload = Get-ArtifactPayloadValue -Artifact $adArtifact -Property $null
 
-    $domainStatus = $null
-    if ($adPayload) {
-        $domainStatus = Get-FirstPayloadProperty -Payload $adPayload -Name 'DomainStatus'
-    }
-
-    if (-not $domainStatus) {
-        Write-HeuristicDebug -Source 'AD' -Message 'Falling back to system artifact for domain status'
-        $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
-        if ($systemArtifact) {
-            $systemPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact)
-            if ($systemPayload -and $systemPayload.ComputerSystem -and -not $systemPayload.ComputerSystem.Error) {
-                $domainStatus = [pscustomobject]@{
-                    DomainJoined = $systemPayload.ComputerSystem.PartOfDomain
-                    Domain       = $systemPayload.ComputerSystem.Domain
-                    Forest       = $null
-                    DomainRole   = if ($systemPayload.ComputerSystem.PSObject.Properties['DomainRole']) { $systemPayload.ComputerSystem.DomainRole } else { $null }
-                }
-            }
-        }
-    }
-
-    if (-not $domainStatus) {
+    $domainStatusInfo = Resolve-AdDomainStatus -Context $Context -AdPayload $adPayload
+    if (-not $domainStatusInfo.Available) {
         Write-HeuristicDebug -Source 'AD' -Message 'Domain status unavailable; reporting collection issue'
         Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'AD health data unavailable, so Active Directory reachability is unknown.' -Subcategory 'Collection'
         return $result
     }
 
-    $domainJoined = $false
-    if ($domainStatus.PSObject.Properties['DomainJoined']) {
-        $domainJoined = [bool]$domainStatus.DomainJoined
-    }
-
-    if (-not $domainJoined) {
+    if (-not $domainStatusInfo.DomainJoined) {
         Write-HeuristicDebug -Source 'AD' -Message 'System not domain joined; marking AD as not applicable'
         Add-CategoryNormal -CategoryResult $result -Title 'AD not applicable' -Subcategory 'Discovery'
         return $result
     }
 
-    $domainName = if ($domainStatus.PSObject.Properties['Domain']) { $domainStatus.Domain } else { $null }
-    $domainRole = $null
-    $domainRoleInt = $null
-    if ($domainStatus.PSObject.Properties['DomainRole']) {
-        $domainRole = $domainStatus.DomainRole
-        try { $domainRoleInt = [int]$domainRole } catch { $domainRoleInt = $null }
+    if ($domainStatusInfo.DomainName) {
+        Add-CategoryNormal -CategoryResult $result -Title ("Domain joined: {0}" -f $domainStatusInfo.DomainName) -Subcategory 'Discovery'
     }
 
-    if ($domainName) {
-        Add-CategoryNormal -CategoryResult $result -Title ("Domain joined: {0}" -f $domainName) -Subcategory 'Discovery'
-    }
+    $discovery     = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Discovery' } else { $null }
+    $reachability  = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Reachability' } else { $null }
+    $sysvol        = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Sysvol' } else { $null }
+    $timeInfo      = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Time' } else { $null }
+    $kerberosInfo  = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Kerberos' } else { $null }
+    $secureInfo    = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Secure' } else { $null }
+    $gpoInfo       = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Gpo' } else { $null }
 
-    $discovery = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Discovery' } else { $null }
-    $reachability = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Reachability' } else { $null }
-    $sysvol = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Sysvol' } else { $null }
-    $timeInfo = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Time' } else { $null }
-    $kerberosInfo = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Kerberos' } else { $null }
-    $secureInfo = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Secure' } else { $null }
-    $gpoInfo = if ($adPayload) { Get-FirstPayloadProperty -Payload $adPayload -Name 'Gpo' } else { $null }
+    $discoveryState = Add-AdDiscoveryFindings -Result $result -Discovery $discovery
+    $connectivityState = Add-AdConnectivityFindings -Result $result -Reachability $reachability -Sysvol $sysvol -Candidates $discoveryState.Candidates
 
-    $srvLookups = @()
-    $srvSuccess = $false
-    if ($discovery -and $discovery.SrvLookups) {
-        foreach ($prop in $discovery.SrvLookups.PSObject.Properties) {
-            $entry = $prop.Value
-            if ($entry) {
-                $srvLookups += $entry
-                if ($entry.Succeeded -eq $true -and $entry.Records -and $entry.Records.Count -gt 0) {
-                    $srvSuccess = $true
-                }
-            }
-        }
-    }
+    $timeState = Add-AdTimeFindings -Result $result -TimeInfo $timeInfo -CandidateHosts $discoveryState.CandidateHosts -CandidateAddresses $discoveryState.CandidateAddresses -DomainName $domainStatusInfo.DomainName -DomainJoined $domainStatusInfo.DomainJoined -DomainRoleInt $domainStatusInfo.DomainRoleInt
 
-    $nltestSuccess = $false
-    if ($discovery) {
-        if ($discovery.DsGetDc -and $discovery.DsGetDc.Succeeded) { $nltestSuccess = $true }
-        if ($discovery.DcList -and $discovery.DcList.Succeeded) { $nltestSuccess = $true }
-    }
+    $secureChannelState = Add-AdSecureChannelFindings -Result $result -SecureInfo $secureInfo
 
-    if ($srvSuccess) {
-        $dcNames = @()
-        if ($discovery -and $discovery.Candidates) {
-            foreach ($candidate in $discovery.Candidates) {
-                if ($candidate.Hostname) { $dcNames += $candidate.Hostname }
-            }
-        }
-        $dcEvidence = if ($dcNames) { ($dcNames | Sort-Object -Unique) -join ', ' } else { 'SRV queries resolved.' }
-        Add-CategoryNormal -CategoryResult $result -Title 'GOOD AD/DNS (SRV resolves)' -Evidence $dcEvidence -Subcategory 'DNS Discovery'
-    } else {
-        $srvErrors = $srvLookups | Where-Object { $_ -and $_.Succeeded -ne $true }
-        $evidence = ($srvErrors | ForEach-Object {
-                if ($_.Error) { "{0}: {1}" -f $_.Query, $_.Error } else { "{0}: no records" -f $_.Query }
-            }) -join '; '
-        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'AD SRV records not resolvable, so Active Directory is unreachable.' -Evidence $evidence -Subcategory 'DNS Discovery'
-    }
+    $noDcReachable = $connectivityState.FullyReachableHosts.Count -eq 0
 
-    if (-not $srvSuccess -and -not $nltestSuccess -and $discovery) {
-        $evidenceBuilder = [System.Text.StringBuilder]::new()
-        if ($discovery.DsGetDc) {
-            if ($discovery.DsGetDc.Error) { Add-StringFragment -Builder $evidenceBuilder -Fragment ("dsgetdc: {0}" -f $discovery.DsGetDc.Error) }
-            elseif ($discovery.DsGetDc.Output) { Add-StringFragment -Builder $evidenceBuilder -Fragment ("dsgetdc output: {0}" -f ($discovery.DsGetDc.Output -join ' | ')) }
-        }
-        if ($discovery.DcList) {
-            if ($discovery.DcList.Error) { Add-StringFragment -Builder $evidenceBuilder -Fragment ("dclist: {0}" -f $discovery.DcList.Error) }
-            elseif ($discovery.DcList.Output) { Add-StringFragment -Builder $evidenceBuilder -Fragment ("dclist output: {0}" -f ($discovery.DcList.Output -join ' | ')) }
-        }
-        $evidenceText = $evidenceBuilder.ToString()
-        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'No DC discovered, so Active Directory is unreachable.' -Evidence $evidenceText -Subcategory 'Discovery'
-    }
+    $null = Add-AdKerberosFindings -Result $result -KerberosInfo $kerberosInfo -NoDcReachable $noDcReachable -TimeSkewHigh $timeState.TimeSkewHigh
 
-    $candidates = @()
-    if ($discovery -and $discovery.Candidates) {
-        foreach ($candidate in $discovery.Candidates) {
-            if ($candidate.Hostname) { $candidates += $candidate.Hostname.ToLowerInvariant() }
-        }
-    }
-    $candidates = $candidates | Sort-Object -Unique
+    Add-AdGroupPolicyFindings -Result $result -GpoInfo $gpoInfo -SharesFailingHosts $connectivityState.SharesFailingHosts -TimeSkewHigh $timeState.TimeSkewHigh
 
-    $portMap = @{}
-    $reachTests = if ($reachability) { $reachability.Tests } else { $null }
-    if ($reachTests) {
-        foreach ($test in $reachTests) {
-            if (-not $test) { continue }
-            $target = if ($test.PSObject.Properties['Target']) { $test.Target } else { $null }
-            if (-not $target) { continue }
-            $key = $target.ToLowerInvariant()
-            if (-not $portMap.ContainsKey($key)) { $portMap[$key] = @{} }
-            if ($test.PSObject.Properties['Port']) {
-                $portMap[$key][$test.Port] = [bool]$test.Success
-            }
-        }
-    }
-
-    $requiredPorts = @(88, 389, 445, 135)
-    $fullyReachableHosts = @()
-    foreach ($entry in $portMap.GetEnumerator()) {
-        $host = $entry.Key
-        $ports = $entry.Value
-        $allOpen = $true
-        foreach ($port in $requiredPorts) {
-            if (-not ($ports.ContainsKey($port) -and $ports[$port])) {
-                $allOpen = $false
-                break
-            }
-        }
-        if ($allOpen) { $fullyReachableHosts += $host }
-    }
-
-    $shareMap = @{}
-    $shareTests = if ($sysvol) { $sysvol.Tests } else { $null }
-    if ($shareTests) {
-        foreach ($test in $shareTests) {
-            if (-not $test) { continue }
-            $target = if ($test.PSObject.Properties['Target']) { $test.Target } else { $null }
-            $share = if ($test.PSObject.Properties['Share']) { $test.Share } else { $null }
-            if (-not $target -or -not $share) { continue }
-            $key = $target.ToLowerInvariant()
-            if (-not $shareMap.ContainsKey($key)) { $shareMap[$key] = @{} }
-            $shareMap[$key][$share.ToUpperInvariant()] = [bool]$test.Success
-        }
-    }
-
-    $reachableWithShares = @()
-    foreach ($host in $fullyReachableHosts) {
-        if ($shareMap.ContainsKey($host)) {
-            $values = $shareMap[$host].Values
-            if ($values -and ($values -contains $true)) {
-                $reachableWithShares += $host
-            }
-        }
-    }
-
-    if ($reachableWithShares.Count -gt 0) {
-        Add-CategoryNormal -CategoryResult $result -Title 'GOOD AD/Reachability (≥1 DC reachable + SYSVOL)' -Evidence (($reachableWithShares | Sort-Object -Unique) -join ', ') -Subcategory 'Connectivity'
-    }
-
-    $testsWithoutErrors = 0
-    if ($reachTests) {
-        foreach ($test in $reachTests) {
-            if ($test -and -not $test.Error) { $testsWithoutErrors++ }
-        }
-    }
-
-    $allPortsTested = $portMap.Count -gt 0
-    if ($candidates.Count -gt 0 -and $allPortsTested -and $fullyReachableHosts.Count -eq 0 -and $testsWithoutErrors -gt 0) {
-        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Cannot reach any DC on required ports, so Active Directory is unreachable.' -Evidence (($portMap.Keys | Sort-Object) -join ', ') -Subcategory 'Connectivity'
-    }
-
-    $sharesFailingHosts = @()
-    foreach ($host in $fullyReachableHosts) {
-        if (-not $shareMap.ContainsKey($host)) { continue }
-        $shares = $shareMap[$host].Values
-        if (-not ($shares -contains $true)) {
-            $sharesFailingHosts += $host
-        }
-    }
-
-    if ($sharesFailingHosts.Count -gt 0) {
-        Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title "Domain shares unreachable (DFS/DNS/auth), so SYSVOL/NETLOGON can't deliver GPOs." -Evidence (($sharesFailingHosts | Sort-Object -Unique) -join ', ') -Subcategory 'SYSVOL'
-    }
-
-    $candidateHosts = @()
-    $candidateAddresses = @()
-    if ($discovery -and $discovery.Candidates) {
-        foreach ($candidate in $discovery.Candidates) {
-            if ($candidate -and $candidate.Hostname) { $candidateHosts += $candidate.Hostname }
-            if ($candidate -and $candidate.Addresses) { $candidateAddresses += $candidate.Addresses }
-        }
-    }
-
-    $timeSkewHigh = $false
-    if ($timeInfo) {
-        $parsed = $timeInfo.Parsed
-        $offset = $null
-        if ($parsed -and $parsed.PSObject.Properties['OffsetSeconds']) {
-            $offset = $parsed.OffsetSeconds
-        }
-        $synchronized = $null
-        if ($parsed -and $parsed.PSObject.Properties['Synchronized']) {
-            $synchronized = $parsed.Synchronized
-        }
-
-        if ($offset -ne $null -and [math]::Abs([double]$offset) -gt 300) {
-            $timeSkewHigh = $true
-            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Kerberos time skew, breaking Active Directory authentication.' -Evidence ("Offset {0} seconds" -f [math]::Round([double]$offset, 2)) -Subcategory 'Time Synchronization'
-        } elseif ($synchronized -eq $false -or ($timeInfo.Status -and $timeInfo.Status.Succeeded -ne $true)) {
-            $timeSkewHigh = $true
-            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Kerberos time skew, breaking Active Directory authentication.' -Evidence 'Time service not synchronized.' -Subcategory 'Time Synchronization'
-        } elseif ($offset -ne $null -and [math]::Abs([double]$offset) -le 300) {
-            Add-CategoryNormal -CategoryResult $result -Title 'GOOD Time (skew ≤5m)' -Evidence ("Offset {0} seconds" -f [math]::Round([double]$offset, 2)) -Subcategory 'Time Synchronization'
-        }
-
-        $clientType = $null
-        $clientServersRaw = $null
-        $peerEntries = @()
-        $sourceRaw = $null
-        if ($parsed) {
-            if ($parsed.PSObject.Properties['ClientType']) { $clientType = $parsed.ClientType }
-            if ($parsed.PSObject.Properties['ClientNtpServer']) { $clientServersRaw = $parsed.ClientNtpServer }
-            if ($parsed.PSObject.Properties['PeerEntries'] -and $parsed.PeerEntries) { $peerEntries = $parsed.PeerEntries }
-            if ($parsed.PSObject.Properties['Source']) { $sourceRaw = $parsed.Source }
-        }
-
-        $manualPeers = @()
-        if ($clientServersRaw) {
-            $components = $clientServersRaw -split '\s+'
-            foreach ($component in $components) {
-                $cleanPeer = Get-CleanTimePeerName -Value $component
-                if (-not $cleanPeer) { continue }
-                if ($cleanPeer -eq '(Local)') { continue }
-                $manualPeers += $cleanPeer
-            }
-        }
-
-        $peerNames = @()
-        foreach ($peerEntry in $peerEntries) {
-            $cleanPeer = Get-CleanTimePeerName -Value $peerEntry
-            if ($cleanPeer) { $peerNames += $cleanPeer }
-        }
-
-        $sourceName = if ($sourceRaw) { Get-CleanTimePeerName -Value $sourceRaw } else { $null }
-
-        $combinedPeers = @()
-        if ($manualPeers) { $combinedPeers += $manualPeers }
-        if ($peerNames) { $combinedPeers += $peerNames }
-        $combinedPeers = $combinedPeers | Sort-Object -Unique
-
-        $suspiciousPeers = @()
-        foreach ($peer in $combinedPeers) {
-            if (-not $peer) { continue }
-            $peerLower = $peer.ToLowerInvariant()
-            if ($peerLower -match 'local cmos clock' -or $peerLower -match 'free-running system clock') { continue }
-            if (Test-IsDomainTimePeer -Peer $peer -CandidateHosts $candidateHosts -CandidateAddresses $candidateAddresses -DomainName $domainName) {
-                continue
-            }
-            $suspiciousPeers += $peer
-        }
-
-        $suspiciousSource = $null
-        if ($sourceName) {
-            $sourceLower = $sourceName.ToLowerInvariant()
-            $isDomainPeer = Test-IsDomainTimePeer -Peer $sourceName -CandidateHosts $candidateHosts -CandidateAddresses $candidateAddresses -DomainName $domainName
-            if (-not $isDomainPeer -or $sourceLower -match 'local cmos clock' -or $sourceLower -match 'free-running system clock' -or $sourceLower -match 'vm ic time synchronization provider') {
-                $suspiciousSource = $sourceName
-            }
-        }
-
-        $clientTypeNormalized = $null
-        if ($clientType) {
-            $clientTypeNormalized = $clientType.ToString().Trim()
-        }
-
-        $isPrimaryDomainController = $false
-        if ($null -ne $domainRoleInt -and $domainRoleInt -eq 5) { $isPrimaryDomainController = $true }
-
-        if ($domainJoined -and -not $isPrimaryDomainController) {
-            $needsWarning = $false
-            if ($clientTypeNormalized -and $clientTypeNormalized.ToUpperInvariant() -ne 'NT5DS') {
-                $needsWarning = $true
-            }
-            if (-not $needsWarning -and $suspiciousPeers.Count -gt 0) { $needsWarning = $true }
-            if (-not $needsWarning -and $suspiciousSource) { $needsWarning = $true }
-
-            if ($needsWarning) {
-                $evidencePieces = @()
-                if ($clientTypeNormalized) { $evidencePieces += "Type $clientTypeNormalized" }
-                if ($suspiciousSource) { $evidencePieces += "Source $suspiciousSource" }
-                if ($suspiciousPeers.Count -gt 0) {
-                    $evidencePieces += ("Peers: {0}" -f (($suspiciousPeers | Sort-Object -Unique) -join ', '))
-                }
-                if (-not $evidencePieces) { $evidencePieces += 'Manual time source detected.' }
-                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Domain time misconfigured (manual NTP), so Active Directory cannot control system time.' -Evidence ($evidencePieces -join '; ') -Subcategory 'Time Synchronization'
-            }
-        }
-    }
-
-    if ($secureInfo) {
-        $scTest = $secureInfo.TestComputerSecureChannel
-        $scBroken = $false
-        if ($scTest) {
-            if ($scTest.Succeeded -eq $true -and $scTest.IsSecure -eq $false) {
-                $scBroken = $true
-            } elseif ($scTest.Succeeded -eq $true -and $scTest.IsSecure -eq $true) {
-                Add-CategoryNormal -CategoryResult $result -Title 'GOOD SecureChannel (verified)' -Subcategory 'Secure Channel'
-            }
-        }
-        if ($secureInfo.NltestScQuery) {
-            $outputText = $secureInfo.NltestScQuery.Output -join ' '
-            if ($outputText -match 'NO_LOGON_SERVERS' -or $outputText -match 'TRUST_FAILURE' -or $outputText -match 'STATUS=\s*0xC000018D') {
-                $scBroken = $true
-            }
-        }
-        if ($scTest -and $scTest.Succeeded -eq $false -and $scTest.Error) {
-            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Secure channel verification failed to run, so machine trust status is unknown.' -Evidence $scTest.Error -Subcategory 'Secure Channel'
-        }
-        if ($scBroken) {
-            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Broken machine secure channel, blocking domain authentication.' -Subcategory 'Secure Channel'
-        }
-    }
-
-    $noDcReachable = $fullyReachableHosts.Count -eq 0
-
-    if ($kerberosInfo) {
-        $kerberosEvents = @()
-        if ($kerberosInfo.Events) {
-            foreach ($event in $kerberosInfo.Events) {
-                if ($event -and -not $event.Error) { $kerberosEvents += $event }
-            }
-        }
-
-        $failureEvents = $kerberosEvents | Where-Object { $_.Id -in 4768, 4771, 4776 }
-        $failureCount = $failureEvents.Count
-        if ($kerberosInfo.Parsed -and $kerberosInfo.Parsed.HasTgt -ne $true) {
-            $title = "Kerberos TGT not present, breaking Active Directory authentication."
-            $evidencePartsBuilder = [System.Text.StringBuilder]::new()
-            Add-StringFragment -Builder $evidencePartsBuilder -Fragment 'klist output missing krbtgt ticket'
-            if ($kerberosInfo.Parsed.PSObject.Properties['TgtRealm'] -and $kerberosInfo.Parsed.TgtRealm) {
-                Add-StringFragment -Builder $evidencePartsBuilder -Fragment ("Expected realm: {0}" -f $kerberosInfo.Parsed.TgtRealm)
-            }
-            if ($noDcReachable) { Add-StringFragment -Builder $evidencePartsBuilder -Fragment 'likely off network' }
-            Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title $title -Evidence $evidencePartsBuilder.ToString() -Subcategory 'Kerberos'
-        }
-
-        if ($failureCount -gt 0) {
-            $severity = if ($failureCount -ge 15) { 'high' } else { 'medium' }
-            if ($noDcReachable -and $severity -eq 'high') { $severity = 'medium' }
-            $messageBuilder = [System.Text.StringBuilder]::new()
-            $null = $messageBuilder.Append(("Kerberos authentication failures detected ({0}), breaking Active Directory authentication" -f $failureCount))
-            if ($timeSkewHigh -and ($failureEvents | Where-Object { $_.Message -match 'KRB_AP_ERR_SKEW' })) {
-                $null = $messageBuilder.Append(' related to time skew')
-            } elseif ($noDcReachable) {
-                $null = $messageBuilder.Append('; DC unreachable')
-            }
-            $failureGroups = $failureEvents | Group-Object -Property Id
-            $failureSummaryParts = [System.Collections.Generic.List[string]]::new()
-            foreach ($group in $failureGroups) {
-                $null = $failureSummaryParts.Add(("{0}x{1}" -f $group.Count, $group.Name))
-            }
-
-            $failureSummary = ($failureSummaryParts -join ', ')
-            Add-CategoryIssue -CategoryResult $result -Severity $severity -Title $messageBuilder.ToString() -Evidence $failureSummary -Subcategory 'Kerberos'
-        }
-    }
-
-    if ($gpoInfo) {
-        $gpResult = $gpoInfo.GpResult
-        $gpoEvents = @()
-        if ($gpoInfo.Events) {
-            foreach ($event in $gpoInfo.Events) {
-                if ($event -and -not $event.Error) { $gpoEvents += $event }
-            }
-        }
-
-        $gpResultSuccess = $false
-        if ($gpResult -and $gpResult.Succeeded -eq $true) { $gpResultSuccess = $true }
-
-        if ($gpResultSuccess -and $gpoEvents.Count -eq 0) {
-            Add-CategoryNormal -CategoryResult $result -Title 'GOOD GPO (processed successfully)' -Subcategory 'Group Policy'
-        } else {
-            $severity = 'medium'
-            if ($gpoEvents.Count -ge 5 -and $sharesFailingHosts.Count -gt 0) { $severity = 'high' }
-            $title = "GPO processing errors, so device policies aren't applied"
-            if ($timeSkewHigh) {
-                $titleBuilder = [System.Text.StringBuilder]::new()
-                $null = $titleBuilder.Append($title)
-                $null = $titleBuilder.Append(' related to time skew')
-                $title = $titleBuilder.ToString()
-            }
-            $evidenceBuilder = [System.Text.StringBuilder]::new()
-            if ($gpResult -and $gpResult.Output) { Add-StringFragment -Builder $evidenceBuilder -Fragment (($gpResult.Output | Select-Object -First 3) -join ' | ') }
-            if ($gpResult -and $gpResult.Error) { Add-StringFragment -Builder $evidenceBuilder -Fragment $gpResult.Error }
-            if ($gpoEvents.Count -gt 0) {
-                $eventGroups = $gpoEvents | Group-Object -Property Id
-                $eventSummaryParts = [System.Collections.Generic.List[string]]::new()
-                foreach ($group in $eventGroups) {
-                    $null = $eventSummaryParts.Add(("{0}x{1}" -f $group.Count, $group.Name))
-                }
-
-                $eventSummary = ($eventSummaryParts -join ', ')
-                if ($eventSummary) { Add-StringFragment -Builder $evidenceBuilder -Fragment $eventSummary }
-            }
-            if ($evidenceBuilder.Length -eq 0) { Add-StringFragment -Builder $evidenceBuilder -Fragment 'GPO data unavailable' }
-            Add-CategoryIssue -CategoryResult $result -Severity $severity -Title $title -Evidence $evidenceBuilder.ToString() -Subcategory 'Group Policy'
-        }
-    }
-
-    $identityArtifact = Get-AnalyzerArtifact -Context $Context -Name 'identity'
-    if ($identityArtifact) {
-        $identityPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $identityArtifact)
-        if ($identityPayload -and $identityPayload.DsRegCmd) {
-            $text = if ($identityPayload.DsRegCmd -is [string[]]) { $identityPayload.DsRegCmd -join "`n" } else { [string]$identityPayload.DsRegCmd }
-            if ($text -match 'AzureAdJoined\s*:\s*YES') {
-                Add-CategoryNormal -CategoryResult $result -Title 'Azure AD join detected' -Subcategory 'Discovery'
-            }
-        }
-    }
+    Add-AdIdentityFindings -Result $result -Context $Context
 
     $eventsArtifact = Get-AnalyzerArtifact -Context $Context -Name 'events'
     if ($eventsArtifact) {
         $eventsPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $eventsArtifact)
-        if ($eventsPayload -and $eventsPayload.GroupPolicy) {
-            $groupPolicyLog = $eventsPayload.GroupPolicy
-            if ($groupPolicyLog.Error) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Unable to read Group Policy event log, so device policy failures may be hidden.' -Evidence $groupPolicyLog.Error -Subcategory 'Group Policy'
-            } else {
-                $entries = if ($groupPolicyLog -is [System.Collections.IEnumerable] -and -not ($groupPolicyLog -is [string])) { @($groupPolicyLog) } else { @($groupPolicyLog) }
-                $sysvolMatches = $entries | Where-Object { $_.Message -match '(?i)\\\\[^\r\n]+\\(SYSVOL|NETLOGON)' -or $_.Message -match '(?i)The network path was not found' -or $_.Message -match '(?i)The system cannot find the path specified' }
-                if ($sysvolMatches.Count -gt 0) {
-                    $selectedSysvolMatches = $sysvolMatches | Select-Object -First 3
-                    $sysvolEvidence = [System.Collections.Generic.List[string]]::new()
-                    foreach ($entry in $selectedSysvolMatches) {
-                        $null = $sysvolEvidence.Add(("[{0}] {1}" -f $entry.Id, $entry.Message))
-                    }
-
-                    $evidence = ($sysvolEvidence -join "`n")
-                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title "Group Policy errors accessing SYSVOL/NETLOGON, so device policies aren't applied." -Evidence $evidence -Subcategory 'Group Policy'
-                }
-
-                $gpoFailures = $entries | Where-Object { $_.Id -in 1058, 1030, 1502, 1503 }
-                if ($gpoFailures.Count -gt 0) {
-                    $selectedGpoFailures = $gpoFailures | Select-Object -First 3
-                    $gpoFailureEvidence = [System.Collections.Generic.List[string]]::new()
-                    foreach ($entry in $selectedGpoFailures) {
-                        $null = $gpoFailureEvidence.Add(("[{0}] {1}" -f $entry.Id, $entry.Message))
-                    }
-
-                    $evidence = ($gpoFailureEvidence -join "`n")
-                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title "Group Policy processing failures detected, so device policies aren't applied." -Evidence $evidence -Subcategory 'Group Policy'
-                }
-            }
-        }
+        Add-AdGroupPolicyEventLogFindings -Result $result -EventsPayload $eventsPayload
     }
 
     return $result

--- a/Analyzers/Heuristics/AD/Common.ps1
+++ b/Analyzers/Heuristics/AD/Common.ps1
@@ -1,0 +1,94 @@
+function Get-FirstPayloadProperty {
+    param(
+        $Payload,
+        [string]$Name
+    )
+
+    if (-not $Payload) { return $null }
+    if ($Payload.PSObject.Properties[$Name]) { return $Payload.$Name }
+    return $null
+}
+
+function Get-ArtifactPayloadValue {
+    param(
+        $Artifact,
+        [string]$Property
+    )
+
+    $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $Artifact)
+    if (-not $payload) { return $null }
+    if ($Property) { return Get-FirstPayloadProperty -Payload $payload -Name $Property }
+    return $payload
+}
+
+function Add-StringFragment {
+    param(
+        [Parameter(Mandatory)]
+        [System.Text.StringBuilder]$Builder,
+        [Parameter(Mandatory)]
+        [string]$Fragment,
+        [string]$Separator = '; '
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Fragment)) { return }
+    if ($Builder.Length -gt 0 -and $Separator) {
+        $null = $Builder.Append($Separator)
+    }
+    $null = $Builder.Append($Fragment)
+}
+
+function Get-CleanTimePeerName {
+    param(
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $null }
+
+    $clean = $Value.Trim()
+    $clean = $clean -replace ',0x[0-9a-fA-F]+', ''
+    $clean = $clean.Trim()
+
+    if ($clean -match '^(?<host>[^\s\(]+)\s*\(') {
+        $clean = $matches['host']
+    }
+
+    return $clean.TrimEnd('.')
+}
+
+function Test-IsDomainTimePeer {
+    param(
+        [string]$Peer,
+        [string[]]$CandidateHosts,
+        [string[]]$CandidateAddresses,
+        [string]$DomainName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Peer)) { return $false }
+
+    $peerLower = $Peer.ToLowerInvariant().TrimEnd('.')
+
+    if ($DomainName) {
+        $domainLower = $DomainName.ToLowerInvariant().TrimStart('.').TrimEnd('.')
+        if ($peerLower -eq $domainLower) { return $true }
+        if ($peerLower.EndsWith(".$domainLower")) { return $true }
+    }
+
+    if ($CandidateHosts) {
+        foreach ($host in $CandidateHosts) {
+            if ([string]::IsNullOrWhiteSpace($host)) { continue }
+            $hostLower = $host.ToLowerInvariant().TrimEnd('.')
+            if ($peerLower -eq $hostLower) { return $true }
+            $short = ($hostLower -split '\.')[0]
+            if ($short -and $peerLower -eq $short) { return $true }
+        }
+    }
+
+    if ($CandidateAddresses) {
+        foreach ($address in $CandidateAddresses) {
+            if ([string]::IsNullOrWhiteSpace($address)) { continue }
+            if ($peerLower -eq $address.ToLowerInvariant()) { return $true }
+        }
+    }
+
+    return $false
+}

--- a/Analyzers/Heuristics/AD/DiscoveryConnectivity.ps1
+++ b/Analyzers/Heuristics/AD/DiscoveryConnectivity.ps1
@@ -1,0 +1,185 @@
+function Add-AdDiscoveryFindings {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $Discovery
+    )
+
+    $srvLookups = @()
+    $srvSuccess = $false
+    if ($Discovery -and $Discovery.SrvLookups) {
+        foreach ($prop in $Discovery.SrvLookups.PSObject.Properties) {
+            $entry = $prop.Value
+            if ($entry) {
+                $srvLookups += $entry
+                if ($entry.Succeeded -eq $true -and $entry.Records -and $entry.Records.Count -gt 0) {
+                    $srvSuccess = $true
+                }
+            }
+        }
+    }
+
+    $nltestSuccess = $false
+    if ($Discovery) {
+        if ($Discovery.DsGetDc -and $Discovery.DsGetDc.Succeeded) { $nltestSuccess = $true }
+        if ($Discovery.DcList -and $Discovery.DcList.Succeeded) { $nltestSuccess = $true }
+    }
+
+    if ($srvSuccess) {
+        $dcNames = @()
+        if ($Discovery -and $Discovery.Candidates) {
+            foreach ($candidate in $Discovery.Candidates) {
+                if ($candidate.Hostname) { $dcNames += $candidate.Hostname }
+            }
+        }
+        $dcEvidence = if ($dcNames) { ($dcNames | Sort-Object -Unique) -join ', ' } else { 'SRV queries resolved.' }
+        Add-CategoryNormal -CategoryResult $Result -Title 'GOOD AD/DNS (SRV resolves)' -Evidence $dcEvidence -Subcategory 'DNS Discovery'
+    } else {
+        $srvErrors = $srvLookups | Where-Object { $_ -and $_.Succeeded -ne $true }
+        $evidence = ($srvErrors | ForEach-Object {
+                if ($_.Error) { "{0}: {1}" -f $_.Query, $_.Error } else { "{0}: no records" -f $_.Query }
+            }) -join '; '
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'AD SRV records not resolvable, so Active Directory is unreachable.' -Evidence $evidence -Subcategory 'DNS Discovery'
+    }
+
+    if (-not $srvSuccess -and -not $nltestSuccess -and $Discovery) {
+        $evidenceBuilder = [System.Text.StringBuilder]::new()
+        if ($Discovery.DsGetDc) {
+            if ($Discovery.DsGetDc.Error) { Add-StringFragment -Builder $evidenceBuilder -Fragment ("dsgetdc: {0}" -f $Discovery.DsGetDc.Error) }
+            elseif ($Discovery.DsGetDc.Output) { Add-StringFragment -Builder $evidenceBuilder -Fragment ("dsgetdc output: {0}" -f ($Discovery.DsGetDc.Output -join ' | ')) }
+        }
+        if ($Discovery.DcList) {
+            if ($Discovery.DcList.Error) { Add-StringFragment -Builder $evidenceBuilder -Fragment ("dclist: {0}" -f $Discovery.DcList.Error) }
+            elseif ($Discovery.DcList.Output) { Add-StringFragment -Builder $evidenceBuilder -Fragment ("dclist output: {0}" -f ($Discovery.DcList.Output -join ' | ')) }
+        }
+        $evidenceText = $evidenceBuilder.ToString()
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'No DC discovered, so Active Directory is unreachable.' -Evidence $evidenceText -Subcategory 'Discovery'
+    }
+
+    $candidates = @()
+    if ($Discovery -and $Discovery.Candidates) {
+        foreach ($candidate in $Discovery.Candidates) {
+            if ($candidate.Hostname) { $candidates += $candidate.Hostname.ToLowerInvariant() }
+        }
+    }
+    $candidates = $candidates | Sort-Object -Unique
+
+    $candidateHosts = @()
+    $candidateAddresses = @()
+    if ($Discovery -and $Discovery.Candidates) {
+        foreach ($candidate in $Discovery.Candidates) {
+            if ($candidate -and $candidate.Hostname) { $candidateHosts += $candidate.Hostname }
+            if ($candidate -and $candidate.Addresses) { $candidateAddresses += $candidate.Addresses }
+        }
+    }
+
+    [pscustomobject]@{
+        SrvSuccess         = $srvSuccess
+        NltestSuccess      = $nltestSuccess
+        Candidates         = $candidates
+        CandidateHosts     = $candidateHosts
+        CandidateAddresses = $candidateAddresses
+    }
+}
+
+function Add-AdConnectivityFindings {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $Reachability,
+        $Sysvol,
+        [string[]]$Candidates
+    )
+
+    $portMap = @{}
+    $reachTests = if ($Reachability) { $Reachability.Tests } else { $null }
+    if ($reachTests) {
+        foreach ($test in $reachTests) {
+            if (-not $test) { continue }
+            $target = if ($test.PSObject.Properties['Target']) { $test.Target } else { $null }
+            if (-not $target) { continue }
+            $key = $target.ToLowerInvariant()
+            if (-not $portMap.ContainsKey($key)) { $portMap[$key] = @{} }
+            if ($test.PSObject.Properties['Port']) {
+                $portMap[$key][$test.Port] = [bool]$test.Success
+            }
+        }
+    }
+
+    $requiredPorts = @(88, 389, 445, 135)
+    $fullyReachableHosts = @()
+    foreach ($entry in $portMap.GetEnumerator()) {
+        $host = $entry.Key
+        $ports = $entry.Value
+        $allOpen = $true
+        foreach ($port in $requiredPorts) {
+            if (-not ($ports.ContainsKey($port) -and $ports[$port])) {
+                $allOpen = $false
+                break
+            }
+        }
+        if ($allOpen) { $fullyReachableHosts += $host }
+    }
+
+    $shareMap = @{}
+    $shareTests = if ($Sysvol) { $Sysvol.Tests } else { $null }
+    if ($shareTests) {
+        foreach ($test in $shareTests) {
+            if (-not $test) { continue }
+            $target = if ($test.PSObject.Properties['Target']) { $test.Target } else { $null }
+            $share = if ($test.PSObject.Properties['Share']) { $test.Share } else { $null }
+            if (-not $target -or -not $share) { continue }
+            $key = $target.ToLowerInvariant()
+            if (-not $shareMap.ContainsKey($key)) { $shareMap[$key] = @{} }
+            $shareMap[$key][$share.ToUpperInvariant()] = [bool]$test.Success
+        }
+    }
+
+    $reachableWithShares = @()
+    foreach ($host in $fullyReachableHosts) {
+        if ($shareMap.ContainsKey($host)) {
+            $values = $shareMap[$host].Values
+            if ($values -and ($values -contains $true)) {
+                $reachableWithShares += $host
+            }
+        }
+    }
+
+    if ($reachableWithShares.Count -gt 0) {
+        Add-CategoryNormal -CategoryResult $Result -Title 'GOOD AD/Reachability (≥1 DC reachable + SYSVOL)' -Evidence (($reachableWithShares | Sort-Object -Unique) -join ', ') -Subcategory 'Connectivity'
+    }
+
+    $testsWithoutErrors = 0
+    if ($reachTests) {
+        foreach ($test in $reachTests) {
+            if ($test -and -not $test.Error) { $testsWithoutErrors++ }
+        }
+    }
+
+    $allPortsTested = $portMap.Count -gt 0
+    if ($Candidates.Count -gt 0 -and $allPortsTested -and $fullyReachableHosts.Count -eq 0 -and $testsWithoutErrors -gt 0) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Cannot reach any DC on required ports, so Active Directory is unreachable.' -Evidence (($portMap.Keys | Sort-Object) -join ', ') -Subcategory 'Connectivity'
+    }
+
+    $sharesFailingHosts = @()
+    foreach ($host in $fullyReachableHosts) {
+        if (-not $shareMap.ContainsKey($host)) { continue }
+        $shares = $shareMap[$host].Values
+        if (-not ($shares -contains $true)) {
+            $sharesFailingHosts += $host
+        }
+    }
+
+    if ($sharesFailingHosts.Count -gt 0) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title "Domain shares unreachable (DFS/DNS/auth), so SYSVOL/NETLOGON can't deliver GPOs." -Evidence (($sharesFailingHosts | Sort-Object -Unique) -join ', ') -Subcategory 'SYSVOL'
+    }
+
+    [pscustomobject]@{
+        FullyReachableHosts = $fullyReachableHosts
+        ReachableWithShares = $reachableWithShares
+        SharesFailingHosts  = $sharesFailingHosts
+        PortMap             = $portMap
+        TestsWithoutErrors  = $testsWithoutErrors
+        AllPortsTested      = $allPortsTested
+    }
+}

--- a/Analyzers/Heuristics/AD/DomainStatus.ps1
+++ b/Analyzers/Heuristics/AD/DomainStatus.ps1
@@ -1,0 +1,60 @@
+function Resolve-AdDomainStatus {
+    param(
+        $Context,
+        $AdPayload
+    )
+
+    $domainStatus = $null
+    if ($AdPayload) {
+        $domainStatus = Get-FirstPayloadProperty -Payload $AdPayload -Name 'DomainStatus'
+    }
+
+    if (-not $domainStatus) {
+        Write-HeuristicDebug -Source 'AD' -Message 'Falling back to system artifact for domain status'
+        $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
+        if ($systemArtifact) {
+            $systemPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact)
+            if ($systemPayload -and $systemPayload.ComputerSystem -and -not $systemPayload.ComputerSystem.Error) {
+                $domainStatus = [pscustomobject]@{
+                    DomainJoined = $systemPayload.ComputerSystem.PartOfDomain
+                    Domain       = $systemPayload.ComputerSystem.Domain
+                    Forest       = $null
+                    DomainRole   = if ($systemPayload.ComputerSystem.PSObject.Properties['DomainRole']) { $systemPayload.ComputerSystem.DomainRole } else { $null }
+                }
+            }
+        }
+    }
+
+    if (-not $domainStatus) {
+        return [pscustomobject]@{
+            Available = $false
+            DomainStatus = $null
+            DomainJoined = $false
+            DomainName = $null
+            DomainRole = $null
+            DomainRoleInt = $null
+        }
+    }
+
+    $domainJoined = $false
+    if ($domainStatus.PSObject.Properties['DomainJoined']) {
+        $domainJoined = [bool]$domainStatus.DomainJoined
+    }
+
+    $domainName = if ($domainStatus.PSObject.Properties['Domain']) { $domainStatus.Domain } else { $null }
+    $domainRole = $null
+    $domainRoleInt = $null
+    if ($domainStatus.PSObject.Properties['DomainRole']) {
+        $domainRole = $domainStatus.DomainRole
+        try { $domainRoleInt = [int]$domainRole } catch { $domainRoleInt = $null }
+    }
+
+    [pscustomobject]@{
+        Available     = $true
+        DomainStatus  = $domainStatus
+        DomainJoined  = $domainJoined
+        DomainName    = $domainName
+        DomainRole    = $domainRole
+        DomainRoleInt = $domainRoleInt
+    }
+}

--- a/Analyzers/Heuristics/AD/GroupPolicy.ps1
+++ b/Analyzers/Heuristics/AD/GroupPolicy.ps1
@@ -1,0 +1,93 @@
+function Add-AdGroupPolicyFindings {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $GpoInfo,
+        [string[]]$SharesFailingHosts,
+        [bool]$TimeSkewHigh
+    )
+
+    if (-not $GpoInfo) { return }
+
+    $gpResult = $GpoInfo.GpResult
+    $gpoEvents = @()
+    if ($GpoInfo.Events) {
+        foreach ($event in $GpoInfo.Events) {
+            if ($event -and -not $event.Error) { $gpoEvents += $event }
+        }
+    }
+
+    $gpResultSuccess = $false
+    if ($gpResult -and $gpResult.Succeeded -eq $true) { $gpResultSuccess = $true }
+
+    if ($gpResultSuccess -and $gpoEvents.Count -eq 0) {
+        Add-CategoryNormal -CategoryResult $Result -Title 'GOOD GPO (processed successfully)' -Subcategory 'Group Policy'
+        return
+    }
+
+    $severity = 'medium'
+    if ($gpoEvents.Count -ge 5 -and $SharesFailingHosts.Count -gt 0) { $severity = 'high' }
+    $title = "GPO processing errors, so device policies aren't applied"
+    if ($TimeSkewHigh) {
+        $titleBuilder = [System.Text.StringBuilder]::new()
+        $null = $titleBuilder.Append($title)
+        $null = $titleBuilder.Append(' related to time skew')
+        $title = $titleBuilder.ToString()
+    }
+    $evidenceBuilder = [System.Text.StringBuilder]::new()
+    if ($gpResult -and $gpResult.Output) { Add-StringFragment -Builder $evidenceBuilder -Fragment (($gpResult.Output | Select-Object -First 3) -join ' | ') }
+    if ($gpResult -and $gpResult.Error) { Add-StringFragment -Builder $evidenceBuilder -Fragment $gpResult.Error }
+    if ($gpoEvents.Count -gt 0) {
+        $eventGroups = $gpoEvents | Group-Object -Property Id
+        $eventSummaryParts = [System.Collections.Generic.List[string]]::new()
+        foreach ($group in $eventGroups) {
+            $null = $eventSummaryParts.Add(("{0}x{1}" -f $group.Count, $group.Name))
+        }
+
+        $eventSummary = ($eventSummaryParts -join ', ')
+        if ($eventSummary) { Add-StringFragment -Builder $evidenceBuilder -Fragment $eventSummary }
+    }
+    if ($evidenceBuilder.Length -eq 0) { Add-StringFragment -Builder $evidenceBuilder -Fragment 'GPO data unavailable' }
+    Add-CategoryIssue -CategoryResult $Result -Severity $severity -Title $title -Evidence $evidenceBuilder.ToString() -Subcategory 'Group Policy'
+}
+
+function Add-AdGroupPolicyEventLogFindings {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $EventsPayload
+    )
+
+    if (-not $EventsPayload -or -not $EventsPayload.GroupPolicy) { return }
+
+    $groupPolicyLog = $EventsPayload.GroupPolicy
+    if ($groupPolicyLog.Error) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Unable to read Group Policy event log, so device policy failures may be hidden.' -Evidence $groupPolicyLog.Error -Subcategory 'Group Policy'
+        return
+    }
+
+    $entries = if ($groupPolicyLog -is [System.Collections.IEnumerable] -and -not ($groupPolicyLog -is [string])) { @($groupPolicyLog) } else { @($groupPolicyLog) }
+    $sysvolMatches = $entries | Where-Object { $_.Message -match '(?i)\\\\[^\r\n]+\\(SYSVOL|NETLOGON)' -or $_.Message -match '(?i)The network path was not found' -or $_.Message -match '(?i)The system cannot find the path specified' }
+    if ($sysvolMatches.Count -gt 0) {
+        $selectedSysvolMatches = $sysvolMatches | Select-Object -First 3
+        $sysvolEvidence = [System.Collections.Generic.List[string]]::new()
+        foreach ($entry in $selectedSysvolMatches) {
+            $null = $sysvolEvidence.Add(("[{0}] {1}" -f $entry.Id, $entry.Message))
+        }
+
+        $evidence = ($sysvolEvidence -join "`n")
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title "Group Policy errors accessing SYSVOL/NETLOGON, so device policies aren't applied." -Evidence $evidence -Subcategory 'Group Policy'
+    }
+
+    $gpoFailures = $entries | Where-Object { $_.Id -in 1058, 1030, 1502, 1503 }
+    if ($gpoFailures.Count -gt 0) {
+        $selectedGpoFailures = $gpoFailures | Select-Object -First 3
+        $gpoFailureEvidence = [System.Collections.Generic.List[string]]::new()
+        foreach ($entry in $selectedGpoFailures) {
+            $null = $gpoFailureEvidence.Add(("[{0}] {1}" -f $entry.Id, $entry.Message))
+        }
+
+        $evidence = ($gpoFailureEvidence -join "`n")
+        Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title "Group Policy processing failures detected, so device policies aren't applied." -Evidence $evidence -Subcategory 'Group Policy'
+    }
+}

--- a/Analyzers/Heuristics/AD/Identity.ps1
+++ b/Analyzers/Heuristics/AD/Identity.ps1
@@ -1,0 +1,18 @@
+function Add-AdIdentityFindings {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $Context
+    )
+
+    $identityArtifact = Get-AnalyzerArtifact -Context $Context -Name 'identity'
+    if (-not $identityArtifact) { return }
+
+    $identityPayload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $identityArtifact)
+    if ($identityPayload -and $identityPayload.DsRegCmd) {
+        $text = if ($identityPayload.DsRegCmd -is [string[]]) { $identityPayload.DsRegCmd -join "`n" } else { [string]$identityPayload.DsRegCmd }
+        if ($text -match 'AzureAdJoined\s*:\s*YES') {
+            Add-CategoryNormal -CategoryResult $Result -Title 'Azure AD join detected' -Subcategory 'Discovery'
+        }
+    }
+}

--- a/Analyzers/Heuristics/AD/Kerberos.ps1
+++ b/Analyzers/Heuristics/AD/Kerberos.ps1
@@ -1,0 +1,58 @@
+function Add-AdKerberosFindings {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $KerberosInfo,
+        [bool]$NoDcReachable,
+        [bool]$TimeSkewHigh
+    )
+
+    if (-not $KerberosInfo) {
+        return [pscustomobject]@{ FailureCount = 0 }
+    }
+
+    $kerberosEvents = @()
+    if ($KerberosInfo.Events) {
+        foreach ($event in $KerberosInfo.Events) {
+            if ($event -and -not $event.Error) { $kerberosEvents += $event }
+        }
+    }
+
+    $failureEvents = $kerberosEvents | Where-Object { $_.Id -in 4768, 4771, 4776 }
+    $failureCount = $failureEvents.Count
+
+    if ($KerberosInfo.Parsed -and $KerberosInfo.Parsed.HasTgt -ne $true) {
+        $title = "Kerberos TGT not present, breaking Active Directory authentication."
+        $evidencePartsBuilder = [System.Text.StringBuilder]::new()
+        Add-StringFragment -Builder $evidencePartsBuilder -Fragment 'klist output missing krbtgt ticket'
+        if ($KerberosInfo.Parsed.PSObject.Properties['TgtRealm'] -and $KerberosInfo.Parsed.TgtRealm) {
+            Add-StringFragment -Builder $evidencePartsBuilder -Fragment ("Expected realm: {0}" -f $KerberosInfo.Parsed.TgtRealm)
+        }
+        if ($NoDcReachable) { Add-StringFragment -Builder $evidencePartsBuilder -Fragment 'likely off network' }
+        Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title $title -Evidence $evidencePartsBuilder.ToString() -Subcategory 'Kerberos'
+    }
+
+    if ($failureCount -gt 0) {
+        $severity = if ($failureCount -ge 15) { 'high' } else { 'medium' }
+        if ($NoDcReachable -and $severity -eq 'high') { $severity = 'medium' }
+        $messageBuilder = [System.Text.StringBuilder]::new()
+        $null = $messageBuilder.Append(("Kerberos authentication failures detected ({0}), breaking Active Directory authentication" -f $failureCount))
+        if ($TimeSkewHigh -and ($failureEvents | Where-Object { $_.Message -match 'KRB_AP_ERR_SKEW' })) {
+            $null = $messageBuilder.Append(' related to time skew')
+        } elseif ($NoDcReachable) {
+            $null = $messageBuilder.Append('; DC unreachable')
+        }
+        $failureGroups = $failureEvents | Group-Object -Property Id
+        $failureSummaryParts = [System.Collections.Generic.List[string]]::new()
+        foreach ($group in $failureGroups) {
+            $null = $failureSummaryParts.Add(("{0}x{1}" -f $group.Count, $group.Name))
+        }
+
+        $failureSummary = ($failureSummaryParts -join ', ')
+        Add-CategoryIssue -CategoryResult $Result -Severity $severity -Title $messageBuilder.ToString() -Evidence $failureSummary -Subcategory 'Kerberos'
+    }
+
+    [pscustomobject]@{
+        FailureCount = $failureCount
+    }
+}

--- a/Analyzers/Heuristics/AD/SecureChannel.ps1
+++ b/Analyzers/Heuristics/AD/SecureChannel.ps1
@@ -1,0 +1,36 @@
+function Add-AdSecureChannelFindings {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $SecureInfo
+    )
+
+    $scBroken = $false
+    if ($SecureInfo) {
+        $scTest = $SecureInfo.TestComputerSecureChannel
+        if ($scTest) {
+            if ($scTest.Succeeded -eq $true -and $scTest.IsSecure -eq $false) {
+                $scBroken = $true
+            } elseif ($scTest.Succeeded -eq $true -and $scTest.IsSecure -eq $true) {
+                Add-CategoryNormal -CategoryResult $Result -Title 'GOOD SecureChannel (verified)' -Subcategory 'Secure Channel'
+            }
+        }
+        if ($SecureInfo.NltestScQuery) {
+            $outputText = $SecureInfo.NltestScQuery.Output -join ' '
+            if ($outputText -match 'NO_LOGON_SERVERS' -or $outputText -match 'TRUST_FAILURE' -or $outputText -match 'STATUS=\s*0xC000018D') {
+                $scBroken = $true
+            }
+        }
+        if ($scTest -and $scTest.Succeeded -eq $false -and $scTest.Error) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Secure channel verification failed to run, so machine trust status is unknown.' -Evidence $scTest.Error -Subcategory 'Secure Channel'
+        }
+    }
+
+    if ($scBroken) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Broken machine secure channel, blocking domain authentication.' -Subcategory 'Secure Channel'
+    }
+
+    [pscustomobject]@{
+        SecureChannelBroken = $scBroken
+    }
+}

--- a/Analyzers/Heuristics/AD/Time.ps1
+++ b/Analyzers/Heuristics/AD/Time.ps1
@@ -1,0 +1,126 @@
+function Add-AdTimeFindings {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $TimeInfo,
+        [string[]]$CandidateHosts,
+        [string[]]$CandidateAddresses,
+        [string]$DomainName,
+        [bool]$DomainJoined,
+        [int]$DomainRoleInt
+    )
+
+    $timeSkewHigh = $false
+    $clientType = $null
+    $clientServersRaw = $null
+    $peerEntries = @()
+    $sourceRaw = $null
+
+    if ($TimeInfo) {
+        $parsed = $TimeInfo.Parsed
+        $offset = $null
+        if ($parsed -and $parsed.PSObject.Properties['OffsetSeconds']) {
+            $offset = $parsed.OffsetSeconds
+        }
+        $synchronized = $null
+        if ($parsed -and $parsed.PSObject.Properties['Synchronized']) {
+            $synchronized = $parsed.Synchronized
+        }
+
+        if ($offset -ne $null -and [math]::Abs([double]$offset) -gt 300) {
+            $timeSkewHigh = $true
+            Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Kerberos time skew, breaking Active Directory authentication.' -Evidence ("Offset {0} seconds" -f [math]::Round([double]$offset, 2)) -Subcategory 'Time Synchronization'
+        } elseif ($synchronized -eq $false -or ($TimeInfo.Status -and $TimeInfo.Status.Succeeded -ne $true)) {
+            $timeSkewHigh = $true
+            Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Kerberos time skew, breaking Active Directory authentication.' -Evidence 'Time service not synchronized.' -Subcategory 'Time Synchronization'
+        } elseif ($offset -ne $null -and [math]::Abs([double]$offset) -le 300) {
+            Add-CategoryNormal -CategoryResult $Result -Title 'GOOD Time (skew ≤5m)' -Evidence ("Offset {0} seconds" -f [math]::Round([double]$offset, 2)) -Subcategory 'Time Synchronization'
+        }
+
+        if ($parsed) {
+            if ($parsed.PSObject.Properties['ClientType']) { $clientType = $parsed.ClientType }
+            if ($parsed.PSObject.Properties['ClientNtpServer']) { $clientServersRaw = $parsed.ClientNtpServer }
+            if ($parsed.PSObject.Properties['PeerEntries'] -and $parsed.PeerEntries) { $peerEntries = $parsed.PeerEntries }
+            if ($parsed.PSObject.Properties['Source']) { $sourceRaw = $parsed.Source }
+        }
+    }
+
+    $manualPeers = @()
+    if ($clientServersRaw) {
+        $components = $clientServersRaw -split '\s+'
+        foreach ($component in $components) {
+            $cleanPeer = Get-CleanTimePeerName -Value $component
+            if (-not $cleanPeer) { continue }
+            if ($cleanPeer -eq '(Local)') { continue }
+            $manualPeers += $cleanPeer
+        }
+    }
+
+    $peerNames = @()
+    foreach ($peerEntry in $peerEntries) {
+        $cleanPeer = Get-CleanTimePeerName -Value $peerEntry
+        if ($cleanPeer) { $peerNames += $cleanPeer }
+    }
+
+    $sourceName = if ($sourceRaw) { Get-CleanTimePeerName -Value $sourceRaw } else { $null }
+
+    $combinedPeers = @()
+    if ($manualPeers) { $combinedPeers += $manualPeers }
+    if ($peerNames) { $combinedPeers += $peerNames }
+    $combinedPeers = $combinedPeers | Sort-Object -Unique
+
+    $suspiciousPeers = @()
+    foreach ($peer in $combinedPeers) {
+        if (-not $peer) { continue }
+        $peerLower = $peer.ToLowerInvariant()
+        if ($peerLower -match 'local cmos clock' -or $peerLower -match 'free-running system clock') { continue }
+        if (Test-IsDomainTimePeer -Peer $peer -CandidateHosts $CandidateHosts -CandidateAddresses $CandidateAddresses -DomainName $DomainName) {
+            continue
+        }
+        $suspiciousPeers += $peer
+    }
+
+    $suspiciousSource = $null
+    if ($sourceName) {
+        $sourceLower = $sourceName.ToLowerInvariant()
+        $isDomainPeer = Test-IsDomainTimePeer -Peer $sourceName -CandidateHosts $CandidateHosts -CandidateAddresses $CandidateAddresses -DomainName $DomainName
+        if (-not $isDomainPeer -or $sourceLower -match 'local cmos clock' -or $sourceLower -match 'free-running system clock' -or $sourceLower -match 'vm ic time synchronization provider') {
+            $suspiciousSource = $sourceName
+        }
+    }
+
+    $clientTypeNormalized = $null
+    if ($clientType) {
+        $clientTypeNormalized = $clientType.ToString().Trim()
+    }
+
+    $isPrimaryDomainController = $false
+    if ($null -ne $DomainRoleInt -and $DomainRoleInt -eq 5) { $isPrimaryDomainController = $true }
+
+    if ($DomainJoined -and -not $isPrimaryDomainController) {
+        $needsWarning = $false
+        if ($clientTypeNormalized -and $clientTypeNormalized.ToUpperInvariant() -ne 'NT5DS') {
+            $needsWarning = $true
+        }
+        if (-not $needsWarning -and $suspiciousPeers.Count -gt 0) { $needsWarning = $true }
+        if (-not $needsWarning -and $suspiciousSource) { $needsWarning = $true }
+
+        if ($needsWarning) {
+            $evidencePieces = @()
+            if ($clientTypeNormalized) { $evidencePieces += "Type $clientTypeNormalized" }
+            if ($suspiciousSource) { $evidencePieces += "Source $suspiciousSource" }
+            if ($suspiciousPeers.Count -gt 0) {
+                $evidencePieces += ("Peers: {0}" -f (($suspiciousPeers | Sort-Object -Unique) -join ', '))
+            }
+            if (-not $evidencePieces) { $evidencePieces += 'Manual time source detected.' }
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Domain time misconfigured (manual NTP), so Active Directory cannot control system time.' -Evidence ($evidencePieces -join '; ') -Subcategory 'Time Synchronization'
+        }
+    }
+
+    [pscustomobject]@{
+        TimeSkewHigh         = $timeSkewHigh
+        SuspiciousPeers      = $suspiciousPeers
+        SuspiciousSource     = $suspiciousSource
+        ClientTypeNormalized = $clientTypeNormalized
+    }
+}


### PR DESCRIPTION
## Summary
- split the Active Directory heuristics into focused helper scripts for discovery, connectivity, time, secure channel, Kerberos, group policy, and identity concerns
- streamline `Invoke-ADHeuristics` to orchestrate the new helpers while keeping existing outputs and logging behaviour

## Testing
- `pwsh -NoLogo -NoProfile -Command ". '$PWD/Analyzers/Heuristics/AD.ps1'"` *(fails: `pwsh` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de7d0faf34832d8b43c867ee508837