### PR TITLE
Handle nested driver inventory payload values

### DIFF
--- a/Analyzers/Heuristics/Hardware/Common.ps1
+++ b/Analyzers/Heuristics/Hardware/Common.ps1
@@ -5,12 +5,15 @@ function ConvertTo-HardwareDriverText {
 
     if ($null -eq $Value) { return $null }
 
-    if ($Value -is [pscustomobject]) {
-        if ($Value.PSObject.Properties['Error'] -and $Value.Error) {
+    if ($Value -is [pscustomobject] -or $Value -is [System.Collections.IDictionary]) {
+        $asObject = [pscustomobject]$Value
+
+        if ($asObject.PSObject.Properties['Error'] -and $asObject.Error) {
             return $null
         }
-        if ($Value.PSObject.Properties['Value'] -and $Value.Value) {
-            return [string]$Value.Value
+
+        if ($asObject.PSObject.Properties['Value']) {
+            return ConvertTo-HardwareDriverText -Value $asObject.Value
         }
     }
 
@@ -18,10 +21,12 @@ function ConvertTo-HardwareDriverText {
         $builder = [System.Text.StringBuilder]::new()
         foreach ($item in $Value) {
             if ($null -eq $item) { continue }
-            $text = [string]$item
+            $text = ConvertTo-HardwareDriverText -Value $item
+            if ([string]::IsNullOrWhiteSpace($text)) { continue }
             if ($builder.Length -gt 0) { $null = $builder.AppendLine() }
             $null = $builder.Append($text)
         }
+        if ($builder.Length -eq 0) { return $null }
         return $builder.ToString()
     }
 


### PR DESCRIPTION
## Summary
- update ConvertTo-HardwareDriverText to recursively unwrap nested Value properties
- ensure enumerable payload items are flattened into text instead of rendering as System.Object[]

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e20c47faa0832da4afcd066f2fe0da