### PR TITLE
Fix driver inventory text handling

### DIFF
--- a/Analyzers/Heuristics/Hardware/Common.ps1
+++ b/Analyzers/Heuristics/Hardware/Common.ps1
@@ -9,8 +9,11 @@ function ConvertTo-HardwareDriverText {
         if ($Value.PSObject.Properties['Error'] -and $Value.Error) {
             return $null
         }
-        if ($Value.PSObject.Properties['Value'] -and $Value.Value) {
-            return [string]$Value.Value
+        if ($Value.PSObject.Properties['Value']) {
+            $inner = $Value.Value
+            if ($null -eq $inner) { return $null }
+            if ([object]::ReferenceEquals($inner, $Value)) { return $null }
+            return ConvertTo-HardwareDriverText -Value $inner
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust driver inventory text conversion to unwrap nested payload objects instead of coercing them to `System.Object[]`
- guard against self-referential payloads while preserving existing enumerable handling

## Testing
- not run (PowerShell tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2117d5ce0832da78c7edc4dee6d17