### PR TITLE
Add remediation guidance to issue cards

### DIFF
--- a/Analyzers/AnalyzerCommon.ps1
+++ b/Analyzers/AnalyzerCommon.ps1
@@ -219,7 +219,11 @@ function Add-CategoryIssue {
 
         [string]$Subcategory = $null,
 
-        [string]$CheckId = $null
+        [string]$CheckId = $null,
+
+        [string]$Remediation = $null,
+
+        [string]$RemediationScript = $null
     )
 
     $source = Get-HeuristicSourceMetadata
@@ -244,6 +248,14 @@ function Add-CategoryIssue {
 
     if ($PSBoundParameters.ContainsKey('CheckId') -and -not [string]::IsNullOrWhiteSpace($CheckId)) {
         $entry['CheckId'] = $CheckId
+    }
+
+    if ($PSBoundParameters.ContainsKey('Remediation') -and -not [string]::IsNullOrWhiteSpace($Remediation)) {
+        $entry['Remediation'] = $Remediation.Trim()
+    }
+
+    if ($PSBoundParameters.ContainsKey('RemediationScript') -and -not [string]::IsNullOrWhiteSpace($RemediationScript)) {
+        $entry['RemediationScript'] = $RemediationScript
     }
 
     if ($source) { $entry['Source'] = $source }

--- a/Analyzers/Heuristics/Network/Network.ps1
+++ b/Analyzers/Heuristics/Network/Network.ps1
@@ -2700,9 +2700,9 @@ function Invoke-NetworkHeuristics {
                 if ($descriptionText) { $evidence['Description'] = $descriptionText }
                 if ($linkText) { $evidence['LinkSpeed'] = $linkText }
                 if ($policyText) { $evidence['Policy'] = $policyText }
-                $evidence['remediation'] = 'Re-enable auto-negotiation on the NIC and replace the cable or switch port until it links at gigabit full duplex.'
+                $remediation = 'Re-enable auto-negotiation on the NIC and replace the cable or switch port until it links at gigabit full duplex.'
 
-                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Adapter {0} stuck at 100 Mb half duplex, so users will hit collisions and slow LAN throughput." -f $alias) -Evidence $evidence -Subcategory 'Adapters'
+                Add-CategoryIssue -CategoryResult $result -Severity 'high' -Title ("Adapter {0} stuck at 100 Mb half duplex, so users will hit collisions and slow LAN throughput." -f $alias) -Evidence $evidence -Subcategory 'Adapters' -Remediation $remediation
                 continue
             }
 
@@ -2715,9 +2715,9 @@ function Invoke-NetworkHeuristics {
                 if ($descriptionText) { $evidence['Description'] = $descriptionText }
                 if ($policyText) { $evidence['Policy'] = $policyText } elseif ($policyBits) { $evidence['Policy'] = ('{0:N0} bps' -f $policyBits) }
                 if ($linkText) { $evidence['LinkSpeed'] = $linkText } elseif ($linkBits) { $evidence['LinkSpeed'] = ('{0:N0} bps' -f $linkBits) }
-                $evidence['remediation'] = 'Set the NIC and switch port to matching speed/duplex or leave both on auto-negotiation so the link meets policy.'
+                $remediation = 'Set the NIC and switch port to matching speed/duplex or leave both on auto-negotiation so the link meets policy.'
 
-                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ("Adapter {0} policy {1} disagrees with negotiated {2}, so throughput and stability will suffer until they match." -f $alias, $policyLabel, $linkLabel) -Evidence $evidence -Subcategory 'Adapters'
+                Add-CategoryIssue -CategoryResult $result -Severity 'medium' -Title ("Adapter {0} policy {1} disagrees with negotiated {2}, so throughput and stability will suffer until they match." -f $alias, $policyLabel, $linkLabel) -Evidence $evidence -Subcategory 'Adapters' -Remediation $remediation
             }
         }
     }

--- a/Analyzers/Network/Analyze-Vpn.ps1
+++ b/Analyzers/Network/Analyze-Vpn.ps1
@@ -184,15 +184,23 @@ function Add-VpnIssue {
         $Services,
         [string]$Subcategory,
         [string]$Remediation,
+        [string]$RemediationScript,
         [hashtable]$ExtraEvidence
     )
 
     $evidence = New-VpnEvidence -Connection $Connection -Network $Network -Certificates $Certificates -Services $Services -Additional $ExtraEvidence
