### PR TITLE
Refactor printing heuristics into modular scripts

### DIFF
--- a/Analyzers/Heuristics/Printing.ps1
+++ b/Analyzers/Heuristics/Printing.ps1
@@ -4,57 +4,12 @@
 #>
 
 . (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'AnalyzerCommon.ps1')
-
-function ConvertTo-PrintingArray {
-    param($Value)
-
-    if ($null -eq $Value) { return @() }
-    if ($Value -is [string]) { return @($Value) }
-    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [hashtable])) {
-        $itemsList = New-Object System.Collections.Generic.List[object]
-        foreach ($item in $Value) { $itemsList.Add($item) | Out-Null }
-        return $itemsList.ToArray()
-    }
-    return @($Value)
-}
-
-function Get-PrintingPlatformInfo {
-    param($Context)
-
-    $isWindowsServer = $null
-    $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
-    if ($systemArtifact) {
-        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact)
-        if ($payload -and $payload.OperatingSystem -and -not $payload.OperatingSystem.Error) {
-            $caption = [string]$payload.OperatingSystem.Caption
-            if ($caption) {
-                $isWindowsServer = ($caption -match '(?i)windows\s+server')
-            }
-        }
-    }
-
-    $isWorkstation = $null
-    if ($isWindowsServer -eq $true) { $isWorkstation = $false }
-    elseif ($isWindowsServer -eq $false) { $isWorkstation = $true }
-
-    return [pscustomobject]@{
-        IsWindowsServer = $isWindowsServer
-        IsWorkstation   = $isWorkstation
-    }
-}
-
-function Normalize-PrintingServiceState {
-    param([string]$Value)
-
-    if (-not $Value) { return 'unknown' }
-    $trimmed = $Value.Trim()
-    if (-not $trimmed) { return 'unknown' }
-
-    $lower = $trimmed.ToLowerInvariant()
-    if ($lower -like 'run*') { return 'running' }
-    if ($lower -like 'stop*') { return 'stopped' }
-    return 'other'
-}
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Printing/Common.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Printing/Platform.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Printing/Spooler.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Printing/Inventory.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Printing/Events.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Printing/NetworkTests.ps1')
 
 function Invoke-PrintingHeuristics {
     param(
@@ -100,133 +55,23 @@ function Invoke-PrintingHeuristics {
         }
     }
 
-    if ($payload.Spooler) {
-        $spooler = $payload.Spooler
-        if ($spooler.Error) {
-            Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title "Print Spooler state unavailable, so printing security and reliability risks can't be evaluated." -Evidence $spooler.Error -Subcategory 'Spooler Service'
-        } else {
-            $status = if ($spooler.Status) { [string]$spooler.Status } else { 'Unknown' }
-            $startMode = if ($spooler.StartMode) { [string]$spooler.StartMode } else { $spooler.StartType }
-            $statusNorm = Normalize-PrintingServiceState -Value $status
-            Add-CategoryCheck -CategoryResult $result -Name 'Spooler status' -Status $status -Details ("StartMode: {0}" -f $startMode)
-            if ($statusNorm -eq 'running') {
-                if ($isWorkstation) {
-                    Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'Print Spooler running — disable if this workstation does not need printing (PrintNightmare).' -Evidence ("Status: {0}; StartMode: {1}" -f $status, $startMode) -Subcategory 'Spooler Service'
-                } else {
-                    Add-CategoryNormal -CategoryResult $result -Title 'Print Spooler running' -Evidence ("Status: {0}; StartMode: {1}" -f $status, $startMode) -Subcategory 'Spooler Service'
-                }
-            } else {
-                $note = if ($isWorkstation) { 'PrintNightmare guidance: disable spooler unless required.' } else { 'Printing will remain offline until the spooler is started.' }
-                Add-CategoryIssue -CategoryResult $result -Severity 'info' -Title 'Print Spooler not running, exposing printing security and reliability risks until resolved.' -Evidence ("Status: {0}; StartMode: {1}; Note: {2}" -f $status, $startMode, $note) -Subcategory 'Spooler Service'
-            }
+    Invoke-PrintingSpoolerChecks -Result $result -Spooler $payload.Spooler -IsWorkstation $isWorkstation
+
+    $inventorySummary = Invoke-PrinterInventoryChecks -Result $result -Payload $payload
+
+    Invoke-PrinterEventChecks -Result $result -Events $payload.Events
+    Invoke-PrinterNetworkTestChecks -Result $result -NetworkTests $payload.NetworkTests
+
+    if ($inventorySummary) {
+        Write-HeuristicDebug -Source 'Printing' -Message 'Printer analysis summary' -Data ([ordered]@{
+            OfflineCount = $inventorySummary.OfflinePrinters.Count
+            WsdCount     = $inventorySummary.WsdPrinters.Count
+            StaleJobs    = $inventorySummary.StuckJobs.Count
+        })
+
+        if ($inventorySummary.Printers.Count -gt 0 -and $inventorySummary.OfflinePrinters.Count -eq 0) {
+            Add-CategoryNormal -CategoryResult $result -Title ('Printers online ({0})' -f $inventorySummary.Printers.Count) -Subcategory 'Printers'
         }
-    }
-
-    $defaultPrinter = $payload.DefaultPrinter
-    $offlinePrintersList = New-Object System.Collections.Generic.List[object]
-    $wsdPrintersList = New-Object System.Collections.Generic.List[object]
-    $stuckJobsList = New-Object System.Collections.Generic.List[object]
-    $printers = ConvertTo-PrintingArray $payload.Printers
-    Write-HeuristicDebug -Source 'Printing' -Message 'Analyzing printer inventory' -Data ([ordered]@{
-        PrinterCount = $printers.Count
-        Default      = $defaultPrinter
-    })
-
-    foreach ($printer in $printers) {
-        if (-not $printer) { continue }
-        $name = [string]$printer.Name
-        $status = if ($printer.PrinterStatus) { [string]$printer.PrinterStatus } else { '' }
-        $queueStatus = if ($printer.QueueStatus) { [string]$printer.QueueStatus } else { '' }
-        $offline = $false
-        if ($printer.PSObject.Properties['WorkOffline']) {
-            try { if ([bool]$printer.WorkOffline) { $offline = $true } } catch { }
-        }
-        if (-not $offline -and ($status -match '(?i)offline' -or $queueStatus -match '(?i)offline')) { $offline = $true }
-        if ($offline) {
-            $offlinePrintersList.Add($name) | Out-Null
-            if ($defaultPrinter -and $name -eq $defaultPrinter) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Default printer offline, exposing printing security and reliability risks.' -Evidence $name -Subcategory 'Printers'
-            } else {
-                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ('Printer offline: {0}, exposing printing security and reliability risks.' -f $name) -Subcategory 'Printers'
-            }
-        }
-
-        if ($printer.Connection -and $printer.Connection.Kind -eq 'WSD') {
-            $wsdPrintersList.Add($name) | Out-Null
-        }
-
-        if ($printer.Jobs) {
-            foreach ($job in $printer.Jobs) {
-                if (-not $job) { continue }
-                if ($job.AgeMinutes -and $job.AgeMinutes -gt 60) {
-                    $severity = if ($job.AgeMinutes -ge 240) { 'high' } else { 'medium' }
-                    $jobName = if ($job.DocumentName) { [string]$job.DocumentName } elseif ($job.PSObject.Properties['Id']) { "Job $($job.Id)" } else { 'Print job' }
-                    $ageRounded = [math]::Round($job.AgeMinutes,1)
-                    $stuckJobsList.Add(("{0} ({1} min old)" -f $jobName, $ageRounded)) | Out-Null
-                    Add-CategoryIssue -CategoryResult $result -Severity $severity -Title ('Stale print job detected on {0}, exposing printing security and reliability risks.' -f $name) -Evidence (("{0} age {1} minutes" -f $jobName, $ageRounded)) -Subcategory 'Queues'
-                }
-            }
-        }
-    }
-
-    $offlinePrinters = $offlinePrintersList.ToArray()
-    $wsdPrinters = $wsdPrintersList.ToArray()
-    $stuckJobs = $stuckJobsList.ToArray()
-
-    Write-HeuristicDebug -Source 'Printing' -Message 'Printer analysis summary' -Data ([ordered]@{
-        OfflineCount = $offlinePrinters.Count
-        WsdCount     = $wsdPrinters.Count
-        StaleJobs    = $stuckJobs.Count
-    })
-
-    if ($stuckJobs.Count -gt 0) {
-        Add-CategoryCheck -CategoryResult $result -Name 'Stale print jobs' -Status ([string]$stuckJobs.Count) -Details ($stuckJobs -join '; ')
-    }
-
-    if ($wsdPrinters.Count -gt 0) {
-        Add-CategoryIssue -CategoryResult $result -Severity 'low' -Title ('Printers using WSD ports: {0}, exposing printing security and reliability risks.' -f ($wsdPrinters -join ', ')) -Evidence 'WSD ports are less reliable for enterprise printing; prefer Standard TCP/IP.' -Subcategory 'Printers'
-    }
-
-    if ($payload.Events) {
-        $events = $payload.Events
-        if ($events.Admin) {
-            $admin = $events.Admin
-            Add-CategoryCheck -CategoryResult $result -Name 'PrintService/Admin errors' -Status ([string]$admin.ErrorCount)
-            if ($admin.ErrorCount -gt 0) {
-                $severity = if ($admin.ErrorCount -ge 5) { 'high' } else { 'medium' }
-                $driverCrashSummaries = [System.Collections.Generic.List[string]]::new()
-                foreach ($entry in $admin.DriverCrashCount.GetEnumerator()) {
-                    $null = $driverCrashSummaries.Add(("{0}={1}" -f $entry.Key, $entry.Value))
-                }
-
-                $evidence = "Errors: {0}; Driver crash IDs: {1}" -f $admin.ErrorCount, ($driverCrashSummaries -join ', ')
-                Add-CategoryIssue -CategoryResult $result -Severity $severity -Title 'PrintService Admin log reporting errors, exposing printing security and reliability risks.' -Evidence $evidence -Subcategory 'Event Logs'
-            }
-        }
-        if ($events.Operational) {
-            $op = $events.Operational
-            Add-CategoryCheck -CategoryResult $result -Name 'PrintService/Operational warnings' -Status ([string]$op.WarningCount)
-            if ($op.ErrorCount -gt 10) {
-                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title 'PrintService Operational log has frequent errors, exposing printing security and reliability risks.' -Evidence ("Errors: {0}" -f $op.ErrorCount) -Subcategory 'Event Logs'
-            }
-        }
-    }
-
-    if ($payload.NetworkTests) {
-        foreach ($testGroup in (ConvertTo-PrintingArray $payload.NetworkTests)) {
-            if (-not $testGroup) { continue }
-            foreach ($test in (ConvertTo-PrintingArray $testGroup.Tests)) {
-                if (-not $test) { continue }
-                if ($test.Success -eq $false -or $test.Error) {
-                    $evidence = "Host: {0}; Test: {1}; Error: {2}" -f $testGroup.Host, $test.Name, ($test.Error ? $test.Error : 'Connection failure')
-                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ('Printer host connectivity test failed ({0}), exposing printing security and reliability risks.' -f $testGroup.Host) -Evidence $evidence -Subcategory 'Network Tests'
-                }
-            }
-        }
-    }
-
-    if ($printers.Count -gt 0 -and $offlinePrinters.Count -eq 0) {
-        Add-CategoryNormal -CategoryResult $result -Title ('Printers online ({0})' -f $printers.Count) -Subcategory 'Printers'
     }
 
     return $result

--- a/Analyzers/Heuristics/Printing/Common.ps1
+++ b/Analyzers/Heuristics/Printing/Common.ps1
@@ -1,0 +1,25 @@
+function ConvertTo-PrintingArray {
+    param($Value)
+
+    if ($null -eq $Value) { return @() }
+    if ($Value -is [string]) { return @($Value) }
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [hashtable])) {
+        $itemsList = New-Object System.Collections.Generic.List[object]
+        foreach ($item in $Value) { $itemsList.Add($item) | Out-Null }
+        return $itemsList.ToArray()
+    }
+    return @($Value)
+}
+
+function Normalize-PrintingServiceState {
+    param([string]$Value)
+
+    if (-not $Value) { return 'unknown' }
+    $trimmed = $Value.Trim()
+    if (-not $trimmed) { return 'unknown' }
+
+    $lower = $trimmed.ToLowerInvariant()
+    if ($lower -like 'run*') { return 'running' }
+    if ($lower -like 'stop*') { return 'stopped' }
+    return 'other'
+}

