### PR TITLE
Stop duplicate Print Spooler printing issue

### DIFF
--- a/Analyzers/Heuristics/Printing/Spooler.ps1
+++ b/Analyzers/Heuristics/Printing/Spooler.ps1
@@ -20,9 +20,7 @@ function Invoke-PrintingSpoolerChecks {
     Add-CategoryCheck -CategoryResult $Result -Name 'Spooler status' -Status $status -Details ("StartMode: {0}" -f $startMode)
 
     if ($statusNorm -eq 'running') {
-        if ($IsWorkstation) {
-            Add-CategoryIssue -CategoryResult $Result -Severity 'medium' -Title 'Print Spooler running — disable if this workstation does not need printing (PrintNightmare).' -Evidence ("Status: {0}; StartMode: {1}" -f $status, $startMode) -Subcategory 'Spooler Service'
-        } else {
+        if (-not $IsWorkstation) {
             Add-CategoryNormal -CategoryResult $Result -Title 'Print Spooler running' -Evidence ("Status: {0}; StartMode: {1}" -f $status, $startMode) -Subcategory 'Spooler Service'
         }
         return


### PR DESCRIPTION
## Summary
- prevent the printing heuristic from emitting the Print Spooler medium issue that duplicates the services card
- keep the normal result for non-workstation hosts when the spooler is running

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e210d21de0832da2960e5322054d23