-    if ($Remediation) {
-        $evidence['remediation'] = $Remediation
+    $issueArguments = @{
+        CategoryResult = $CategoryResult
+        Severity       = $Severity
+        Title          = $Title
+        Evidence       = $evidence
+        Subcategory    = $Subcategory
     }
 
-    Add-CategoryIssue -CategoryResult $CategoryResult -Severity $Severity -Title $Title -Evidence $evidence -Subcategory $Subcategory
+    if ($Remediation) { $issueArguments['Remediation'] = $Remediation }
+    if ($RemediationScript) { $issueArguments['RemediationScript'] = $RemediationScript }
+
+    Add-CategoryIssue @issueArguments
 }
 
 function Add-VpnHealthyFinding {

--- a/Modules/Common.psm1
+++ b/Modules/Common.psm1
@@ -712,6 +712,32 @@ function New-IssueCardHtml {
     [void]$bodyBuilder.Append("<pre class='report-pre'>$evidenceHtml</pre>")
   }
 
+  $hasRemediation = -not [string]::IsNullOrWhiteSpace($Entry.Remediation)
+  $hasRemediationScript = -not [string]::IsNullOrWhiteSpace($Entry.RemediationScript)
+  if ($hasRemediation -or $hasRemediationScript) {
+    $remediationBuilder = [System.Text.StringBuilder]::new()
+    [void]$remediationBuilder.Append("<div class='report-remediation'>")
+    [void]$remediationBuilder.Append("<h4 class='report-remediation__title'>Remediation</h4>")
+
+    if ($hasRemediation) {
+      $remediationHtml = Encode-Html $Entry.Remediation
+      $remediationHtml = [regex]::Replace($remediationHtml, '\\r?\\n', '<br>')
+      [void]$remediationBuilder.Append("<p class='report-remediation__text'>$remediationHtml</p>")
+    }
+
+    if ($hasRemediationScript) {
+      $codeId = 'remediation-' + ([guid]::NewGuid().ToString('N'))
+      $codeHtml = Encode-Html $Entry.RemediationScript
+      $buttonLabel = Encode-Html 'Copy PowerShell'
+      $successLabel = Encode-Html 'Copied!'
+      $failureLabel = Encode-Html 'Copy failed'
+      [void]$remediationBuilder.Append("<div class='report-remediation__code'><button type='button' class='report-copy-button' data-copy-target='#$codeId' data-copy-success='$successLabel' data-copy-failure='$failureLabel'>$buttonLabel</button><pre class='report-pre'><code id='$codeId' class='language-powershell'>$codeHtml</code></pre></div>")
+    }
+
+    [void]$remediationBuilder.Append('</div>')
+    [void]$bodyBuilder.Append($remediationBuilder.ToString())
+  }
+
   $badgeFragment = "<span class='report-badge report-badge--$cardClass'>$badgeHtml</span>"
   $summaryFragment = "<span class='report-card__summary-text'>$summaryText</span>"
 

--- a/styles/device-health-report.css
+++ b/styles/device-health-report.css
@@ -307,6 +307,80 @@ details.report-card[open] > summary {
   margin-top: 0;
 }
 
+.report-remediation {
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border-subtle);
+  background-color: var(--color-surface-muted);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.report-remediation__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.report-remediation__text {
+  margin: 0;
+  color: var(--color-text-primary);
+  line-height: 1.55;
+}
+
+.report-remediation__code {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.report-remediation__code .report-pre {
+  margin: 0;
+}
+
+.report-copy-button {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  padding: var(--space-xxs) var(--space-sm);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-subtle);
+  background-color: var(--color-surface);
+  color: var(--color-heading);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.report-copy-button:hover {
+  background-color: var(--color-heading);
+  color: #ffffff;
+  border-color: var(--color-heading);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.report-copy-button:focus-visible {
+  outline: 2px solid var(--color-heading);
+  outline-offset: 2px;
+}
+
+.report-copy-button.is-success {
+  background-color: var(--color-state-good-border);
+  border-color: var(--color-state-good-border);
+  color: #ffffff;
+}
+
+.report-copy-button.is-error {
+  background-color: var(--color-state-bad-border);
+  border-color: var(--color-state-bad-border);
+  color: #ffffff;
+}
+
 .report-section {
   margin: var(--space-lg) 0;
   border: 1px solid var(--color-border-subtle);


### PR DESCRIPTION
## Summary
- allow issue cards to carry remediation text and optional PowerShell fixes through the analyzer pipeline
- render remediation guidance with copyable PowerShell code in the HTML report and style the new section
- update network heuristics and VPN helper to pass remediation text via the new plumbing instead of embedding it in evidence

## Testing
- `pwsh -NoLogo -Command "Set-StrictMode -Version Latest; . (Resolve-Path 'Analyzers/AnalyzerCommon.ps1'); . (Resolve-Path 'Analyzers/HtmlComposer.ps1')"` *(fails: `pwsh` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e393cca8b0832d873e9073c0378f35