--- a/Analyzers/Heuristics/Printing/Events.ps1
+++ b/Analyzers/Heuristics/Printing/Events.ps1
@@ -1,0 +1,32 @@
+function Invoke-PrinterEventChecks {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $Events
+    )
+
+    if (-not $Events) { return }
+
+    if ($Events.Admin) {
+        $admin = $Events.Admin
+        Add-CategoryCheck -CategoryResult $Result -Name 'PrintService/Admin errors' -Status ([string]$admin.ErrorCount)
+        if ($admin.ErrorCount -gt 0) {
+            $severity = if ($admin.ErrorCount -ge 5) { 'high' } else { 'medium' }
+            $driverCrashSummaries = [System.Collections.Generic.List[string]]::new()
+            foreach ($entry in $admin.DriverCrashCount.GetEnumerator()) {
+                $null = $driverCrashSummaries.Add(("{0}={1}" -f $entry.Key, $entry.Value))
+            }
+
+            $evidence = "Errors: {0}; Driver crash IDs: {1}" -f $admin.ErrorCount, ($driverCrashSummaries -join ', ')
+            Add-CategoryIssue -CategoryResult $Result -Severity $severity -Title 'PrintService Admin log reporting errors, exposing printing security and reliability risks.' -Evidence $evidence -Subcategory 'Event Logs'
+        }
+    }
+
+    if ($Events.Operational) {
+        $op = $Events.Operational
+        Add-CategoryCheck -CategoryResult $Result -Name 'PrintService/Operational warnings' -Status ([string]$op.WarningCount)
+        if ($op.ErrorCount -gt 10) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'PrintService Operational log has frequent errors, exposing printing security and reliability risks.' -Evidence ("Errors: {0}" -f $op.ErrorCount) -Subcategory 'Event Logs'
+        }
+    }
+}

