### PR TITLE
Skip System Reserved volumes from free-space heuristic

### DIFF
--- a/Analyzers/Heuristics/Storage/Storage.Volumes.ps1
+++ b/Analyzers/Heuristics/Storage/Storage.Volumes.ps1
@@ -118,11 +118,17 @@ function Invoke-StorageVolumeEvaluation {
             $label = if ($hasDriveLetter) { $volume.DriveLetter } elseif ($rawLabel) { $rawLabel } else { 'Unknown' }
 
             $shouldSkip = $false
-            if (-not $hasDriveLetter) {
+            $skipReason = $null
+            if ($rawLabel -match '^(?i)system reserved$') {
+                $shouldSkip = $true
+                $skipReason = 'System Reserved volume'
+            } elseif (-not $hasDriveLetter) {
                 if ($rawLabel -match '(?i)recovery|reserved|diagnostic|tools|restore') {
                     $shouldSkip = $true
+                    $skipReason = 'Hidden maintenance volume'
                 } elseif ($sizeGb -lt 1) {
                     $shouldSkip = $true
+                    $skipReason = 'Volume smaller than 1 GB'
                 }
             }
 
@@ -131,6 +137,7 @@ function Invoke-StorageVolumeEvaluation {
                     Label = if ($rawLabel) { $rawLabel } else { $label }
                     SizeGb = $sizeGb
                     HasDriveLetter = $hasDriveLetter
+                    Reason = if ($skipReason) { $skipReason } else { 'Not specified' }
                 })
                 continue
             }


### PR DESCRIPTION
## Summary
- skip volumes labeled "System Reserved" when evaluating free-space to avoid false alarms
- log the reason when hidden volumes are skipped for easier troubleshooting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e20cb19f5c832d872ca6c6bf82e495