### PR TITLE
Wrap conditional hashtable values for PS5 compatibility

### DIFF
--- a/Analyzers/Heuristics/AD.ps1
+++ b/Analyzers/Heuristics/AD.ps1
@@ -22,7 +22,7 @@ function Invoke-ADHeuristics {
     )
 
     Write-HeuristicDebug -Source 'AD' -Message 'Starting Active Directory heuristics evaluation' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
     })
 
     $result = New-CategoryResult -Name 'Active Directory Health'

--- a/Analyzers/Heuristics/AD/DomainStatus.ps1
+++ b/Analyzers/Heuristics/AD/DomainStatus.ps1
@@ -19,7 +19,7 @@ function Resolve-AdDomainStatus {
                     DomainJoined = $systemPayload.ComputerSystem.PartOfDomain
                     Domain       = $systemPayload.ComputerSystem.Domain
                     Forest       = $null
-                    DomainRole   = if ($systemPayload.ComputerSystem.PSObject.Properties['DomainRole']) { $systemPayload.ComputerSystem.DomainRole } else { $null }
+                    DomainRole   = $( if ($systemPayload.ComputerSystem.PSObject.Properties['DomainRole']) { $systemPayload.ComputerSystem.DomainRole } else { $null } )
                 }
             }
         }

--- a/Analyzers/Heuristics/Events.ps1
+++ b/Analyzers/Heuristics/Events.ps1
@@ -56,7 +56,7 @@ function Invoke-EventsHeuristics {
     )
 
     Write-HeuristicDebug -Source 'Events' -Message 'Starting event log heuristics' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
     })
 
     $deviceName = Get-EventsCurrentDeviceName -Context $Context

--- a/Analyzers/Heuristics/Events/Netlogon.ps1
+++ b/Analyzers/Heuristics/Events/Netlogon.ps1
@@ -119,7 +119,7 @@ function Invoke-EventsNetlogonTrustChecks {
     $evidence = [ordered]@{
         eventIdSet = @($eventIdSet)
         count      = $recentMatches.Count
-        lastUtc    = if ($lastEvent -and $lastEvent.TimeUtc) { $lastEvent.TimeUtc.ToString('o') } else { $null }
+        lastUtc    = $( if ($lastEvent -and $lastEvent.TimeUtc) { $lastEvent.TimeUtc.ToString('o') } else { $null } )
     }
 
     $severity = 'medium'

--- a/Analyzers/Heuristics/Events/Vpn.ps1
+++ b/Analyzers/Heuristics/Events/Vpn.ps1
@@ -150,7 +150,7 @@ function Invoke-EventsVpnAuthenticationChecks {
         $entry = [ordered]@{
             provider   = $match.Provider
             eventId    = $match.EventId
-            lastUtc    = if ($match.TimeUtc) { $match.TimeUtc.ToString('o') } else { $null }
+            lastUtc    = $( if ($match.TimeUtc) { $match.TimeUtc.ToString('o') } else { $null } )
             msgSnippet = $match.MsgSnippet
         }
         if ($match.VpnName) { $entry['vpnName'] = $match.VpnName }

--- a/Analyzers/Heuristics/Hardware/InvokeHardware.ps1
+++ b/Analyzers/Heuristics/Hardware/InvokeHardware.ps1
@@ -5,7 +5,7 @@ function Invoke-HardwareHeuristics {
     )
 
     Write-HeuristicDebug -Source 'Hardware' -Message 'Starting hardware heuristics' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
     })
 
     $result = New-CategoryResult -Name 'Hardware'