--- a/Analyzers/Heuristics/Printing/Inventory.ps1
+++ b/Analyzers/Heuristics/Printing/Inventory.ps1
@@ -1,0 +1,73 @@
+function Invoke-PrinterInventoryChecks {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        [Parameter(Mandatory)]
+        $Payload
+    )
+
+    $defaultPrinter = $Payload.DefaultPrinter
+    $offlinePrintersList = New-Object System.Collections.Generic.List[object]
+    $wsdPrintersList = New-Object System.Collections.Generic.List[object]
+    $stuckJobsList = New-Object System.Collections.Generic.List[object]
+    $printers = ConvertTo-PrintingArray $Payload.Printers
+
+    Write-HeuristicDebug -Source 'Printing' -Message 'Analyzing printer inventory' -Data ([ordered]@{
+        PrinterCount = $printers.Count
+        Default      = $defaultPrinter
+    })
+
+    foreach ($printer in $printers) {
+        if (-not $printer) { continue }
+
+        $name = [string]$printer.Name
+        $status = if ($printer.PrinterStatus) { [string]$printer.PrinterStatus } else { '' }
+        $queueStatus = if ($printer.QueueStatus) { [string]$printer.QueueStatus } else { '' }
+        $offline = $false
+        if ($printer.PSObject.Properties['WorkOffline']) {
+            try { if ([bool]$printer.WorkOffline) { $offline = $true } } catch { }
+        }
+        if (-not $offline -and ($status -match '(?i)offline' -or $queueStatus -match '(?i)offline')) { $offline = $true }
+        if ($offline) {
+            $offlinePrintersList.Add($name) | Out-Null
+            if ($defaultPrinter -and $name -eq $defaultPrinter) {
+                Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title 'Default printer offline, exposing printing security and reliability risks.' -Evidence $name -Subcategory 'Printers'
+            } else {
+                Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title ('Printer offline: {0}, exposing printing security and reliability risks.' -f $name) -Subcategory 'Printers'
+            }
+        }
+
+        if ($printer.Connection -and $printer.Connection.Kind -eq 'WSD') {
+            $wsdPrintersList.Add($name) | Out-Null
+        }
+
+        if ($printer.Jobs) {
+            foreach ($job in $printer.Jobs) {
+                if (-not $job) { continue }
+                if ($job.AgeMinutes -and $job.AgeMinutes -gt 60) {
+                    $severity = if ($job.AgeMinutes -ge 240) { 'high' } else { 'medium' }
+                    $jobName = if ($job.DocumentName) { [string]$job.DocumentName } elseif ($job.PSObject.Properties['Id']) { "Job $($job.Id)" } else { 'Print job' }
+                    $ageRounded = [math]::Round($job.AgeMinutes, 1)
+                    $stuckJobsList.Add(("{0} ({1} min old)" -f $jobName, $ageRounded)) | Out-Null
+                    Add-CategoryIssue -CategoryResult $Result -Severity $severity -Title ('Stale print job detected on {0}, exposing printing security and reliability risks.' -f $name) -Evidence (("{0} age {1} minutes" -f $jobName, $ageRounded)) -Subcategory 'Queues'
+                }
+            }
+        }
+    }
+
+    $stuckJobs = $stuckJobsList.ToArray()
+    if ($stuckJobs.Count -gt 0) {
+        Add-CategoryCheck -CategoryResult $Result -Name 'Stale print jobs' -Status ([string]$stuckJobs.Count) -Details ($stuckJobs -join '; ')
+    }
+
+    if ($wsdPrintersList.Count -gt 0) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'low' -Title ('Printers using WSD ports: {0}, exposing printing security and reliability risks.' -f ($wsdPrintersList -join ', ')) -Evidence 'WSD ports are less reliable for enterprise printing; prefer Standard TCP/IP.' -Subcategory 'Printers'
+    }
+
+    return [pscustomobject]@{
+        Printers        = $printers
+        OfflinePrinters = $offlinePrintersList.ToArray()
+        WsdPrinters     = $wsdPrintersList.ToArray()
+        StuckJobs       = $stuckJobs
+    }
+}

