### PR TITLE
Silence verbose module import noise

### DIFF
--- a/Analyzers/Analyze-Diagnostics.ps1
+++ b/Analyzers/Analyze-Diagnostics.ps1
@@ -20,7 +20,7 @@ Write-Verbose ("Starting analysis for input folder '{0}'." -f $InputFolder)
 
 $commonModulePath = Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'Modules/Common.psm1'
 if (Test-Path -Path $commonModulePath) {
-    Import-Module $commonModulePath -Force
+    Import-Module $commonModulePath -Force -Verbose:$false
     Write-Verbose ("Imported common module from '{0}'." -f $commonModulePath)
 }
 

--- a/Analyzers/Heuristics/Network/DHCP/Dhcp-AnalyzerHelper.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Dhcp-AnalyzerHelper.ps1
@@ -20,7 +20,7 @@ function Import-DhcpAnalyzerDependencies {
         while ($current) {
             $candidate = Join-Path -Path $current -ChildPath 'Modules/Common.psm1'
             if (Test-Path -Path $candidate) {
-                Import-Module -Name $candidate -Force
+                Import-Module -Name $candidate -Force -Verbose:$false
                 $commonModuleLoaded = Get-Module | Where-Object { $_.Path -eq (Resolve-Path -Path $candidate) }
                 break
             }

--- a/Collectors/Network/Collect-Wlan.ps1
+++ b/Collectors/Network/Collect-Wlan.ps1
@@ -18,7 +18,7 @@ $collectorRoot = Split-Path -Path $PSScriptRoot -Parent
 $repositoryRoot = Split-Path -Path $collectorRoot -Parent
 $passwordStrengthModule = Join-Path -Path $repositoryRoot -ChildPath 'Modules\\PasswordStrength\\PasswordStrength.psm1'
 if (Test-Path -LiteralPath $passwordStrengthModule) {
-    Import-Module -Name $passwordStrengthModule -ErrorAction Stop
+    Import-Module -Name $passwordStrengthModule -ErrorAction Stop -Verbose:$false
 }
 
 function Test-IsWindows {

--- a/Modules/PasswordStrength/PasswordStrength.psm1
+++ b/Modules/PasswordStrength/PasswordStrength.psm1
@@ -309,4 +309,4 @@ function Test-PasswordStrength {
     return [pscustomobject]$result
 }
 
-Export-ModuleMember -Function Test-PasswordStrength
+Export-ModuleMember -Function Test-PasswordStrength -Verbose:$false

--- a/backups/Legacy/Analyze-Diagnostics.ps1
+++ b/backups/Legacy/Analyze-Diagnostics.ps1
@@ -21,7 +21,7 @@ param(
 $ErrorActionPreference = 'SilentlyContinue'
 
 $commonModulePath = Join-Path (Split-Path $PSScriptRoot -Parent) 'Modules/Common.psm1'
-Import-Module $commonModulePath -Force
+Import-Module $commonModulePath -Force -Verbose:$false
 
 $Root = $InputFolder
 


### PR DESCRIPTION
## Summary
- suppress automatic verbose output from module imports used by analyzers and collectors
- prevent the password strength module from emitting verbose export messages when loaded

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e216f7383c832dae65dabe6a9f45a1