### PR TITLE
Remove PASS prefix from firewall normal title

### DIFF
--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -516,7 +516,7 @@ function Invoke-NetworkFirewallProfileAnalysis {
         $evidence['DisabledProfiles'] = $disabledProfiles.ToArray()
         Add-CategoryIssue -CategoryResult $CategoryResult -Severity 'critical' -Title 'Windows Firewall is disabled for one or more profiles — the endpoint is unprotected from network attacks.' -Evidence $evidence -Subcategory $subcategory -CheckId $disabledCheckId
     } else {
-        Add-CategoryNormal -CategoryResult $CategoryResult -Title 'PASS: All firewall profiles enabled (Domain, Private, Public).' -Evidence $evidence -Subcategory $subcategory -CheckId $enabledCheckId
+        Add-CategoryNormal -CategoryResult $CategoryResult -Title 'All firewall profiles enabled (Domain, Private, Public).' -Evidence $evidence -Subcategory $subcategory -CheckId $enabledCheckId
     }
 }
 


### PR DESCRIPTION
## Summary
- update the Windows Firewall normal card title to omit the "PASS:" prefix for consistency with other cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1f35a7088832db52b0118f1ee711b