### PR TITLE
Add shared ipconfig helper for collectors

### DIFF
--- a/Collectors/Network/Collect-Network.ps1
+++ b/Collectors/Network/Collect-Network.ps1
@@ -11,7 +11,19 @@ param(
 . (Join-Path -Path $PSScriptRoot -ChildPath '..\\CollectorCommon.ps1')
 
 function Get-IpConfiguration {
-    return Invoke-CollectorNativeCommand -FilePath 'ipconfig.exe' -ArgumentList '/all' -SourceLabel 'ipconfig.exe'
+    $result = Invoke-IpconfigAll
+
+    if ($null -eq $result) { return $result }
+
+    if ($result -is [psobject] -and $result.PSObject.Properties.Name -contains 'Error') {
+        return $result
+    }
+
+    if ($result -is [psobject] -and $result.PSObject.Properties.Name -contains 'Lines') {
+        return $result.Lines
+    }
+
+    return $result
 }
 
 function Get-RoutingTable {


### PR DESCRIPTION
## Summary
- add a reusable helper that caches `ipconfig /all` output as raw text and parsed lines
- update network collectors to consume the shared helper and reuse the parsed data
- adjust DHCP helpers to emit the cached output while preserving existing payload formats

## Testing
- No tests were run (PowerShell is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68de7f0c5fdc832d8cc1d1748fa12935