--- a/Analyzers/Heuristics/Printing/NetworkTests.ps1
+++ b/Analyzers/Heuristics/Printing/NetworkTests.ps1
@@ -1,0 +1,20 @@
+function Invoke-PrinterNetworkTestChecks {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $NetworkTests
+    )
+
+    if (-not $NetworkTests) { return }
+
+    foreach ($testGroup in (ConvertTo-PrintingArray $NetworkTests)) {
+        if (-not $testGroup) { continue }
+        foreach ($test in (ConvertTo-PrintingArray $testGroup.Tests)) {
+            if (-not $test) { continue }
+            if ($test.Success -eq $false -or $test.Error) {
+                $evidence = "Host: {0}; Test: {1}; Error: {2}" -f $testGroup.Host, $test.Name, ($test.Error ? $test.Error : 'Connection failure')
+                Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title ('Printer host connectivity test failed ({0}), exposing printing security and reliability risks.' -f $testGroup.Host) -Evidence $evidence -Subcategory 'Network Tests'
+            }
+        }
+    }
+}

--- a/Analyzers/Heuristics/Printing/Platform.ps1
+++ b/Analyzers/Heuristics/Printing/Platform.ps1
@@ -1,0 +1,24 @@
+function Get-PrintingPlatformInfo {
+    param($Context)
+
+    $isWindowsServer = $null
+    $systemArtifact = Get-AnalyzerArtifact -Context $Context -Name 'system'
+    if ($systemArtifact) {
+        $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $systemArtifact)
+        if ($payload -and $payload.OperatingSystem -and -not $payload.OperatingSystem.Error) {
+            $caption = [string]$payload.OperatingSystem.Caption
+            if ($caption) {
+                $isWindowsServer = ($caption -match '(?i)windows\s+server')
+            }
+        }
+    }
+
+    $isWorkstation = $null
+    if ($isWindowsServer -eq $true) { $isWorkstation = $false }
+    elseif ($isWindowsServer -eq $false) { $isWorkstation = $true }
+
+    return [pscustomobject]@{
+        IsWindowsServer = $isWindowsServer
+        IsWorkstation   = $isWorkstation
+    }
+}