@@ -48,13 +48,13 @@ function Invoke-HardwareHeuristics {
 
     Write-HeuristicDebug -Source 'Hardware' -Message 'Resolved driver inventory' -Data ([ordered]@{
         RowCount = $entries.Count
-        Source   = if ($inventory) { $inventory.Source } else { $null }
+        Source   = $( if ($inventory) { $inventory.Source } else { $null } )
     })
 
     if ($entries.Count -eq 0) {
         Write-HeuristicDebug -Source 'Hardware' -Message 'Driver inventory parsing diagnostics' -Data ([ordered]@{
-            AvailableProperties = if ($inventory -and $inventory.AvailableProperties -and $inventory.AvailableProperties.Count -gt 0) { $inventory.AvailableProperties -join ', ' } else { $null }
-            TextPreview         = if ($inventory -and $inventory.TextPreview) { $inventory.TextPreview } else { $null }
+            AvailableProperties = $( if ($inventory -and $inventory.AvailableProperties -and $inventory.AvailableProperties.Count -gt 0) { $inventory.AvailableProperties -join ', ' } else { $null } )
+            TextPreview         = $( if ($inventory -and $inventory.TextPreview) { $inventory.TextPreview } else { $null } )
         })
         $hasRawDriverData = $inventory -and ($inventory.HasDriverQueryData -or $inventory.HasTextPayload)
         $title = if ($hasRawDriverData) {
@@ -69,7 +69,7 @@ function Invoke-HardwareHeuristics {
     $failureEventMap = Get-DriverFailureEventMap -Context $Context
     Write-HeuristicDebug -Source 'Hardware' -Message 'Loaded driver failure event map' -Data ([ordered]@{
         HasEvents = ($failureEventMap -and ($failureEventMap.Count -gt 0))
-        Keys      = if ($failureEventMap) { $failureEventMap.Count } else { 0 }
+        Keys      = $( if ($failureEventMap) { $failureEventMap.Count } else { 0 } )
     })
 
     $bluetoothDrivers = New-Object System.Collections.Generic.List[pscustomobject]
@@ -188,7 +188,7 @@ function Invoke-HardwareHeuristics {
     $pnpText = ConvertTo-HardwareDriverText -Value $payload.PnpProblems
     Write-HeuristicDebug -Source 'Hardware' -Message 'Problem device text resolved' -Data ([ordered]@{
         HasText = [bool]$pnpText
-        Length  = if ($pnpText) { $pnpText.Length } else { 0 }
+        Length  = $( if ($pnpText) { $pnpText.Length } else { 0 } )
     })
 
     if ($pnpText) {

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpClientEvents.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpClientEvents.ps1
@@ -58,9 +58,9 @@ foreach ($group in $grouped) {
     $evidence = [ordered]@{
         EventId       = [int]$group.Name
         Count         = $group.Count
-        LatestTime    = if ($latest.TimeCreated) { (ConvertFrom-Iso8601 $latest.TimeCreated).ToString('o') } else { $latest.TimeCreated }
-        FirstSeenTime = if ($first.TimeCreated) { (ConvertFrom-Iso8601 $first.TimeCreated).ToString('o') } else { $first.TimeCreated }
-        SampleMessage = if ($latest.Message) { Get-TopLines -Text $latest.Message -Count 20 } else { $null }
+        LatestTime    = $( if ($latest.TimeCreated) { (ConvertFrom-Iso8601 $latest.TimeCreated).ToString('o') } else { $latest.TimeCreated } )
+        FirstSeenTime = $( if ($first.TimeCreated) { (ConvertFrom-Iso8601 $first.TimeCreated).ToString('o') } else { $first.TimeCreated } )
+        SampleMessage = $( if ($latest.Message) { Get-TopLines -Text $latest.Message -Count 20 } else { $null } )
     }
 
     $description = if ($descriptionMap.ContainsKey($idText)) { $descriptionMap[$idText] } else { "DHCP client issue ($idText)" }

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpLeaseExpiry.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpLeaseExpiry.ps1
@@ -46,7 +46,7 @@ foreach ($adapter in (Ensure-Array $payload.AdapterConfigurations)) {
     }
     $evidence = [ordered]@{
         Adapter        = Get-AdapterIdentity $adapter
-        LeaseObtained  = if ($obtained) { $obtained.ToString('o') } else { $adapter.DHCPLeaseObtained }
+        LeaseObtained  = $( if ($obtained) { $obtained.ToString('o') } else { $adapter.DHCPLeaseObtained } )
         LeaseExpires   = $expires.ToString('o')
         CheckedAt      = $now.ToString('o')
     }

--- a/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpScopeExhaustion.ps1
+++ b/Analyzers/Heuristics/Network/DHCP/Analyze-DhcpScopeExhaustion.ps1
@@ -33,9 +33,9 @@ if ($exhaustionEvents) {
     $oldest = $sorted | Select-Object -Last 1
     $eventEvidence = [ordered]@{
         Count         = $exhaustionEvents.Count
-        LatestTime    = if ($latest.TimeCreated) { (ConvertFrom-Iso8601 $latest.TimeCreated).ToString('o') } else { $latest.TimeCreated }
-        FirstSeenTime = if ($oldest.TimeCreated) { (ConvertFrom-Iso8601 $oldest.TimeCreated).ToString('o') } else { $oldest.TimeCreated }
-        SampleMessage = if ($latest.Message) { Get-TopLines -Text $latest.Message -Count 20 } else { $null }
+        LatestTime    = $( if ($latest.TimeCreated) { (ConvertFrom-Iso8601 $latest.TimeCreated).ToString('o') } else { $latest.TimeCreated } )
+        FirstSeenTime = $( if ($oldest.TimeCreated) { (ConvertFrom-Iso8601 $oldest.TimeCreated).ToString('o') } else { $oldest.TimeCreated } )
+        SampleMessage = $( if ($latest.Message) { Get-TopLines -Text $latest.Message -Count 20 } else { $null } )
     }
 }
 

--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -476,7 +476,7 @@ function Invoke-NetworkFirewallProfileAnalysis {
 
         $summary = [ordered]@{
             Name    = $name
-            Enabled = if ($profile.PSObject.Properties['Enabled']) { $profile.Enabled } else { $null }
+            Enabled = $( if ($profile.PSObject.Properties['Enabled']) { $profile.Enabled } else { $null } )
         }
 
         if ($profile.PSObject.Properties['DefaultInboundAction']) {
@@ -656,9 +656,9 @@ function Get-NetworkSwitchPortExpectations {
         $record = [pscustomobject]@{
             Alias            = $aliasText
             AliasKeys        = $aliasList.ToArray()
-            ExpectedSwitch   = if ($SwitchValue) { [string]$SwitchValue } else { $null }
-            ExpectedPort     = if ($PortValue) { [string]$PortValue } else { $null }
-            ExpectedLabel    = if ($displayLabel) { [string]$displayLabel } else { $null }
+            ExpectedSwitch   = $( if ($SwitchValue) { [string]$SwitchValue } else { $null } )
+            ExpectedPort     = $( if ($PortValue) { [string]$PortValue } else { $null } )
+            ExpectedLabel    = $( if ($displayLabel) { [string]$displayLabel } else { $null } )
             Source           = $SourceLabel
             Raw              = $RawValue
             NormalizedSwitch = Normalize-NetworkInventoryText $SwitchValue
@@ -775,7 +775,7 @@ function Get-NetworkSwitchPortExpectations {
     return [pscustomobject]@{
         Records = $records.ToArray()
         Map     = $aliasLookup
-        Sources = if ($sourcesUsed.Count -gt 0) { [System.Linq.Enumerable]::ToArray($sourcesUsed) } else { @() }
+        Sources = $( if ($sourcesUsed.Count -gt 0) { [System.Linq.Enumerable]::ToArray($sourcesUsed) } else { @() } )
         Count   = $records.Count
     }
 }
@@ -1126,7 +1126,7 @@ function ConvertTo-NetworkLinkSpeedMetrics {
     $label = if ($Text) { $Text.Trim() } else { $null }
 
     return [pscustomobject]@{
-        Text          = if ($label) { $label } else { $null }
+        Text          = $( if ($label) { $label } else { $null } )
         BitsPerSecond = $bits
     }
 }
@@ -1257,16 +1257,16 @@ function Get-NetworkDnsInterfaceInventory {
 
             $key = $alias.ToLowerInvariant()
             if (-not $map.ContainsKey($key)) {
-                $map[$key] = [ordered]@{
-                    Alias       = $alias
-                    Description = if ($entry.PSObject.Properties['InterfaceDescription']) { [string]$entry.InterfaceDescription } else { $null }
-                    Status      = $null
-                    IPv4        = @()
-                    IPv6        = @()
-                    Gateways    = @()
-                    IPv6Gateways = @()
-                    MacAddress  = if ($macMap.ContainsKey($key)) { $macMap[$key] } else { $null }
-                }
+            $map[$key] = [ordered]@{
+                Alias       = $alias
+                Description = $( if ($entry.PSObject.Properties['InterfaceDescription']) { [string]$entry.InterfaceDescription } else { $null } )
+                Status      = $null
+                IPv4        = @()
+                IPv6        = @()
+                Gateways    = @()
+                IPv6Gateways = @()
+                MacAddress  = $( if ($macMap.ContainsKey($key)) { $macMap[$key] } else { $null } )
+            }
             }
 
             $info = $map[$key]
@@ -1310,13 +1310,13 @@ function Get-NetworkDnsInterfaceInventory {
             $alias = if ($aliasMap.ContainsKey($key)) { $aliasMap[$key] } else { $key }
             $map[$key] = [ordered]@{
                 Alias       = $alias
-                Description = if ($descriptionMap.ContainsKey($key)) { $descriptionMap[$key] } else { $null }
+                Description = $( if ($descriptionMap.ContainsKey($key)) { $descriptionMap[$key] } else { $null } )
                 Status      = $null
                 IPv4        = @()
                 IPv6        = @()
                 Gateways    = @()
                 IPv6Gateways = @()
-                MacAddress  = if ($macMap.ContainsKey($key)) { $macMap[$key] } else { $null }
+                MacAddress  = $( if ($macMap.ContainsKey($key)) { $macMap[$key] } else { $null } )
             }
         }
 
@@ -1383,16 +1383,16 @@ function Get-NetworkAdapterLinkInventory {
             $linkSpeedValue = if ($adapter.PSObject.Properties['LinkSpeed']) { [string]$adapter.LinkSpeed } else { $null }
 
             if (-not $map.ContainsKey($key)) {
-                $map[$key] = [ordered]@{
-                    Alias            = $alias
-                    Description      = if ($adapter.PSObject.Properties['InterfaceDescription']) { [string]$adapter.InterfaceDescription } else { $null }
-                    Status           = if ($adapter.PSObject.Properties['Status']) { [string]$adapter.Status } else { $null }
-                    LinkSpeedText    = $linkSpeedValue
-                    LinkSpeed        = ConvertTo-NetworkLinkSpeedMetrics $linkSpeedValue
-                    DriverInformation = if ($adapter.PSObject.Properties['DriverInformation']) { [string]$adapter.DriverInformation } else { $null }
-                    Properties       = New-Object System.Collections.Generic.List[object]
-                    Key              = $key
-                }
+            $map[$key] = [ordered]@{
+                Alias            = $alias
+                Description      = $( if ($adapter.PSObject.Properties['InterfaceDescription']) { [string]$adapter.InterfaceDescription } else { $null } )
+                Status           = $( if ($adapter.PSObject.Properties['Status']) { [string]$adapter.Status } else { $null } )
+                LinkSpeedText    = $linkSpeedValue
+                LinkSpeed        = ConvertTo-NetworkLinkSpeedMetrics $linkSpeedValue
+                DriverInformation = $( if ($adapter.PSObject.Properties['DriverInformation']) { [string]$adapter.DriverInformation } else { $null } )
+                Properties       = New-Object System.Collections.Generic.List[object]
+                Key              = $key
+            }
             } else {
                 $info = $map[$key]
                 if (-not $info.Description -and $adapter.PSObject.Properties['InterfaceDescription']) { $info.Description = [string]$adapter.InterfaceDescription }
@@ -2074,7 +2074,7 @@ function Invoke-NetworkHeuristics {
     )
 
     Write-HeuristicDebug -Source 'Network' -Message 'Starting network heuristics' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
         InputFolder   = $InputFolder
     })
 
@@ -2115,7 +2115,7 @@ function Invoke-NetworkHeuristics {
     Write-HeuristicDebug -Source 'Network' -Message 'Computed DHCP folder path' -Data ([ordered]@{
         CollectionRoot = $resolvedRoot
         DhcpFolder     = $dhcpFolder
-        Exists         = if ($dhcpFolder) { Test-Path -LiteralPath $dhcpFolder } else { $false }
+        Exists         = $( if ($dhcpFolder) { Test-Path -LiteralPath $dhcpFolder } else { $false } )
     })
 
     $result = New-CategoryResult -Name 'Network'
@@ -2166,7 +2166,7 @@ function Invoke-NetworkHeuristics {
             $arpEntries = ConvertTo-NetworkArpEntries -Value $payload.Arp
         }
         Write-HeuristicDebug -Source 'Network' -Message 'Parsed ARP entries' -Data ([ordered]@{
-            Count = if ($arpEntries) { $arpEntries.Count } else { 0 }
+            Count = $( if ($arpEntries) { $arpEntries.Count } else { 0 } )
         })
 
         $gatewayInventory = $null
@@ -2225,7 +2225,7 @@ function Invoke-NetworkHeuristics {
 
                 $entryRecord = [pscustomobject]@{
                     Gateway      = $gateway
-                    Interfaces   = if ($detail.Interfaces.Count -gt 0) { [System.Linq.Enumerable]::ToArray($detail.Interfaces) } else { @() }
+                    Interfaces   = $( if ($detail.Interfaces.Count -gt 0) { [System.Linq.Enumerable]::ToArray($detail.Interfaces) } else { @() } )
                     NormalizedMac = $match.NormalizedMac
                     Type         = $match.Type
                 }
@@ -2444,8 +2444,8 @@ function Invoke-NetworkHeuristics {
         }
 
         Write-HeuristicDebug -Source 'Network' -Message 'Parsed IPv6 routing data' -Data ([ordered]@{
-            NeighborCount = if ($ipv6Neighbors) { $ipv6Neighbors.Count } else { 0 }
-            RouterCount   = if ($ipv6Routers) { $ipv6Routers.Count } else { 0 }
+            NeighborCount = $( if ($ipv6Neighbors) { $ipv6Neighbors.Count } else { 0 } )
+            RouterCount   = $( if ($ipv6Routers) { $ipv6Routers.Count } else { 0 } )
             NeighborError = $neighborPayloadError
             RouterError   = $routerPayloadError
         })
@@ -2466,7 +2466,7 @@ function Invoke-NetworkHeuristics {
                     $aliasLabel = if ($entry.PSObject.Properties['Alias']) { [string]$entry.Alias } else { $null }
                     $globalIpv6Records.Add([pscustomobject]@{
                         Alias     = $aliasLabel
-                        Addresses = if ($addressSet.Count -gt 0) { [System.Linq.Enumerable]::ToArray($addressSet) } else { @() }
+                        Addresses = $( if ($addressSet.Count -gt 0) { [System.Linq.Enumerable]::ToArray($addressSet) } else { @() } )
                     }) | Out-Null
                 }
             }
@@ -2520,8 +2520,8 @@ function Invoke-NetworkHeuristics {
             }
 
             $routerMacRecords.Add([pscustomobject]@{
-                InterfaceName = if ($router.InterfaceName) { [string]$router.InterfaceName } else { $null }
-                Address       = if ($router.Address) { [string]$router.Address } else { $null }
+                InterfaceName = $( if ($router.InterfaceName) { [string]$router.InterfaceName } else { $null } )
+                Address       = $( if ($router.Address) { [string]$router.Address } else { $null } )
                 Macs          = ($macs | Sort-Object -Unique)
             }) | Out-Null
         }
@@ -2739,7 +2739,7 @@ function Invoke-NetworkHeuristics {
         $expectationCount = if ($switchPortExpectations -and $switchPortExpectations.Records) { $switchPortExpectations.Records.Count } else { 0 }
         Write-HeuristicDebug -Source 'Network' -Message 'Resolved switch port expectations' -Data ([ordered]@{
             Count   = $expectationCount
-            Sources = if ($switchPortExpectations -and $switchPortExpectations.Sources) { ($switchPortExpectations.Sources -join ', ') } else { '(none)' }
+            Sources = $( if ($switchPortExpectations -and $switchPortExpectations.Sources) { ($switchPortExpectations.Sources -join ', ') } else { '(none)' } )
         })
 
         if ($neighborCount -eq 0) {

--- a/Analyzers/Heuristics/Office.ps1
+++ b/Analyzers/Heuristics/Office.ps1
@@ -17,7 +17,7 @@ function Invoke-OfficeHeuristics {
     )
 
     Write-HeuristicDebug -Source 'Office' -Message 'Starting Office heuristics' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
     })
 
     $result = New-CategoryResult -Name 'Office'

--- a/Analyzers/Heuristics/Office/OutlookCache.ps1
+++ b/Analyzers/Heuristics/Office/OutlookCache.ps1
@@ -20,7 +20,7 @@ function Invoke-OutlookCacheHeuristic {
     if ($cacheArtifact) {
         $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $cacheArtifact)
         Write-HeuristicDebug -Source 'Office' -Message 'Evaluating Outlook caches payload' -Data ([ordered]@{
-            CacheCount = if ($payload -and $payload.Caches) { $payload.Caches.Count } else { 0 }
+            CacheCount = $( if ($payload -and $payload.Caches) { $payload.Caches.Count } else { 0 } )
         })
 
         if ($payload -and $payload.Caches -and -not $payload.Caches.Error) {

--- a/Analyzers/Heuristics/Office/OutlookConnectivity.ps1
+++ b/Analyzers/Heuristics/Office/OutlookConnectivity.ps1
@@ -20,7 +20,7 @@ function Invoke-OutlookConnectivityHeuristic {
     if ($connectivityArtifact) {
         $payload = Resolve-SinglePayload -Payload (Get-ArtifactPayload -Artifact $connectivityArtifact)
         Write-HeuristicDebug -Source 'Office' -Message 'Evaluating Outlook connectivity payload' -Data ([ordered]@{
-            OstCount = if ($payload -and $payload.OstFiles) { $payload.OstFiles.Count } else { 0 }
+            OstCount = $( if ($payload -and $payload.OstFiles) { $payload.OstFiles.Count } else { 0 } )
         })
 
         if ($payload -and $payload.OstFiles) {

--- a/Analyzers/Heuristics/Printing.ps1
+++ b/Analyzers/Heuristics/Printing.ps1
@@ -18,7 +18,7 @@ function Invoke-PrintingHeuristics {
     )
 
     Write-HeuristicDebug -Source 'Printing' -Message 'Starting printing heuristics' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
     })
 
     $result = New-CategoryResult -Name 'Printing'

--- a/Analyzers/Heuristics/Security.ps1
+++ b/Analyzers/Heuristics/Security.ps1
@@ -30,7 +30,7 @@ function Invoke-SecurityHeuristics {
     )
 
     Write-HeuristicDebug -Source 'Security' -Message 'Starting security heuristics' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
     })
 
     $result = New-CategoryResult -Name 'Security'

--- a/Analyzers/Heuristics/Security/Security.Autorun.ps1
+++ b/Analyzers/Heuristics/Security/Security.Autorun.ps1
@@ -19,7 +19,7 @@ function Invoke-SecurityAutorunChecks {
         if ($autorunPayload -and $autorunPayload.ExplorerPolicies) {
             $autorunEntries = ConvertTo-List $autorunPayload.ExplorerPolicies
             Write-HeuristicDebug -Source 'Security' -Message 'Analyzing autorun policy entries' -Data ([ordered]@{
-                EntryCount = if ($autorunEntries) { $autorunEntries.Count } else { 0 }
+                EntryCount = $( if ($autorunEntries) { $autorunEntries.Count } else { 0 } )
             })
 
             $preferredPaths = @(

--- a/Analyzers/Heuristics/Services.ps1
+++ b/Analyzers/Heuristics/Services.ps1
@@ -86,7 +86,7 @@ function Invoke-ServicesHeuristics {
     )
 
     Write-HeuristicDebug -Source 'Services' -Message 'Invoke-ServicesHeuristics: START' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
     })
 
     $result = New-CategoryResult -Name 'Services'
@@ -258,7 +258,7 @@ function Invoke-ServicesHeuristics {
     Write-HeuristicDebug -Source 'Services' -Message 'Resolved services artifact' -Data ([ordered]@{
         Found      = [bool]$selectedArtifact
         Candidates = (($artifactCandidates | ForEach-Object { $_.Key }) -join ', ')
-        Selected   = if ($selectedCandidate) { $selectedCandidate.Key } else { '(none)' }
+        Selected   = $( if ($selectedCandidate) { $selectedCandidate.Key } else { '(none)' } )
     })
 
     if (-not $selectedArtifact) {

--- a/Analyzers/Heuristics/Services/Services.Common.ps1
+++ b/Analyzers/Heuristics/Services/Services.Common.ps1
@@ -114,9 +114,9 @@ function Get-ServiceStateInfo {
         Exists              = $true
         Name                = $Name
         DisplayName         = $displayName
-        Status              = if ($status) { $status } else { 'Unknown' }
+        Status              = $( if ($status) { $status } else { 'Unknown' } )
         StatusNormalized    = Normalize-ServiceStateValue -Value $status
-        StartMode           = if ($startMode) { $startMode } else { 'Unknown' }
+        StartMode           = $( if ($startMode) { $startMode } else { 'Unknown' } )
         StartModeNormalized = Normalize-ServiceStartValue -Value $startMode
     }
 }
@@ -194,7 +194,7 @@ function ConvertTo-ServiceCollection {
 
         $entry = [ordered]@{
             Name                 = $name
-            DisplayName          = if ($displayName) { $displayName } else { $name }
+            DisplayName          = $( if ($displayName) { $displayName } else { $name } )
             Status               = $statusSource
             State                = $stateValue
             StartMode            = $startSource

--- a/Analyzers/Heuristics/Storage.ps1
+++ b/Analyzers/Heuristics/Storage.ps1
@@ -18,7 +18,7 @@ function Invoke-StorageHeuristics {
     )
 
     Write-HeuristicDebug -Source 'Storage' -Message 'Starting storage heuristics' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
     })
 
     $result = New-CategoryResult -Name 'Storage'

--- a/Analyzers/Heuristics/Storage/Storage.Volumes.ps1
+++ b/Analyzers/Heuristics/Storage/Storage.Volumes.ps1
@@ -182,10 +182,10 @@ function Invoke-StorageVolumeEvaluation {
 
             if ($shouldSkip) {
                 Write-HeuristicDebug -Source 'Storage' -Message 'Skipping hidden volume for free space evaluation' -Data ([ordered]@{
-                    Label = if ($rawLabel) { $rawLabel } else { $label }
+                    Label = $( if ($rawLabel) { $rawLabel } else { $label } )
                     SizeGb = $sizeGb
                     HasDriveLetter = $hasDriveLetter
-                    Reason = if ($skipReason) { $skipReason } else { 'Not specified' }
+                    Reason = $( if ($skipReason) { $skipReason } else { 'Not specified' } )
                 })
                 continue
             }

--- a/Analyzers/Heuristics/System.ps1
+++ b/Analyzers/Heuristics/System.ps1
@@ -22,7 +22,7 @@ function Invoke-SystemHeuristics {
     )
 
     Write-HeuristicDebug -Source 'System' -Message 'Starting system heuristics' -Data ([ordered]@{
-        ArtifactCount = if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 }
+        ArtifactCount = $( if ($Context -and $Context.Artifacts) { $Context.Artifacts.Count } else { 0 } )
     })
 
     $result = New-CategoryResult -Name 'System'

--- a/Analyzers/HtmlComposer.ps1
+++ b/Analyzers/HtmlComposer.ps1
@@ -380,7 +380,7 @@ function Convert-ToIssueCard {
     )
 
     if (-not $Issue) {
-        Write-HtmlDebug -Stage 'Composer.IssueCard' -Message 'Issue conversion skipped because entry was null.' -Data @{ Category = if ($Category -and $Category.PSObject.Properties['Name']) { [string]$Category.Name } else { '(unknown)' } }
+        Write-HtmlDebug -Stage 'Composer.IssueCard' -Message 'Issue conversion skipped because entry was null.' -Data @{ Category = $( if ($Category -and $Category.PSObject.Properties['Name']) { [string]$Category.Name } else { '(unknown)' } ) }
         return $null
     }
 
@@ -428,12 +428,12 @@ function Convert-ToIssueCard {
 
     $card = [pscustomobject]@{
         Severity    = $severity
-        CssClass    = if ($severity) { $severity } else { 'info' }
-        BadgeText   = if ($Issue.Severity) { ([string]$Issue.Severity).ToUpperInvariant() } else { 'ISSUE' }
+        CssClass    = $( if ($severity) { $severity } else { 'info' } )
+        BadgeText   = $( if ($Issue.Severity) { ([string]$Issue.Severity).ToUpperInvariant() } else { 'ISSUE' } )
         Area        = Get-IssueAreaLabel -Category $Category -Entry $Issue
         Message     = $Issue.Title
-        Explanation = if ($hasDetail -and -not $hasNewLines) { $detail } else { $null }
-        Evidence    = if ($hasDetail -and $hasNewLines) { $detail } else { $null }
+        Explanation = $( if ($hasDetail -and -not $hasNewLines) { $detail } else { $null } )
+        Evidence    = $( if ($hasDetail -and $hasNewLines) { $detail } else { $null } )
         Source     = $issueSource
         Remediation = $remediationText
         RemediationScript = $remediationScript
@@ -454,7 +454,7 @@ function Convert-ToGoodCard {
     )
 
     if (-not $Normal) {
-        Write-HtmlDebug -Stage 'Composer.GoodCard' -Message 'Positive finding conversion skipped because entry was null.' -Data @{ Category = if ($Category -and $Category.PSObject.Properties['Name']) { [string]$Category.Name } else { '(unknown)' } }
+        Write-HtmlDebug -Stage 'Composer.GoodCard' -Message 'Positive finding conversion skipped because entry was null.' -Data @{ Category = $( if ($Category -and $Category.PSObject.Properties['Name']) { [string]$Category.Name } else { '(unknown)' } ) }
         return $null
     }
 
@@ -589,7 +589,7 @@ function Get-FailedCollectorReports {
             if ($status -eq $false) {
                 $detail = if ($result.PSObject.Properties['Error'] -and $result.Error) { [string]$result.Error } else { 'Collector reported failure.' }
                 $failures.Add([pscustomobject]@{
-                        Key     = if ($displayName) { $displayName } else { 'Collector' }
+                        Key     = $( if ($displayName) { $displayName } else { 'Collector' } )
                         Status  = 'Execution failed'
                         Details = $detail
                         Path    = $scriptPath
@@ -601,7 +601,7 @@ function Get-FailedCollectorReports {
             if ($status -eq $true) {
                 if ($null -eq $output -or ([string]::IsNullOrWhiteSpace([string]$output))) {
                     $failures.Add([pscustomobject]@{
-                            Key     = if ($displayName) { $displayName } else { 'Collector' }
+                            Key     = $( if ($displayName) { $displayName } else { 'Collector' } )
                             Status  = 'No output'
                             Details = 'Collector did not return a path or payload reference.'
                             Path    = $scriptPath
@@ -630,7 +630,7 @@ function Get-FailedCollectorReports {
                 if (-not $resolvedAny -and $missing.Count -gt 0) {
                     $detailText = "Expected file not found: {0}" -f ($missing -join ', ')
                     $failures.Add([pscustomobject]@{
-                            Key     = if ($displayName) { $displayName } else { 'Collector' }
+                            Key     = $( if ($displayName) { $displayName } else { 'Collector' } )
                             Status  = 'Output missing'
                             Details = $detailText
                             Path    = $scriptPath
@@ -659,7 +659,7 @@ function Get-FailedCollectorReports {
 
                 if ($data -and $data.PSObject.Properties['Error'] -and $data.Error) {
                     $failures.Add([pscustomobject]@{
-                            Key     = if ($path) { [System.IO.Path]::GetFileName($path) } else { $key }
+                            Key     = $( if ($path) { [System.IO.Path]::GetFileName($path) } else { $key } )
                             Status  = 'Parse error'
                             Details = [string]$data.Error
                             Path    = $path
@@ -684,7 +684,7 @@ function Get-FailedCollectorReports {
 
                     if ($isEmpty) {
                         $failures.Add([pscustomobject]@{
-                                Key     = if ($path) { [System.IO.Path]::GetFileName($path) } else { $key }
+                                Key     = $( if ($path) { [System.IO.Path]::GetFileName($path) } else { $key } )
                                 Status  = 'Empty output'
                                 Details = 'Captured file contained no payload.'
                                 Path    = $path

--- a/Analyzers/Network/Analyze-Vpn.ps1
+++ b/Analyzers/Network/Analyze-Vpn.ps1
@@ -118,8 +118,8 @@ function New-VpnEvidence {
             }
             $certSummary = [ordered]@{
                 thumbprintLast8 = $suffix
-                notAfterUtc     = if ($cert.PSObject.Properties['notAfterUtc']) { $cert.notAfterUtc } else { $null }
-                isExpired       = if ($cert.PSObject.Properties['isExpired']) { $cert.isExpired } else { $null }
+                notAfterUtc     = $( if ($cert.PSObject.Properties['notAfterUtc']) { $cert.notAfterUtc } else { $null } )
+                isExpired       = $( if ($cert.PSObject.Properties['isExpired']) { $cert.isExpired } else { $null } )
             }
         } else {
             $certSummary = [ordered]@{ status = 'not-found' }
@@ -130,16 +130,16 @@ function New-VpnEvidence {
     if ($Connection -and $Connection.PSObject.Properties['lastStatus'] -and $Connection.lastStatus) {
         $status = $Connection.lastStatus
         $lastStatusSummary = [ordered]@{
-            connected         = if ($status.PSObject.Properties['connected']) { $status.connected } else { $null }
-            connectedSinceUtc = if ($status.PSObject.Properties['connectedSinceUtc']) { $status.connectedSinceUtc } else { $null }
-            bytesIn           = if ($status.PSObject.Properties['bytesIn']) { $status.bytesIn } else { $null }
-            bytesOut          = if ($status.PSObject.Properties['bytesOut']) { $status.bytesOut } else { $null }
-            lastError         = if ($status.PSObject.Properties['lastError']) { $status.lastError } else { $null }
+            connected         = $( if ($status.PSObject.Properties['connected']) { $status.connected } else { $null } )
+            connectedSinceUtc = $( if ($status.PSObject.Properties['connectedSinceUtc']) { $status.connectedSinceUtc } else { $null } )
+            bytesIn           = $( if ($status.PSObject.Properties['bytesIn']) { $status.bytesIn } else { $null } )
+            bytesOut          = $( if ($status.PSObject.Properties['bytesOut']) { $status.bytesOut } else { $null } )
+            lastError         = $( if ($status.PSObject.Properties['lastError']) { $status.lastError } else { $null } )
         }
     }
 
     $evidence = [ordered]@{
-        vpnName             = if ($Connection) { $Connection.name } else { $null }
+        vpnName             = $( if ($Connection) { $Connection.name } else { $null } )
         vpnType             = $vpnType
         serverAddress       = $serverAddress
         splitTunneling      = $splitTunneling

--- a/Collectors/Hardware/Collect-StorageSnapshot.ps1
+++ b/Collectors/Hardware/Collect-StorageSnapshot.ps1
@@ -123,8 +123,8 @@ function Get-StorageWearSnapshot {
         $row = [ordered]@{
             DeviceId     = $disk.DeviceId
             FriendlyName = $disk.FriendlyName
-            SerialNumber = if ($disk.PSObject.Properties['SerialNumber']) { $disk.SerialNumber } else { $null }
-            MediaType    = if ($disk.PSObject.Properties['MediaType']) { $disk.MediaType } else { $null }
+            SerialNumber = $( if ($disk.PSObject.Properties['SerialNumber']) { $disk.SerialNumber } else { $null } )
+            MediaType    = $( if ($disk.PSObject.Properties['MediaType']) { $disk.MediaType } else { $null } )
             Wear         = $null
             Temperature  = $null
             Error        = $null

--- a/Collectors/Network/Collect-Lan8021x.ps1
+++ b/Collectors/Network/Collect-Lan8021x.ps1
@@ -77,9 +77,9 @@ function Get-Lan8021xDot3Events {
 
         $results += [ordered]@{
             timeCreatedUtc = $timeCreatedUtc
-            level          = if ($event.PSObject.Properties['LevelDisplayName']) { [string]$event.LevelDisplayName } else { $null }
-            eventId        = if ($event.PSObject.Properties['Id']) { [int]$event.Id } else { $null }
-            provider       = if ($event.PSObject.Properties['ProviderName']) { [string]$event.ProviderName } else { $null }
+            level          = $( if ($event.PSObject.Properties['LevelDisplayName']) { [string]$event.LevelDisplayName } else { $null } )
+            eventId        = $( if ($event.PSObject.Properties['Id']) { [int]$event.Id } else { $null } )
+            provider       = $( if ($event.PSObject.Properties['ProviderName']) { [string]$event.ProviderName } else { $null } )
             message        = $message
         }
     }
@@ -116,19 +116,19 @@ function Get-Lan8021xMachineCertificates {
             foreach ($eku in $cert.EnhancedKeyUsageList) {
                 if (-not $eku) { continue }
                 $ekuDetails += [ordered]@{
-                    friendlyName = if ($eku.PSObject.Properties['FriendlyName']) { [string]$eku.FriendlyName } else { $null }
-                    oid          = if ($eku.PSObject.Properties['Value']) { [string]$eku.Value } else { $null }
+                    friendlyName = $( if ($eku.PSObject.Properties['FriendlyName']) { [string]$eku.FriendlyName } else { $null } )
+                    oid          = $( if ($eku.PSObject.Properties['Value']) { [string]$eku.Value } else { $null } )
                 }
             }
         }
 
         $results += [ordered]@{
-            subject         = if ($cert.PSObject.Properties['Subject']) { [string]$cert.Subject } else { $null }
-            issuer          = if ($cert.PSObject.Properties['Issuer']) { [string]$cert.Issuer } else { $null }
-            thumbprint      = if ($cert.PSObject.Properties['Thumbprint']) { [string]$cert.Thumbprint } else { $null }
+            subject         = $( if ($cert.PSObject.Properties['Subject']) { [string]$cert.Subject } else { $null } )
+            issuer          = $( if ($cert.PSObject.Properties['Issuer']) { [string]$cert.Issuer } else { $null } )
+            thumbprint      = $( if ($cert.PSObject.Properties['Thumbprint']) { [string]$cert.Thumbprint } else { $null } )
             notBeforeUtc    = $notBeforeUtc
             notAfterUtc     = $notAfterUtc
-            hasPrivateKey   = if ($cert.PSObject.Properties['HasPrivateKey']) { [bool]$cert.HasPrivateKey } else { $null }
+            hasPrivateKey   = $( if ($cert.PSObject.Properties['HasPrivateKey']) { [bool]$cert.HasPrivateKey } else { $null } )
             enhancedKeyUsage = $ekuDetails
         }
     }
@@ -154,7 +154,7 @@ function Invoke-Main {
         $machineCerts  = Get-Lan8021xMachineCertificates
 
         $payload['netsh'] = [ordered]@{
-            interfaces = if ($interfacesRaw) {
+            interfaces = $( if ($interfacesRaw) {
                 if ($interfacesRaw -is [pscustomobject] -and $interfacesRaw.PSObject.Properties['Error'] -and $interfacesRaw.Error) {
                     $interfacesRaw
                 } else {
@@ -162,8 +162,8 @@ function Invoke-Main {
                 }
             } else {
                 $null
-            }
-            profiles = if ($profilesRaw) {
+            } )
+            profiles = $( if ($profilesRaw) {
                 if ($profilesRaw -is [pscustomobject] -and $profilesRaw.PSObject.Properties['Error'] -and $profilesRaw.Error) {
                     $profilesRaw
                 } else {
@@ -171,7 +171,7 @@ function Invoke-Main {
                 }
             } else {
                 $null
-            }
+            } )
         }
 
         $payload['events'] = [ordered]@{

--- a/Collectors/Network/Collect-Lldp.ps1
+++ b/Collectors/Network/Collect-Lldp.ps1
@@ -204,18 +204,18 @@ function Parse-LldpctlKeyValue {
         $neighbor = [ordered]@{
             Source                     = 'lldpctl'
             InterfaceAlias             = $entry.InterfaceAlias
-            LocalPortId                = if ($entry.Contains('LocalPortId')) { $entry['LocalPortId'] } else { $null }
-            LocalChassisId             = if ($entry.Contains('LocalChassisId')) { $entry['LocalChassisId'] } else { $null }
-            NeighborChassisId          = if ($entry.Contains('NeighborChassisId')) { $entry['NeighborChassisId'] } else { $null }
-            NeighborSystemName         = if ($entry.Contains('NeighborSystemName')) { $entry['NeighborSystemName'] } else { $null }
-            NeighborSystemDescription  = if ($entry.Contains('NeighborSystemDescription')) { $entry['NeighborSystemDescription'] } else { $null }
-            NeighborPortId             = if ($entry.Contains('NeighborPortId')) { $entry['NeighborPortId'] } else { $null }
-            NeighborPortIdSubtype      = if ($entry.Contains('NeighborPortIdSubtype')) { $entry['NeighborPortIdSubtype'] } else { $null }
-            NeighborPortDescription    = if ($entry.Contains('NeighborPortDescription')) { $entry['NeighborPortDescription'] } else { $null }
-            NeighborTtl                = if ($entry.Contains('NeighborTtl')) { $entry['NeighborTtl'] } else { $null }
+            LocalPortId                = $( if ($entry.Contains('LocalPortId')) { $entry['LocalPortId'] } else { $null } )
+            LocalChassisId             = $( if ($entry.Contains('LocalChassisId')) { $entry['LocalChassisId'] } else { $null } )
+            NeighborChassisId          = $( if ($entry.Contains('NeighborChassisId')) { $entry['NeighborChassisId'] } else { $null } )
+            NeighborSystemName         = $( if ($entry.Contains('NeighborSystemName')) { $entry['NeighborSystemName'] } else { $null } )
+            NeighborSystemDescription  = $( if ($entry.Contains('NeighborSystemDescription')) { $entry['NeighborSystemDescription'] } else { $null } )
+            NeighborPortId             = $( if ($entry.Contains('NeighborPortId')) { $entry['NeighborPortId'] } else { $null } )
+            NeighborPortIdSubtype      = $( if ($entry.Contains('NeighborPortIdSubtype')) { $entry['NeighborPortIdSubtype'] } else { $null } )
+            NeighborPortDescription    = $( if ($entry.Contains('NeighborPortDescription')) { $entry['NeighborPortDescription'] } else { $null } )
+            NeighborTtl                = $( if ($entry.Contains('NeighborTtl')) { $entry['NeighborTtl'] } else { $null } )
             NeighborCapabilities       = $caps
             NeighborManagementAddresses = ($entry.NeighborManagementAddresses | Select-Object -Unique)
-            Vlans                      = if ($entry.Vlans.Keys.Count -gt 0) { $entry.Vlans } else { $null }
+            Vlans                      = $( if ($entry.Vlans.Keys.Count -gt 0) { $entry.Vlans } else { $null } )
             Raw                        = $entry.Raw
         }
 

--- a/Collectors/Network/Collect-VpnBaseline.ps1
+++ b/Collectors/Network/Collect-VpnBaseline.ps1
@@ -66,9 +66,9 @@ function Get-VpnServiceState {
 
     if ($service) {
         return [ordered]@{
-            StartType = if ($service.PSObject.Properties['StartMode']) { [string]$service.StartMode } elseif ($service.PSObject.Properties['StartType']) { [string]$service.StartType } else { $null }
-            Status    = if ($service.PSObject.Properties['State']) { [string]$service.State } elseif ($service.PSObject.Properties['Status']) { [string]$service.Status } else { $null }
-            Path      = if ($service.PSObject.Properties['PathName']) { [string]$service.PathName } else { $null }
+            StartType = $( if ($service.PSObject.Properties['StartMode']) { [string]$service.StartMode } elseif ($service.PSObject.Properties['StartType']) { [string]$service.StartType } else { $null } )
+            Status    = $( if ($service.PSObject.Properties['State']) { [string]$service.State } elseif ($service.PSObject.Properties['Status']) { [string]$service.Status } else { $null } )
+            Path      = $( if ($service.PSObject.Properties['PathName']) { [string]$service.PathName } else { $null } )
         }
     }
 
@@ -79,8 +79,8 @@ function Get-VpnServiceState {
     try {
         $fallback = Get-Service -Name $Name -ErrorAction Stop
         return [ordered]@{
-            StartType = if ($fallback.PSObject.Properties['StartType']) { [string]$fallback.StartType } else { $null }
-            Status    = if ($fallback.PSObject.Properties['Status']) { [string]$fallback.Status } else { $null }
+            StartType = $( if ($fallback.PSObject.Properties['StartType']) { [string]$fallback.StartType } else { $null } )
+            Status    = $( if ($fallback.PSObject.Properties['Status']) { [string]$fallback.Status } else { $null } )
             Path      = $null
         }
     } catch {
@@ -333,10 +333,10 @@ function Get-VpnConnectionRecords {
 
             $record = [ordered]@{
                 name    = [string]$connection.Name
-                guid    = if ($connection.PSObject.Properties['Guid']) { [string]$connection.Guid } else { $null }
-                type    = if ($connection.PSObject.Properties['TunnelType']) { [string]$connection.TunnelType } else { 'Unknown' }
-                serverAddress = if ($connection.PSObject.Properties['ServerAddress']) { [string]$connection.ServerAddress } else { $null }
-                splitTunneling = if ($connection.PSObject.Properties['SplitTunneling']) { [bool]$connection.SplitTunneling } else { $null }
+                guid    = $( if ($connection.PSObject.Properties['Guid']) { [string]$connection.Guid } else { $null } )
+                type    = $( if ($connection.PSObject.Properties['TunnelType']) { [string]$connection.TunnelType } else { 'Unknown' } )
+                serverAddress = $( if ($connection.PSObject.Properties['ServerAddress']) { [string]$connection.ServerAddress } else { $null } )
+                splitTunneling = $( if ($connection.PSObject.Properties['SplitTunneling']) { [bool]$connection.SplitTunneling } else { $null } )
                 auth    = Get-VpnAuthMetadata -Connection $connection
                 dnsSuffixes = Get-VpnDnsSuffixes -Connection $connection
                 routes  = Get-VpnRoutes -Connection $connection
@@ -716,9 +716,9 @@ function Get-VpnEvents {
             $eventData = ConvertTo-VpnEventData -Event $event
 
             $events += [ordered]@{
-                timeCreatedUtc = if ($timeUtc) { $timeUtc.ToString('o') } else { $null }
+                timeCreatedUtc = $( if ($timeUtc) { $timeUtc.ToString('o') } else { $null } )
                 provider       = $provider
-                level          = if ($event.PSObject.Properties['LevelDisplayName']) { [string]$event.LevelDisplayName } else { $null }
+                level          = $( if ($event.PSObject.Properties['LevelDisplayName']) { [string]$event.LevelDisplayName } else { $null } )
                 eventId        = $eventId
                 recordId       = $recordId
                 message        = Sanitize-VpnEventMessage -Message $message

--- a/Collectors/Network/DHCP/Dhcp-Common.ps1
+++ b/Collectors/Network/DHCP/Dhcp-Common.ps1
@@ -91,7 +91,7 @@ function Get-DhcpClientEvents {
             ProviderName = $event.ProviderName
             Level        = $event.LevelDisplayName
             RecordId     = $event.RecordId
-            TimeCreated  = if ($event.TimeCreated) { $event.TimeCreated.ToString('o') } else { $null }
+            TimeCreated  = $( if ($event.TimeCreated) { $event.TimeCreated.ToString('o') } else { $null } )
             Message      = $event.Message
         })
     }

--- a/Collectors/Security/Collect-Firewall.ps1
+++ b/Collectors/Security/Collect-Firewall.ps1
@@ -308,22 +308,22 @@ function Get-FirewallRules {
         }
 
         $record = [ordered]@{
-            Name         = if ($rule.PSObject.Properties['Name']) { [string]$rule.Name } else { $null }
-            DisplayName  = if ($rule.PSObject.Properties['DisplayName']) { [string]$rule.DisplayName } else { $null }
-            Direction    = if ($rule.PSObject.Properties['Direction']) { [string]$rule.Direction } else { $null }
-            Action       = if ($rule.PSObject.Properties['Action']) { [string]$rule.Action } else { $null }
-            Enabled      = if ($rule.PSObject.Properties['Enabled']) { $rule.Enabled } else { $null }
-            Profile      = if ($rule.PSObject.Properties['Profile']) { [string]$rule.Profile } else { $null }
-            PolicyStore  = if ($rule.PSObject.Properties['PolicyStoreSourceType']) { [string]$rule.PolicyStoreSourceType } else { $null }
-            Program      = if ($rule.PSObject.Properties['Program']) { [string]$rule.Program } else { $null }
-            Service      = if ($rule.PSObject.Properties['Service']) { [string]$rule.Service } else { $null }
-            Group        = if ($rule.PSObject.Properties['DisplayGroup']) { [string]$rule.DisplayGroup } else { $null }
-            Description  = if ($rule.PSObject.Properties['Description']) { [string]$rule.Description } else { $null }
+            Name         = $( if ($rule.PSObject.Properties['Name']) { [string]$rule.Name } else { $null } )
+            DisplayName  = $( if ($rule.PSObject.Properties['DisplayName']) { [string]$rule.DisplayName } else { $null } )
+            Direction    = $( if ($rule.PSObject.Properties['Direction']) { [string]$rule.Direction } else { $null } )
+            Action       = $( if ($rule.PSObject.Properties['Action']) { [string]$rule.Action } else { $null } )
+            Enabled      = $( if ($rule.PSObject.Properties['Enabled']) { $rule.Enabled } else { $null } )
+            Profile      = $( if ($rule.PSObject.Properties['Profile']) { [string]$rule.Profile } else { $null } )
+            PolicyStore  = $( if ($rule.PSObject.Properties['PolicyStoreSourceType']) { [string]$rule.PolicyStoreSourceType } else { $null } )
+            Program      = $( if ($rule.PSObject.Properties['Program']) { [string]$rule.Program } else { $null } )
+            Service      = $( if ($rule.PSObject.Properties['Service']) { [string]$rule.Service } else { $null } )
+            Group        = $( if ($rule.PSObject.Properties['DisplayGroup']) { [string]$rule.DisplayGroup } else { $null } )
+            Description  = $( if ($rule.PSObject.Properties['Description']) { [string]$rule.Description } else { $null } )
             Protocol     = $protocol
             LocalPort    = $localPort
             RemotePort   = $remotePort
-            LocalAddress = if ($localAddressValues.Count -gt 0) { $localAddressValues.ToArray() } else { $null }
-            RemoteAddress = if ($remoteAddressValues.Count -gt 0) { $remoteAddressValues.ToArray() } else { $null }
+            LocalAddress = $( if ($localAddressValues.Count -gt 0) { $localAddressValues.ToArray() } else { $null } )
+            RemoteAddress = $( if ($remoteAddressValues.Count -gt 0) { $remoteAddressValues.ToArray() } else { $null } )
         }
 
         $result.Add([pscustomobject]$record) | Out-Null

--- a/Collectors/Services/Collect-Printing.ps1
+++ b/Collectors/Services/Collect-Printing.ps1
@@ -180,8 +180,8 @@ function Get-PrinterDictionaries {
                     JobSize       = $job.JobSize
                     PagesPrinted  = $job.PagesPrinted
                     TotalPages    = $job.TotalPages
-                    SubmittedBy   = if ($job.PSObject.Properties['UserName']) { [string]$job.UserName } else { $null }
-                    SubmittedTime = if ($submitted) { $submitted.ToString('o') } else { $null }
+                    SubmittedBy   = $( if ($job.PSObject.Properties['UserName']) { [string]$job.UserName } else { $null } )
+                    SubmittedTime = $( if ($submitted) { $submitted.ToString('o') } else { $null } )
                     AgeMinutes    = $ageMinutes
                 })
             }
@@ -211,12 +211,12 @@ function Get-PrinterDictionaries {
 
         $printerDict = [ordered]@{
             Name           = $printerName
-            ShareName      = if ($printer.PSObject.Properties['ShareName']) { [string]$printer.ShareName } else { $null }
+            ShareName      = $( if ($printer.PSObject.Properties['ShareName']) { [string]$printer.ShareName } else { $null } )
             ComputerName   = $computerName
-            Comment        = if ($printer.PSObject.Properties['Comment']) { [string]$printer.Comment } else { $null }
-            Location       = if ($printer.PSObject.Properties['Location']) { [string]$printer.Location } else { $null }
-            QueueStatus    = if ($printer.PSObject.Properties['QueueStatus']) { [string]$printer.QueueStatus } else { $null }
-            PrinterStatus  = if ($printer.PSObject.Properties['PrinterStatus']) { [string]$printer.PrinterStatus } else { $null }
+            Comment        = $( if ($printer.PSObject.Properties['Comment']) { [string]$printer.Comment } else { $null } )
+            Location       = $( if ($printer.PSObject.Properties['Location']) { [string]$printer.Location } else { $null } )
+            QueueStatus    = $( if ($printer.PSObject.Properties['QueueStatus']) { [string]$printer.QueueStatus } else { $null } )
+            PrinterStatus  = $( if ($printer.PSObject.Properties['PrinterStatus']) { [string]$printer.PrinterStatus } else { $null } )
             WorkOffline    = $workOffline
             Default        = $defaultPrinter
             PortName       = $portName
@@ -351,7 +351,7 @@ function Convert-Event {
         Id          = $Event.Id
         Level       = $Event.LevelDisplayName
         Provider    = $Event.ProviderName
-        TimeCreated = if ($Event.TimeCreated) { $Event.TimeCreated.ToString('o') } else { $null }
+        TimeCreated = $( if ($Event.TimeCreated) { $Event.TimeCreated.ToString('o') } else { $null } )
         Message     = ($Event.Message -replace '\s+', ' ').Trim()
     }
 }
@@ -410,7 +410,7 @@ function Collect-PrintEvents {
             WarningCount = ($operationalEvents | Where-Object { $_.LevelDisplayName -eq 'Warning' }).Count
             Events       = $operationalConverted
         }
-        Errors = if ($errors -is [System.Collections.Generic.List[string]]) { $errors.ToArray() } else { $errors }
+        Errors = $( if ($errors -is [System.Collections.Generic.List[string]]) { $errors.ToArray() } else { $errors } )
     }
 }
 
@@ -423,8 +423,8 @@ function Invoke-PortTest {
 
     $testResult = [ordered]@{
         Name           = $Definition.Name
-        Port           = if ($Definition.ContainsKey('Port')) { $Definition.Port } else { $null }
-        Type           = if ($Definition.ContainsKey('Type')) { $Definition.Type } else { 'Tcp' }
+        Port           = $( if ($Definition.ContainsKey('Port')) { $Definition.Port } else { $null } )
+        Type           = $( if ($Definition.ContainsKey('Type')) { $Definition.Type } else { 'Tcp' } )
         Success        = $null
         RemoteAddress  = $null
         PingSucceeded  = $null

--- a/Collectors/Services/Collect-ServiceBaseline.ps1
+++ b/Collectors/Services/Collect-ServiceBaseline.ps1
@@ -70,8 +70,8 @@ function Get-ServiceInventory {
     $inventory = Get-CollectorServiceInventory
 
     return [pscustomobject]@{
-        Items  = if ($inventory.Items) { @($inventory.Items) } else { @() }
-        Errors = if ($inventory.Errors) { @($inventory.Errors) } else { @() }
+        Items  = $( if ($inventory.Items) { @($inventory.Items) } else { @() } )
+        Errors = $( if ($inventory.Errors) { @($inventory.Errors) } else { @() } )
         Source = $inventory.Source
     }
 }
@@ -140,7 +140,7 @@ function Get-ServiceRecord {
         StartType             = $startDisplay
         NormalizedStartType   = Normalize-ServiceStartType $startDisplay
         Raw                   = $rawLine
-        StartModeRaw          = if ($startMode) { $startMode.Trim() } else { '' }
+        StartModeRaw          = $( if ($startMode) { $startMode.Trim() } else { '' } )
         DelayedAutoStart      = $delayed
     }
 }
@@ -188,11 +188,11 @@ function Get-CriticalServiceSnapshot {
             Name                = $name
             Display             = $display
             Note                = $note
-            Status              = if ($record) { $record.Status } else { 'Not Found' }
-            NormalizedStatus    = if ($record) { $record.NormalizedStatus } else { 'missing' }
-            StartType           = if ($record) { $record.StartType } else { 'Unknown' }
-            NormalizedStartType = if ($record) { $record.NormalizedStartType } else { 'unknown' }
-            Raw                 = if ($record) { $record.Raw } else { $null }
+            Status              = $( if ($record) { $record.Status } else { 'Not Found' } )
+            NormalizedStatus    = $( if ($record) { $record.NormalizedStatus } else { 'missing' } )
+            StartType           = $( if ($record) { $record.StartType } else { 'Unknown' } )
+            NormalizedStartType = $( if ($record) { $record.NormalizedStartType } else { 'unknown' } )
+            Raw                 = $( if ($record) { $record.Raw } else { $null } )
         })
     }
     return $snapshot.ToArray()
@@ -212,9 +212,9 @@ function Get-LegacyServiceSnapshot {
 
         $null = $snapshot.Add([pscustomobject]@{
             Name             = $name
-            Status           = if ($record) { $record.Status } else { 'Not Found' }
-            NormalizedStatus = if ($record) { $record.NormalizedStatus } else { 'missing' }
-            Raw              = if ($record) { $record.Raw } else { $null }
+            Status           = $( if ($record) { $record.Status } else { 'Not Found' } )
+            NormalizedStatus = $( if ($record) { $record.NormalizedStatus } else { 'missing' } )
+            Raw              = $( if ($record) { $record.Raw } else { $null } )
         })
     }
     return $snapshot.ToArray()

--- a/Collectors/System/Collect-Events.ps1
+++ b/Collectors/System/Collect-Events.ps1
@@ -112,8 +112,8 @@ function Get-EventRecords {
 
     $result = [ordered]@{
         LogName   = $LogName
-        EventIds  = if ($EventIds) { @($EventIds) } else { @() }
-        StartTime = if ($StartTime) { $StartTime.ToString('o') } else { $null }
+        EventIds  = $( if ($EventIds) { @($EventIds) } else { @() } )
+        StartTime = $( if ($StartTime) { $StartTime.ToString('o') } else { $null } )
         Events    = @()
         Error     = $null
     }

--- a/Collectors/System/Collect-MicrosoftStoreFunctional.ps1
+++ b/Collectors/System/Collect-MicrosoftStoreFunctional.ps1
@@ -61,8 +61,8 @@ function Get-StorePackageState {
 
     return [ordered]@{
         storePackagePresent = $present
-        installedLocationOk = if ($present) { [bool]$locationOk } else { $false }
-        appxManifestFound   = if ($present) { $manifestFound } else { $false }
+        installedLocationOk = $( if ($present) { [bool]$locationOk } else { $false } )
+        appxManifestFound   = $( if ($present) { $manifestFound } else { $false } )
     }
 }
 

--- a/Collectors/System/Collect-Services.ps1
+++ b/Collectors/System/Collect-Services.ps1
@@ -23,7 +23,7 @@ function Get-ServiceMatrix {
 
     if ($inventory.Errors -and $inventory.Errors.Count -gt 0) {
         return [PSCustomObject]@{
-            Source = if ($inventory.Source) { $inventory.Source } else { 'ServiceInventory' }
+            Source = $( if ($inventory.Source) { $inventory.Source } else { 'ServiceInventory' } )
             Error  = ($inventory.Errors -join '; ')
         }
     }

--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -524,14 +524,14 @@ function Convert-DiskBlock {
   }
 
   return [pscustomobject]@{
-    Number            = if ($props.ContainsKey('Number')) { $props['Number'] } else { '' }
-    FriendlyName      = if ($props.ContainsKey('FriendlyName')) { $props['FriendlyName'] } else { '' }
+    Number            = $( if ($props.ContainsKey('Number')) { $props['Number'] } else { '' } )
+    FriendlyName      = $( if ($props.ContainsKey('FriendlyName')) { $props['FriendlyName'] } else { '' } )
     OperationalStatus = $operStatuses
     HealthStatus      = $healthStatuses
-    IsBoot            = if ($props.ContainsKey('IsBoot')) { ConvertTo-NullableBool $props['IsBoot'] } else { $null }
-    IsSystem          = if ($props.ContainsKey('IsSystem')) { ConvertTo-NullableBool $props['IsSystem'] } else { $null }
-    IsOffline         = if ($props.ContainsKey('IsOffline')) { ConvertTo-NullableBool $props['IsOffline'] } else { $null }
-    IsReadOnly        = if ($props.ContainsKey('IsReadOnly')) { ConvertTo-NullableBool $props['IsReadOnly'] } else { $null }
+    IsBoot            = $( if ($props.ContainsKey('IsBoot')) { ConvertTo-NullableBool $props['IsBoot'] } else { $null } )
+    IsSystem          = $( if ($props.ContainsKey('IsSystem')) { ConvertTo-NullableBool $props['IsSystem'] } else { $null } )
+    IsOffline         = $( if ($props.ContainsKey('IsOffline')) { ConvertTo-NullableBool $props['IsOffline'] } else { $null } )
+    IsReadOnly        = $( if ($props.ContainsKey('IsReadOnly')) { ConvertTo-NullableBool $props['IsReadOnly'] } else { $null } )
     Raw               = $BlockText
   }
 }

--- a/Modules/PasswordStrength/PasswordStrength.psm1
+++ b/Modules/PasswordStrength/PasswordStrength.psm1
@@ -93,8 +93,8 @@ function Test-PasswordStrength {
             Category           = 'Very Weak'
             EstimatedBits      = 0
             EstimatedGuesses   = '1.00E+02'
-            CrackTimeOnline_s  = if ($OnlineGuessesPerSecond -le 0) { [double]::PositiveInfinity } else { 1e2 / $OnlineGuessesPerSecond }
-            CrackTimeOffline_s = if ($OfflineGuessesPerSecond -le 0) { [double]::PositiveInfinity } else { 1e2 / $OfflineGuessesPerSecond }
+            CrackTimeOnline_s  = $( if ($OnlineGuessesPerSecond -le 0) { [double]::PositiveInfinity } else { 1e2 / $OnlineGuessesPerSecond } )
+            CrackTimeOffline_s = $( if ($OfflineGuessesPerSecond -le 0) { [double]::PositiveInfinity } else { 1e2 / $OfflineGuessesPerSecond } )
             AlphabetSizeUsed   = 0
             Length             = $passwordText.Length
             Warnings           = $warnings.ToArray()

--- a/backups/Legacy/Analyze-Diagnostics.ps1
+++ b/backups/Legacy/Analyze-Diagnostics.ps1
@@ -697,7 +697,7 @@ function Parse-IpconfigAdapters {
     $results.Add([pscustomobject]@{
       Name               = $adapter.Name
       Description        = $description
-      DescriptionKey     = if ($description) { $description.ToLowerInvariant() } else { '' }
+      DescriptionKey     = $( if ($description) { $description.ToLowerInvariant() } else { '' } )
       MacText            = $mac
       MacNormalized      = Normalize-MacAddress $mac
       DhcpEnabled        = $dhcpEnabled
@@ -773,7 +773,7 @@ function Parse-NetworkAdapterConfigs {
 
     $results.Add([pscustomobject]@{
       Description        = $description
-      DescriptionKey     = if ($description) { $description.ToLowerInvariant() } else { '' }
+      DescriptionKey     = $( if ($description) { $description.ToLowerInvariant() } else { '' } )
       MacText            = $mac
       MacNormalized      = Normalize-MacAddress $mac
       Index              = $index
@@ -913,9 +913,9 @@ function Combine-DhcpAdapterData {
       HasApipa             = $hasApipa
       MediaState           = $ipAdapter.MediaState
       IpconfigRaw          = $ipAdapter.RawBlock
-      NicRaw               = if ($matchedNic) { $matchedNic.RawBlock } else { '' }
-      NicIpEnabled         = if ($matchedNic) { $matchedNic.IPEnabled } else { $null }
-      Source               = if ($matchedNic) { 'ipconfig + Win32_NetworkAdapterConfiguration' } else { 'ipconfig' }
+      NicRaw               = $( if ($matchedNic) { $matchedNic.RawBlock } else { '' } )
+      NicIpEnabled         = $( if ($matchedNic) { $matchedNic.IPEnabled } else { $null } )
+      Source               = $( if ($matchedNic) { 'ipconfig + Win32_NetworkAdapterConfiguration' } else { 'ipconfig' } )
     })
   }
 
@@ -940,7 +940,7 @@ function Combine-DhcpAdapterData {
     }
 
     $results.Add([pscustomobject]@{
-      DisplayName          = if ($nic.Description) { $nic.Description } else { "Adapter Index $($nic.Index)" }
+      DisplayName          = $( if ($nic.Description) { $nic.Description } else { "Adapter Index $($nic.Index)" } )
       Description          = $nic.Description
       MacText              = $nic.MacText
       MacNormalized        = $nic.MacNormalized
@@ -2564,7 +2564,7 @@ if ($raw['outlook_autodiscover']){
         $autoResults += [pscustomobject]@{
           Domain   = $domainValue
           Status   = $status
-          Target   = if ($target) { $target } else { $null }
+          Target   = $( if ($target) { $target } else { $null } )
           Evidence = $text
         }
       }
@@ -2878,7 +2878,7 @@ if ($raw['office_security']) {
     $macroSecurityStatus.Add([pscustomobject]@{
       App               = $appInfo.Name
       BlockEnforced     = $blockFullyEnforced
-      BlockEvidence     = if ($blockFullyEnforced -and $macroEvidenceContext) { $macroEvidenceText } else { '' }
+      BlockEvidence     = $( if ($blockFullyEnforced -and $macroEvidenceContext) { $macroEvidenceText } else { '' } )
       AnyBlockContexts  = ($blockCompliant.Count -gt 0)
       WarningsStrict    = $warningsStrict
       ProtectedViewGood = $protectedViewGood


### PR DESCRIPTION
## Summary
- wrap conditional hashtable and PSCustomObject values in `$()` so they evaluate as expressions in PowerShell 5
- update analyzers, collectors, and shared modules to avoid invoking bare `if` statements when constructing issue payloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e38691ab78832dae2781ed3c1a2cb9