### PR TITLE
Prefer friendly volume names in free space cards

### DIFF
--- a/Analyzers/Heuristics/Storage/Storage.Volumes.ps1
+++ b/Analyzers/Heuristics/Storage/Storage.Volumes.ps1
@@ -141,7 +141,7 @@ function Invoke-StorageVolumeEvaluation {
                 }
             }
 
-            $volumeName = if ($volumeFriendlyName) {
+            $preferredVolumeName = if ($volumeFriendlyName) {
                 $volumeFriendlyName
             } elseif ($volumeLabel) {
                 $volumeLabel
@@ -150,13 +150,13 @@ function Invoke-StorageVolumeEvaluation {
             }
 
             $volumeDisplay = if ($driveLetterDisplay) {
-                if ($volumeName -and ($volumeName -ine $driveLetterDisplay)) {
-                    "{0} (`"{1}`")" -f $driveLetterDisplay, $volumeName
+                if ($preferredVolumeName) {
+                    "{0} (`"{1}`")" -f $driveLetterDisplay, $preferredVolumeName
                 } else {
                     $driveLetterDisplay
                 }
-            } elseif ($volumeName) {
-                $volumeName
+            } elseif ($preferredVolumeName) {
+                $preferredVolumeName
             } else {
                 $label
             }


### PR DESCRIPTION
## Summary
- prefer friendly volume names when composing volume display strings
- fall back to filesystem labels when no friendly name is available
- show the chosen volume name alongside the drive letter for clarity in cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e39376f79c832d86a88560680ddd5d