--- a/Analyzers/Heuristics/Printing/Spooler.ps1
+++ b/Analyzers/Heuristics/Printing/Spooler.ps1
@@ -1,0 +1,33 @@
+function Invoke-PrintingSpoolerChecks {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+        $Spooler,
+        [bool]$IsWorkstation
+    )
+
+    if (-not $Spooler) { return }
+
+    if ($Spooler.Error) {
+        Add-CategoryIssue -CategoryResult $Result -Severity 'high' -Title "Print Spooler state unavailable, so printing security and reliability risks can't be evaluated." -Evidence $Spooler.Error -Subcategory 'Spooler Service'
+        return
+    }
+
+    $status = if ($Spooler.Status) { [string]$Spooler.Status } else { 'Unknown' }
+    $startMode = if ($Spooler.StartMode) { [string]$Spooler.StartMode } else { $Spooler.StartType }
+    $statusNorm = Normalize-PrintingServiceState -Value $status
+
+    Add-CategoryCheck -CategoryResult $Result -Name 'Spooler status' -Status $status -Details ("StartMode: {0}" -f $startMode)
+
+    if ($statusNorm -eq 'running') {
+        if ($IsWorkstation) {
+            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Print Spooler running — disable if this workstation does not need printing (PrintNightmare).' -Evidence ("Status: {0}; StartMode: {1}" -f $status, $startMode) -Subcategory 'Spooler Service'
+        } else {
+            Add-CategoryNormal -CategoryResult $Result -Title 'Print Spooler running' -Evidence ("Status: {0}; StartMode: {1}" -f $status, $startMode) -Subcategory 'Spooler Service'
+        }
+        return
+    }
+
+    $note = if ($IsWorkstation) { 'PrintNightmare guidance: disable spooler unless required.' } else { 'Printing will remain offline until the spooler is started.' }
+    Add-CategoryIssue -CategoryResult $Result -Severity 'info' -Title 'Print Spooler not running, exposing printing security and reliability risks until resolved.' -Evidence ("Status: {0}; StartMode: {1}; Note: {2}" -f $status, $startMode, $note) -Subcategory 'Spooler Service'
+}


### PR DESCRIPTION
## Summary
- split the monolithic printing analyzer into reusable helper scripts for shared utilities, platform detection, spooler, inventory, events, and network checks
- update the main printing heuristic to dot-source the new modules and centralize summary logging

## Testing
- not run (pwsh not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de877fb66c832da23dce5cdf9a9bc2