### PR TITLE
Improve Device Health report navigation and visual hierarchy

### DIFF
--- a/Analyzers/HtmlComposer.ps1
+++ b/Analyzers/HtmlComposer.ps1
@@ -626,14 +626,18 @@ function Build-SummaryCardHtml {
         }
     }
 
+    $summarySectionId = 'section-overview'
     $sb = New-Object System.Text.StringBuilder
-    $null = $sb.AppendLine('<h1>Device Health Report</h1>')
-    $null = $sb.AppendLine("<h2 class='report-subtitle'>Generated $generatedAtHtml</h2>")
-    $null = $sb.AppendLine("<div class='report-card report-card--overview'>")
-    $null = $sb.AppendLine("  <div class='score-section'>")
-    $null = $sb.AppendLine("    <div class='score-section__primary'>")
-    & $appendIndented $sb $overallRingHtml '      '
-    $null = $sb.AppendLine("      <div class='report-badge-group'>")
+    $null = $sb.AppendLine("<section class='report-summary' id='$summarySectionId'>")
+    $null = $sb.AppendLine("  <div class='report-summary__heading'>")
+    $null = $sb.AppendLine('    <h1>Device Health Report</h1>')
+    $null = $sb.AppendLine("    <h2 class='report-subtitle'>Generated $generatedAtHtml</h2>")
+    $null = $sb.AppendLine('  </div>')
+    $null = $sb.AppendLine("  <div class='report-card report-card--overview'>")
+    $null = $sb.AppendLine("    <div class='score-section'>")
+    $null = $sb.AppendLine("      <div class='score-section__primary'>")
+    & $appendIndented $sb $overallRingHtml '        '
+    $null = $sb.AppendLine("        <div class='report-badge-group'>")
     foreach ($badge in @(
             @{ Key = 'critical'; Label = 'CRITICAL'; Class = 'critical' },
             @{ Key = 'high';     Label = 'HIGH';     Class = 'bad' },
@@ -644,40 +648,114 @@ function Build-SummaryCardHtml {
         )) {
         $count = if ($counts.ContainsKey($badge.Key)) { $counts[$badge.Key] } else { 0 }
         $labelHtml = Encode-Html $badge.Label
-        $null = $sb.AppendLine("        <span class='report-badge report-badge--$($badge.Class)'><span class='report-badge__label'>$labelHtml</span><span class='report-badge__value'>$count</span></span>")
+        $null = $sb.AppendLine("          <span class='report-badge report-badge--$($badge.Class)'><span class='report-badge__label'>$labelHtml</span><span class='report-badge__value'>$count</span></span>")
     }
+    $null = $sb.AppendLine('        </div>')
     $null = $sb.AppendLine('      </div>')
     $null = $sb.AppendLine('    </div>')
+    $null = $sb.AppendLine("    <table class='report-table report-table--overview' cellspacing='0' cellpadding='0'>")
+    $null = $sb.AppendLine('      <colgroup>')
+    $null = $sb.AppendLine("        <col class='report-table__col--overview-primary'>")
+    $null = $sb.AppendLine("        <col class='report-table__col--overview-secondary'>")
+    $null = $sb.AppendLine('      </colgroup>')
+    $null = $sb.AppendLine('      <tbody>')
+    $null = $sb.AppendLine('        <tr>')
+    $null = $sb.AppendLine("          <td>")
+    $null = $sb.AppendLine("            <h3 class='report-overview__group-title'>Device</h3>")
+    $null = $sb.AppendLine("            <table class='report-table report-table--key-value' cellspacing='0' cellpadding='0'>")
+    $null = $sb.AppendLine("              <tr><td>Device Name</td><td>$(Encode-Html $deviceName)</td></tr>")
+    $null = $sb.AppendLine("              <tr><td>Device State</td><td>$(Encode-Html $deviceState)</td></tr>")
+    $null = $sb.AppendLine("              <tr><td>System</td><td>$(Encode-Html $osText)</td></tr>")
+    $null = $sb.AppendLine('            </table>')
+    $null = $sb.AppendLine('          </td>')
+    $null = $sb.AppendLine('          <td>')
+    $null = $sb.AppendLine("            <h3 class='report-overview__group-title'>Network</h3>")
+    $null = $sb.AppendLine("            <table class='report-table report-table--key-value' cellspacing='0' cellpadding='0'>")
+    $null = $sb.AppendLine("              <tr><td>IPv4</td><td>$(Encode-Html $ipv4Text)</td></tr>")
+    $null = $sb.AppendLine("              <tr><td>Gateway</td><td>$(Encode-Html $gatewayText)</td></tr>")
+    $null = $sb.AppendLine("              <tr><td>DNS</td><td>$(Encode-Html $dnsText)</td></tr>")
+    $null = $sb.AppendLine('            </table>')
+    $null = $sb.AppendLine('          </td>')
+    $null = $sb.AppendLine('        </tr>')
+    $null = $sb.AppendLine('      </tbody>')
+    $null = $sb.AppendLine('    </table>')
     $null = $sb.AppendLine('  </div>')
-    $null = $sb.AppendLine("  <table class='report-table report-table--overview' cellspacing='0' cellpadding='0'>")
-    $null = $sb.AppendLine('    <colgroup>')
-    $null = $sb.AppendLine("      <col class='report-table__col--overview-primary'>")
-    $null = $sb.AppendLine("      <col class='report-table__col--overview-secondary'>")
-    $null = $sb.AppendLine('    </colgroup>')
-    $null = $sb.AppendLine('    <tbody>')
-    $null = $sb.AppendLine('      <tr>')
-    $null = $sb.AppendLine("        <td>")
-    $null = $sb.AppendLine("          <h3 class='report-overview__group-title'>Device</h3>")
-    $null = $sb.AppendLine("          <table class='report-table report-table--key-value' cellspacing='0' cellpadding='0'>")
-    $null = $sb.AppendLine("            <tr><td>Device Name</td><td>$(Encode-Html $deviceName)</td></tr>")
-    $null = $sb.AppendLine("            <tr><td>Device State</td><td>$(Encode-Html $deviceState)</td></tr>")
-    $null = $sb.AppendLine("            <tr><td>System</td><td>$(Encode-Html $osText)</td></tr>")
-    $null = $sb.AppendLine('          </table>')
-    $null = $sb.AppendLine('        </td>')
-    $null = $sb.AppendLine('        <td>')
-    $null = $sb.AppendLine("          <h3 class='report-overview__group-title'>Network</h3>")
-    $null = $sb.AppendLine("          <table class='report-table report-table--key-value' cellspacing='0' cellpadding='0'>")
-    $null = $sb.AppendLine("            <tr><td>IPv4</td><td>$(Encode-Html $ipv4Text)</td></tr>")
-    $null = $sb.AppendLine("            <tr><td>Gateway</td><td>$(Encode-Html $gatewayText)</td></tr>")
-    $null = $sb.AppendLine("            <tr><td>DNS</td><td>$(Encode-Html $dnsText)</td></tr>")
-    $null = $sb.AppendLine('          </table>')
-    $null = $sb.AppendLine('        </td>')
-    $null = $sb.AppendLine('      </tr>')
-    $null = $sb.AppendLine('    </tbody>')
-    $null = $sb.AppendLine('  </table>')
-    $null = $sb.AppendLine('</div>')
+    $null = $sb.AppendLine('</section>')
 
     return $sb.ToString()
+}
+
+function Build-ReportNavigation {
+    param(
+        [System.Collections.IEnumerable]$Sections
+    )
+
+    if (-not $Sections) { return '' }
+
+    $items = New-Object System.Collections.Generic.List[string]
+    foreach ($section in $Sections) {
+        if (-not $section) { continue }
+
+        $id = $null
+        $label = $null
+        $count = $null
+        $description = $null
+
+        if ($section -is [System.Collections.IDictionary]) {
+            if ($section.Contains('Id')) { $id = [string]$section['Id'] }
+            if ($section.Contains('Label')) { $label = [string]$section['Label'] }
+            if ($section.Contains('Count')) { $count = $section['Count'] }
+            if ($section.Contains('Description')) { $description = [string]$section['Description'] }
+        } else {
+            if ($section.PSObject.Properties['Id']) { $id = [string]$section.Id }
+            if ($section.PSObject.Properties['Label']) { $label = [string]$section.Label }
+            if ($section.PSObject.Properties['Count']) { $count = $section.Count }
+            if ($section.PSObject.Properties['Description']) { $description = [string]$section.Description }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($id)) { continue }
+
+        $safeId = [regex]::Replace($id.ToLowerInvariant(), '[^a-z0-9\-_]+', '-')
+        $safeId = [regex]::Replace($safeId, '^-+|-+$', '')
+        if (-not $safeId) { $safeId = [regex]::Replace($id, '\\s+', '-') }
+        if (-not $safeId) { continue }
+
+        $labelText = if ($label) { $label } else { $id }
+        $labelHtml = Encode-Html $labelText
+        $hrefHtml = Encode-Html ("#$safeId")
+
+        $countFragment = ''
+        if ($null -ne $count -and $count -ne '') {
+            $countValue = Encode-Html ([string]$count)
+            $countFragment = "<span class='report-nav__count'>$countValue</span>"
+        }
+
+        $descriptionFragment = ''
+        if (-not [string]::IsNullOrWhiteSpace($description)) {
+            $descriptionFragment = "<span class='report-nav__description'>$(Encode-Html $description)</span>"
+        }
+
+        $linkBuilder = [System.Text.StringBuilder]::new()
+        $null = $linkBuilder.Append("<li class='report-nav__item'>")
+        $null = $linkBuilder.Append("<a class='report-nav__link' href='$hrefHtml'>")
+        $null = $linkBuilder.Append("<span class='report-nav__label'>$labelHtml</span>")
+        if ($countFragment) { $null = $linkBuilder.Append($countFragment) }
+        if ($descriptionFragment) { $null = $linkBuilder.Append($descriptionFragment) }
+        $null = $linkBuilder.Append('</a></li>')
+
+        $items.Add($linkBuilder.ToString()) | Out-Null
+    }
+
+    if ($items.Count -eq 0) { return '' }
+
+    $builder = [System.Text.StringBuilder]::new()
+    $null = $builder.Append("<nav class='report-nav' aria-label='Report sections'><ul class='report-nav__list'>")
+    foreach ($item in $items) {
+        $null = $builder.Append($item)
+    }
+    $null = $builder.Append('</ul></nav>')
+
+    return $builder.ToString()
 }
 
 function Build-GoodSection {
@@ -1141,10 +1219,15 @@ function New-AnalyzerHtml {
         Write-HtmlDebug -Stage 'Composer' -Message 'No summary provided; synthesized default summary.'
     }
 
-    $head = '<!doctype html><html><head><meta charset="utf-8"><title>Device Health Report</title><link rel="stylesheet" href="styles/device-health-report.css"></head><body class="page report-page">'
     $summaryHtml = Build-SummaryCardHtml -Summary $Summary -Issues $issues -Normals $normals
-    $goodHtml = New-ReportSection -Title "What Looks Good ($($normals.Count))" -ContentHtml (Build-GoodSection -Normals $normals) -Open
-    $issuesHtml = New-ReportSection -Title "Detected Issues ($($issues.Count))" -ContentHtml (Build-IssueSection -Issues $issues) -Open
+    $goodSectionId = 'section-good'
+    $issuesSectionId = 'section-issues'
+    $failedSectionId = 'section-failed'
+    $rawSectionId = 'section-raw'
+
+    $head = '<!doctype html><html><head><meta charset="utf-8"><title>Device Health Report</title><link rel="stylesheet" href="styles/device-health-report.css"></head><body class="page report-page"><main class="report-main">'
+    $goodHtml = New-ReportSection -Id $goodSectionId -Title "What Looks Good ($($normals.Count))" -ContentHtml (Build-GoodSection -Normals $normals) -Open
+    $issuesHtml = New-ReportSection -Id $issuesSectionId -Title "Detected Issues ($($issues.Count))" -ContentHtml (Build-IssueSection -Issues $issues) -Open
     $failedReports = Get-FailedCollectorReports -Context $Context
     $failedTitle = "Failed Reports ({0})" -f $failedReports.Count
     Write-HtmlDebug -Stage 'Composer' -Message 'Failed collector section prepared.' -Data @{ Count = $failedReports.Count }
@@ -1168,13 +1251,22 @@ function New-AnalyzerHtml {
         $null = $failedContentBuilder.Append("</table></div>")
         $failedContent = $failedContentBuilder.ToString()
     }
-    $failedHtml = New-ReportSection -Title $failedTitle -ContentHtml $failedContent -Open
-    $rawHtml = New-ReportSection -Title 'Raw (key excerpts)' -ContentHtml (Build-RawSection -Context $Context)
+    $failedHtml = New-ReportSection -Id $failedSectionId -Title $failedTitle -ContentHtml $failedContent -Open
+    $rawHtml = New-ReportSection -Id $rawSectionId -Title 'Raw (key excerpts)' -ContentHtml (Build-RawSection -Context $Context)
+    $rawCount = if ($Context -and $Context.Artifacts) { ($Context.Artifacts.Keys | Measure-Object).Count } else { 0 }
+    $navSections = @(
+        @{ Id = 'section-overview'; Label = 'Overview'; Description = 'Score & device summary' },
+        @{ Id = $goodSectionId; Label = 'What Looks Good'; Count = $normals.Count },
+        @{ Id = $issuesSectionId; Label = 'Detected Issues'; Count = $issues.Count },
+        @{ Id = $failedSectionId; Label = 'Failed Reports'; Count = $failedReports.Count },
+        @{ Id = $rawSectionId; Label = 'Raw excerpts'; Count = $rawCount }
+    )
+    $navHtml = Build-ReportNavigation -Sections $navSections
     $debugHtml = "<details><summary>Debug</summary>$(Build-DebugSection -Context $Context)</details>"
-    $tail = '</body></html>'
+    $tail = '</main></body></html>'
 
     $htmlBuilder = [System.Text.StringBuilder]::new()
-    foreach ($segment in @($head, $summaryHtml, $goodHtml, $issuesHtml, $failedHtml, $rawHtml, $debugHtml, $tail)) {
+    foreach ($segment in @($head, $summaryHtml, $navHtml, $goodHtml, $issuesHtml, $failedHtml, $rawHtml, $debugHtml, $tail)) {
         if ($segment) { $null = $htmlBuilder.Append($segment) }
     }
 

--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -658,14 +658,32 @@ function New-ReportSection {
   param(
     [string]$Title,
     [string]$ContentHtml,
-    [switch]$Open
+    [switch]$Open,
+    [string]$Id
   )
 
   $openAttr = if ($Open.IsPresent) { ' open' } else { '' }
   $titleValue = if ($null -ne $Title) { $Title } else { '' }
   $titleHtml = Encode-Html $titleValue
   $bodyHtml = if ($null -ne $ContentHtml) { $ContentHtml } else { '' }
-  return "<details class='report-section'$openAttr><summary>$titleHtml</summary><div class='report-section__content'>$bodyHtml</div></details>"
+
+  $idAttr = ''
+  if ($PSBoundParameters.ContainsKey('Id') -and -not [string]::IsNullOrWhiteSpace($Id)) {
+    $trimmedId = $Id.Trim()
+    if ($trimmedId) {
+      $safeId = [regex]::Replace($trimmedId.ToLowerInvariant(), '[^a-z0-9\-_]+', '-')
+      $safeId = [regex]::Replace($safeId, '^-+|-+$', '')
+      if (-not $safeId) {
+        $safeId = [regex]::Replace($trimmedId, '\\s+', '-')
+      }
+
+      if ($safeId) {
+        $idAttr = " id='$safeId'"
+      }
+    }
+  }
+
+  return "<details$idAttr class='report-section'$openAttr><summary>$titleHtml</summary><div class='report-section__content'>$bodyHtml</div></details>"
 }
 
 function New-IssueCardHtml {

--- a/styles/device-health-report.css
+++ b/styles/device-health-report.css
@@ -26,12 +26,132 @@
   color: var(--color-heading);
 }
 
+.report-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.report-summary,
+.report-section {
+  scroll-margin-top: 96px;
+}
+
+.report-summary {
+  padding: var(--space-xl) var(--space-lg);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border-subtle);
+  background-color: var(--color-surface);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.report-summary__heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xxs);
+}
+
+.report-summary .report-card {
+  margin-bottom: 0;
+  box-shadow: none;
+  border-left-color: var(--color-heading);
+}
+
+.report-nav {
+  position: sticky;
+  top: var(--space-sm);
+  z-index: 20;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border-subtle);
+  background-color: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(6px);
+}
+
+.report-nav__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.report-nav__item {
+  flex: 1 1 160px;
+  min-width: 140px;
+  max-width: 220px;
+}
+
+.report-nav__link {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-card);
+  border: 1px solid transparent;
+  background-color: rgba(255, 255, 255, 0.8);
+  color: var(--color-heading);
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.report-nav__link:hover {
+  background-color: var(--color-surface);
+  border-color: var(--color-border-subtle);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  transform: translateY(-1px);
+}
+
+.report-nav__link:focus-visible {
+  outline: 2px solid var(--color-heading);
+  outline-offset: 2px;
+}
+
+.report-nav__label {
+  font-size: 0.95rem;
+}
+
+.report-nav__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  padding: 0 var(--space-xs);
+  border-radius: var(--radius-pill);
+  background-color: rgba(11, 99, 166, 0.12);
+  color: var(--color-heading);
+  font-size: 0.8rem;
+}
+
+.report-nav__description {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--color-text-note);
+}
+
 .report-card {
   margin-bottom: var(--space-md);
   padding: var(--space-md);
   border-radius: var(--radius-card);
   border: 1px solid var(--color-border-subtle);
   background-color: var(--color-surface);
+  border-left-width: 4px;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.report-card:hover,
+.report-card:focus-within {
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  transform: translateY(-1px);
 }
 
 .report-card--static {
@@ -532,38 +652,45 @@ details.report-card[open] > summary {
 
 .report-card--good {
   border-color: var(--color-state-good-border);
+  border-left-color: var(--color-state-good-border);
   background-color: var(--color-state-good-bg);
 }
 
 .report-card--info {
   border-color: var(--color-state-info-border);
+  border-left-color: var(--color-state-info-border);
   background-color: var(--color-state-info-bg);
   color: var(--color-state-info-text);
 }
 
 .report-card--low {
   border-color: var(--color-state-ok-border);
+  border-left-color: var(--color-state-ok-border);
   background-color: var(--color-state-ok-bg);
 }
 
 .report-card--medium {
   border-color: var(--color-state-medium-border);
+  border-left-color: var(--color-state-medium-border);
   background-color: var(--color-state-medium-bg);
 }
 
 .report-card--warning {
   border-color: var(--color-state-warning-border);
+  border-left-color: var(--color-state-warning-border);
   background-color: var(--color-state-warning-bg);
 }
 
 .report-card--high,
 .report-card--bad {
   border-color: var(--color-state-bad-border);
+  border-left-color: var(--color-state-bad-border);
   background-color: var(--color-state-bad-bg);
 }
 
 .report-card--critical {
   border-color: var(--color-state-critical-border);
+  border-left-color: var(--color-state-critical-border);
   background-color: var(--color-state-critical-bg);
   color: var(--color-state-critical-text);
 }
@@ -628,6 +755,33 @@ details.report-card[open] > summary {
 
   .report-table--overview td + td {
     margin-top: var(--space-md);
+  }
+}
+
+@media (max-width: 720px) {
+  .report-summary {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .report-nav {
+    position: static;
+    box-shadow: none;
+    backdrop-filter: none;
+  }
+
+  .report-nav__item {
+    flex: 1 1 100%;
+    max-width: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .report-card,
+  .report-nav__link,
+  .report-nav__link:hover,
+  .report-nav__link:focus-visible {
+    transition: none;
+    transform: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap the report overview in a dedicated section and generate a quick navigation panel from analyzer output
- add optional identifiers to report sections so navigation anchors remain stable and accessible
- refresh report card styling with accent borders, hover states, and responsive tweaks to improve readability

## Testing
- Not run (PowerShell is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68de8760d384832d9681b7a4fd3c8c73