### PR TITLE
Adjust event log gap severity to warning

### DIFF
--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -60,7 +60,7 @@ function Invoke-EventsHeuristics {
                     }
                 } elseif ($entries.Error) {
                     $logSubcategory = ("{0} Event Log" -f $logName)
-                    Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Unable to read {0} event log, so noisy or unhealthy logs may be hidden." -f $logName) -Evidence $entries.Error -Subcategory $logSubcategory
+                    Add-CategoryIssue -CategoryResult $result -Severity 'warning' -Title ("Unable to read {0} event log, so noisy or unhealthy logs may be hidden." -f $logName) -Evidence $entries.Error -Subcategory $logSubcategory
                 }
             }
 
@@ -86,7 +86,7 @@ function Invoke-EventsHeuristics {
             }
         }
     } else {
-        Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title 'Event log artifact missing, so noisy or unhealthy logs may be hidden.' -Subcategory 'Collection'
+        Add-CategoryIssue -CategoryResult $result -Severity 'warning' -Title 'Event log artifact missing, so noisy or unhealthy logs may be hidden.' -Subcategory 'Collection'
     }
 
     Invoke-EventsVpnAuthenticationChecks -Result $result -Context $Context

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The sections below summarize every analyzer category and the heuristics it curre
 - **Office Click-to-Run** – Flags high/medium issues when ClickToRunSvc is misconfigured and records normals when it is running as expected.
 
 ### Events
-- **Collection** – Emits informational issues when sampled event logs could not be gathered.
+- **Collection** – Emits warning-level issues when sampled event logs cannot be read or artifacts are missing so technicians know gaps may hide noisy logs.
 - **Networking / DNS** – Flags repeated DNS resolution timeouts in the event logs.
 - **Netlogon/LSA (Domain Join)** – Raises issues for secure channel or domain reachability errors observed in the Netlogon logs.
 - **Authentication** – Highlights repeated Kerberos pre-authentication failures and account lockouts while recording normals when skew and failure counts stay within tolerance.


### PR DESCRIPTION
## Summary
- downgrade event log read failure findings to warning severity so gaps show as yellow cards
- document that events collection gaps now emit warnings instead of high-severity issues

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e210481240832d95f4efc98ca4f814