### PR TITLE
Clarify hardware free-space issue labeling

### DIFF
--- a/Analyzers/Heuristics/Storage/Storage.Volumes.ps1
+++ b/Analyzers/Heuristics/Storage/Storage.Volumes.ps1
@@ -124,6 +124,28 @@ function Invoke-StorageVolumeEvaluation {
             $rawLabel = if ($volume.FileSystemLabel) { [string]$volume.FileSystemLabel } else { '' }
             $label = if ($hasDriveLetter) { $volume.DriveLetter } elseif ($rawLabel) { $rawLabel } else { 'Unknown' }
 
+            $driveLetterDisplay = $null
+            if ($hasDriveLetter) {
+                $driveLetterDisplay = ([string]$volume.DriveLetter).Trim()
+                if ($driveLetterDisplay.EndsWith(':')) {
+                    $driveLetterDisplay = $driveLetterDisplay.TrimEnd(':')
+                }
+            }
+
+            $volumeLabel = if (-not [string]::IsNullOrWhiteSpace($rawLabel)) { $rawLabel.Trim() } else { $null }
+
+            $volumeDisplay = if ($driveLetterDisplay) {
+                if ($volumeLabel -and ($volumeLabel -ine $driveLetterDisplay)) {
+                    "{0} (`"{1}`")" -f $driveLetterDisplay, $volumeLabel
+                } else {
+                    $driveLetterDisplay
+                }
+            } elseif ($volumeLabel) {
+                $volumeLabel
+            } else {
+                $label
+            }
+
             $shouldSkip = $false
             $skipReason = $null
             if ($rawLabel -match '^(?i)system reserved$') {
@@ -152,22 +174,22 @@ function Invoke-StorageVolumeEvaluation {
             $threshold = Get-VolumeThreshold -Volume $volume -SizeGB $sizeGb -Config $ThresholdConfig
 
             $details = "Free {0} GB of {1} GB ({2}% free); profile {3}" -f $freeGb, $sizeGb, ([math]::Round($freePct,1)), $threshold.Description
-            Add-CategoryCheck -CategoryResult $CategoryResult -Name ("Volume {0}" -f $label) -Status ([string][math]::Round($freePct,1)) -Details $details
+            Add-CategoryCheck -CategoryResult $CategoryResult -Name ("Volume {0}" -f $volumeDisplay) -Status ([string][math]::Round($freePct,1)) -Details $details
 
             $critPercent = $threshold.CritPercent * 100
             $warnPercent = $threshold.WarnPercent * 100
             $criticalPercent = $threshold.CriticalPercent * 100
             if ($freeGb -le $threshold.CriticalFloorGB -or $freePct -le $criticalPercent) {
                 $evidence = "Free {0} GB ({1}%); critical floor {2} GB or {3}%" -f $freeGb, [math]::Round($freePct,1), $threshold.CriticalFloorGB, [math]::Round($criticalPercent,1)
-                Add-CategoryIssue -CategoryResult $CategoryResult -Severity 'critical' -Title ("Volume {0} nearly out of space ({1} GB remaining), causing imminent system or storage failures." -f $label, $freeGb) -Evidence $evidence -Subcategory 'Free Space'
+                Add-CategoryIssue -CategoryResult $CategoryResult -Severity 'critical' -Title ("Volume {0} nearly out of space ({1} GB remaining), causing imminent system or storage failures." -f $volumeDisplay, $freeGb) -Evidence $evidence -Subcategory 'Free Space'
             } elseif ($freeGb -le $threshold.CritFloorGB -or $freePct -le $critPercent) {
                 $evidence = "Free {0} GB ({1}%); high-risk floor {2} GB or {3}%" -f $freeGb, [math]::Round($freePct,1), $threshold.CritFloorGB, [math]::Round($critPercent,1)
-                Add-CategoryIssue -CategoryResult $CategoryResult -Severity 'high' -Title ("Volume {0} critically low on space ({1} GB remaining), risking system or storage failures." -f $label, $freeGb) -Evidence $evidence -Subcategory 'Free Space'
+                Add-CategoryIssue -CategoryResult $CategoryResult -Severity 'high' -Title ("Volume {0} critically low on space ({1} GB remaining), risking system or storage failures." -f $volumeDisplay, $freeGb) -Evidence $evidence -Subcategory 'Free Space'
             } elseif ($freeGb -le $threshold.WarnFloorGB -or $freePct -le $warnPercent) {
                 $evidence = "Free {0} GB ({1}%); warning floor {2} GB or {3}%" -f $freeGb, [math]::Round($freePct,1), $threshold.WarnFloorGB, [math]::Round($warnPercent,1)
-                Add-CategoryIssue -CategoryResult $CategoryResult -Severity 'medium' -Title ("Volume {0} approaching capacity, risking system or storage failures." -f $label) -Evidence $evidence -Subcategory 'Free Space'
+                Add-CategoryIssue -CategoryResult $CategoryResult -Severity 'medium' -Title ("Volume {0} approaching capacity, risking system or storage failures." -f $volumeDisplay) -Evidence $evidence -Subcategory 'Free Space'
             } else {
-                Add-CategoryNormal -CategoryResult $CategoryResult -Title ("Volume {0} has {1}% free" -f $label, [math]::Round($freePct,1)) -Subcategory 'Free Space'
+                Add-CategoryNormal -CategoryResult $CategoryResult -Title ("Volume {0} has {1}% free" -f $volumeDisplay, [math]::Round($freePct,1)) -Subcategory 'Free Space'
             }
         }
     } elseif ($Payload -and $Payload.PSObject.Properties['Volumes']) {


### PR DESCRIPTION
## Summary
- include filesystem labels alongside drive letters in storage free-space issue and status messages so technicians can quickly identify the affected volume

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2100833d4832db212ab09e44fe720